### PR TITLE
Save Telemetry requestId if AuthenticationActivity is torn down.

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
@@ -65,6 +65,8 @@ public final class AuthenticationActivity extends Activity {
         if (savedInstanceState != null) {
             Logger.verbose(TAG, null, "AuthenticationActivity is re-created after killed by the os.");
             mRestarted = true;
+            mTelemetryRequestId = savedInstanceState.getString(Constants.TELEMETRY_REQUEST_ID);
+            mUiEventBuilder = new UiEvent.Builder();
             return;
         }
 
@@ -200,6 +202,7 @@ public final class AuthenticationActivity extends Activity {
         super.onSaveInstanceState(outState);
 
         outState.putString(Constants.REQUEST_URL_KEY, mRequestUrl);
+        outState.putString(Constants.TELEMETRY_REQUEST_ID, mTelemetryRequestId);
     }
 
     /**


### PR DESCRIPTION
Saves the Telemetry requestId to the `onSaveInstanceState()` `Bundle` if the `AuthenticationActivity` is destroyed (say, if `Don't Keep Activities` is turned on).

Testing with DevUtil is blocked due to #150 - @addev-ashish to test via alternative means