### PR TITLE
Use OauthConstants for error code comparison

### DIFF
--- a/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
@@ -225,7 +225,7 @@ abstract class BaseRequest {
                     null);
         }
 
-        if (MsalUiRequiredException.INVALID_GRANT.equals(tokenResponse.getError())) {
+        if (OauthConstants.ErrorCode.INVALID_GRANT.equals(tokenResponse.getError())) {
             throw new MsalUiRequiredException(MsalUiRequiredException.INVALID_GRANT, tokenResponse.getErrorDescription(), null);
         }
 


### PR DESCRIPTION
Update error code comparison for invalid_grant, use oauth2constants instead of the error code in exception class directly. 