### PR TITLE
91:remove claims from exception class

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MsalServiceException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalServiceException.java
@@ -55,7 +55,6 @@ package com.microsoft.identity.client;
 public final class MsalServiceException extends MsalException {
 
     private final int mHttpStatusCode;
-    private final String mClaims;
 
     /**
      * When {@link java.net.SocketTimeoutException} is thrown, no status code will be caught. Will use 0 instead.
@@ -66,21 +65,12 @@ public final class MsalServiceException extends MsalException {
         super(errorCode, errorMessage, throwable);
 
         mHttpStatusCode = DEFAULT_STATUS_CODE;
-        mClaims = "";
     }
 
     MsalServiceException(final String errorCode, final String errorMessage, final int httpStatusCode, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
 
         mHttpStatusCode = httpStatusCode;
-        mClaims = "";
-    }
-
-    MsalServiceException(final String errorCode, final String errorMessge, final int httpStatusCode, final String claims, final Throwable throwable) {
-        super(errorCode, errorMessge, throwable);
-
-        mHttpStatusCode = httpStatusCode;
-        mClaims = claims;
     }
 
     /**
@@ -88,13 +78,5 @@ public final class MsalServiceException extends MsalException {
      */
     public int getHttpStatusCode() {
         return mHttpStatusCode;
-    }
-
-    /**
-     * @return The claims challenge returned back from the service, will be in the original JSON format sent back from the service.
-     * The sdk doesn't parse it.
-     */
-    public String getClaims() {
-        return mClaims;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalUiRequiredException.java
@@ -36,7 +36,6 @@ package com.microsoft.identity.client;
  */
 
 public final class MsalUiRequiredException extends MsalException {
-    private String mClaims = "";
 
     MsalUiRequiredException(final String errorCode) {
         super(errorCode);
@@ -48,18 +47,5 @@ public final class MsalUiRequiredException extends MsalException {
 
     MsalUiRequiredException(final String errorCode, final String errorMessage, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
-    }
-
-    MsalUiRequiredException(final String errorCode, final String errorMessage, final String claims, final Throwable throwable) {
-        super(errorCode, errorMessage, throwable);
-        mClaims = claims;
-    }
-
-    /**
-     * If {@link MsalUiRequiredException} is caused by a service error i.e. invalid_grant, claims could be returned.
-     * @return
-     */
-    public String getClaims() {
-        return mClaims;
     }
 }

--- a/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
@@ -222,14 +222,14 @@ abstract class BaseRequest {
     void throwExceptionFromTokenResponse(final TokenResponse tokenResponse) throws MsalUiRequiredException, MsalServiceException {
         if (MSALUtils.isEmpty(tokenResponse.getError())) {
             throw new MsalServiceException(MSALError.UNKNOWN_ERROR, "Request failed, but no error returned back from service.", tokenResponse.getHttpStatusCode(),
-                    tokenResponse.getClaims(), null);
+                    null);
         }
 
         if (MSALError.INVALID_GRANT.equals(tokenResponse.getError())) {
-            throw new MsalUiRequiredException(MSALError.INVALID_GRANT, tokenResponse.getErrorDescription(), tokenResponse.getClaims(), null);
+            throw new MsalUiRequiredException(MSALError.INVALID_GRANT, tokenResponse.getErrorDescription(), null);
         }
 
-        throw new MsalServiceException(tokenResponse.getError(), tokenResponse.getErrorDescription(), tokenResponse.getHttpStatusCode(), tokenResponse.getClaims(), null);
+        throw new MsalServiceException(tokenResponse.getError(), tokenResponse.getErrorDescription(), tokenResponse.getHttpStatusCode(), null);
     }
 
     private synchronized Handler getHandler() {


### PR DESCRIPTION
#91 For public client application, there is no need to expose claims in the returned exception. If silent request fails and claims is returned in the JSON response from token endpoint, retry with interactive request will solve it. 