### PR TITLE
fix crashing when uid and utid are not returned in client info

### DIFF
--- a/msal/src/internal/java/com/microsoft/identity/client/ClientInfo.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/ClientInfo.java
@@ -60,10 +60,10 @@ final class ClientInfo {
     }
 
     String getUniqueIdentifier() {
-        return mUniqueIdentifier;
+        return MSALUtils.isEmpty(mUniqueIdentifier) ? "" : mUniqueIdentifier;
     }
 
     String getUniqueTenantIdentifier() {
-        return mUniqueTenantIdentifier;
+        return MSALUtils.isEmpty(mUniqueTenantIdentifier) ? "" : mUniqueTenantIdentifier;
     }
 }


### PR DESCRIPTION
#87 Fix crash if client info is returned but uid and utid are not. 