### PR TITLE
Closes #112 - Update Telemetry Prefix

### DIFF
--- a/msal/src/telemetry/java/com/microsoft/identity/client/EventConstants.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/EventConstants.java
@@ -35,7 +35,7 @@ final class EventConstants {
     /**
      * Prefixes all event names.
      */
-    static final String EVENT_PREFIX = "microsoft.MSAL.";
+    static final String EVENT_PREFIX = "msal.";
 
     /**
      * API Ids for Telemetry.


### PR DESCRIPTION
This change updates the Telemetry event prefix to be `msal.` #112 