### PR TITLE
update the build.gradle and make sure release version is not debuggable

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -23,6 +23,7 @@ android {
         }
         release {
             minifyEnabled false
+            debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }


### PR DESCRIPTION
For all the official release, we should generate release build which should have debuggable disabled. 