### PR TITLE
#80: remove the fallback logic for clientinfo in user object creation

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheTest.java
@@ -558,6 +558,31 @@ public final class TokenCacheTest extends AndroidTestCase {
         assertTrue(rtForAnotherUser.getRefreshToken().equals(anotherRefreshToken));
     }
 
+    @Test
+    public void testTokenSavedWithNoClientInfo() throws MsalException {
+        final String scope = "scope1";
+        final Date expirationDate = AndroidTestUtil.getExpirationDate(AndroidTestUtil.TOKEN_EXPIRATION_IN_MINUTES);
+
+        // save RT for default user
+        PublicClientApplicationTest.saveTokenResponse(mTokenCache, AUTHORITY, CLIENT_ID, getTokenResponseForDefaultUser(
+                ACCESS_TOKEN, REFRESH_TOKEN, scope, expirationDate, null));
+
+        final User user = new User(DISPLAYABLE, "name", "idp", "", "");
+        final AuthenticationRequestParameters requestParameters = getRequestParameters(AUTHORITY, MSALUtils.getScopesAsSet(scope), CLIENT_ID);
+        final AccessTokenCacheItem accessTokenCacheItem = mTokenCache.findAccessToken(requestParameters, user);
+        assertNotNull(accessTokenCacheItem);
+        assertNotNull(accessTokenCacheItem.getUser());
+        final User returnedUser = accessTokenCacheItem.getUser();
+        assertTrue(returnedUser.getUid().equals(""));
+        assertTrue(returnedUser.getUtid().equals(""));
+
+        final RefreshTokenCacheItem refreshTokenCacheItem = mTokenCache.findRefreshToken(requestParameters, user);
+        assertNotNull(refreshTokenCacheItem);
+        assertNotNull(refreshTokenCacheItem.getUser());
+        assertTrue(refreshTokenCacheItem.getUser().getUid().equals(""));
+        assertTrue(refreshTokenCacheItem.getUser().getUtid().equals(""));
+    }
+
     private void verifyUserReturnedFromCacheIsDefaultUser(final BaseTokenCacheItem item) {
         if (item instanceof AccessTokenCacheItem) {
             final AccessTokenCacheItem accessTokenCacheItem = (AccessTokenCacheItem) item;

--- a/msal/src/main/java/com/microsoft/identity/client/User.java
+++ b/msal/src/main/java/com/microsoft/identity/client/User.java
@@ -49,8 +49,8 @@ public class User {
         final String uid;
         final String uTid;
         if (clientInfo == null) {
-            uid = idToken.getUniqueId();
-            uTid = idToken.getTenantId();
+            uid = "";
+            uTid = "";
         } else {
             uid = clientInfo.getUniqueIdentifier();
             uTid = clientInfo.getUniqueTenantIdentifier();
@@ -80,6 +80,13 @@ public class User {
         return mIdentityProvider;
     }
 
+    /**
+     * @return The unique identifier of the user, which is across tenant.
+     */
+    public String getUserIdentifier() {
+        return MSALUtils.getUniqueUserIdentifier(mUid, mUtid);
+    }
+
     // internal methods provided
 
     /**
@@ -105,9 +112,5 @@ public class User {
 
     String getUtid() {
         return mUtid;
-    }
-
-    String getUserIdentifier() {
-        return MSALUtils.getUniqueUserIdentifier(mUid, mUtid);
     }
 }


### PR DESCRIPTION
#80 
1. remove the fallback logic for user object creation. 
2. add tests to ensure that when client info is not returned, uid and utid are stored with empty string. 