### PR TITLE
Synchronizing field access for Events | Stress testing

### DIFF
--- a/msal/src/telemetry/java/com/microsoft/identity/client/Telemetry.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/Telemetry.java
@@ -159,7 +159,10 @@ public final class Telemetry {
         final Pair<String, String> eventKey = new Pair<>(requestId, eventName);
 
         // Compute execution time
-        final Long eventStartTime = mEventsInProgress.get(eventKey);
+        final Long eventStartTime;
+        synchronized (this) {
+            eventStartTime = mEventsInProgress.get(eventKey);
+        }
 
         // If we did not get anything back from the dictionary, most likely its a bug that stopEvent
         // was called without a corresponding startEvent


### PR DESCRIPTION
This change adds synchronization on `this` to write/iterative actions related to Telemetry `Events`