### PR TITLE
110: fail if login.windows.net is provided as authority url

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/AuthorityTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AuthorityTest.java
@@ -67,9 +67,14 @@ public final class AuthorityTest {
         Authority.createAuthority("https://test.com", false);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testDeprecateAuthority() {
-        Authority.createAuthority("https://login.windows.net/common", true);
+        final Authority authority = Authority.createAuthority("https://login.windows.net/common", true);
+        Assert.assertTrue(authority.getAuthorityHost().equals(AadAuthority.AAD_AUTHORITY_HOST));
+        Assert.assertTrue(authority.getAuthority().contains(AadAuthority.AAD_AUTHORITY_HOST));
+
+        final Authority authorityWithPort = Authority.createAuthority("https://login.windows.net:1010/sometenant", true);
+        Assert.assertTrue(authorityWithPort.getAuthority().equals("https://login.microsoftonline.com:1010/sometenant"));
     }
 
     @Test

--- a/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
@@ -42,8 +42,9 @@ class AadAuthority extends Authority {
     private static final String AUTHORIZATION_ENDPOINT = "authorization_endpoint";
 
     static final String DEPRECATED_AAD_AUTHORITY_HOST = "login.windows.net";
+    static final String AAD_AUTHORITY_HOST = "login.microsoftonline.com";
     static final String[] TRUSTED_HOSTS = new String[] {
-            "login.microsoftonline.com", // Microsoft Azure Worldwide
+            AAD_AUTHORITY_HOST, // Microsoft Azure Worldwide
             "login.chinacloudapi.cn", // Microsoft Azure China
             "login.microsoftonline.de", // Microsoft Azure Germany
             "login-us.microsoftonline.com" // Microsoft Azure US government
@@ -59,8 +60,13 @@ class AadAuthority extends Authority {
         super(authority, validateAuthority);
 
         if (authority.getHost().equalsIgnoreCase(DEPRECATED_AAD_AUTHORITY_HOST)) {
-            throw new IllegalArgumentException("login.windows.net is already deprecated, please use "
-                    + "login.microsoftonline.com instead.");
+            try {
+                final String hostWithPort = mAuthorityUrl.getAuthority().replace(DEPRECATED_AAD_AUTHORITY_HOST, AAD_AUTHORITY_HOST);
+                mAuthorityUrl = new URL(String.format("https://%s%s", hostWithPort, mAuthorityUrl.getPath()));
+            } catch (final MalformedURLException e) {
+                Logger.error(TAG, null, "Fail to replace login.windows.net to login.microsoftonline.com", e);
+                throw new IllegalArgumentException("Malformed authority url");
+            }
         }
 
         mAuthorityType = AuthorityType.AAD;


### PR DESCRIPTION
#110 
Authority creation is before token request, since we're going to fail if developer provides login.windows.net as authority, it's the part of parameter validation, throw IllegalArgumentException instead of MsalClientException. 
