### PR TITLE
adding no_wrap for base64 urlEncode to avoid line break

### DIFF
--- a/msal/src/internal/java/com/microsoft/identity/client/MsalUtils.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/MsalUtils.java
@@ -350,7 +350,7 @@ final class MsalUtils {
     }
 
     static String base64UrlEncodeToString(final String message) {
-        return Base64.encodeToString(message.getBytes(Charset.forName(ENCODING_UTF8)), Base64.URL_SAFE);
+        return Base64.encodeToString(message.getBytes(Charset.forName(ENCODING_UTF8)), Base64.URL_SAFE | Base64.NO_WRAP);
     }
 
     /**


### PR DESCRIPTION
Adding NO_WRAP as the encoder flag bit to omit all line terminators. 