### PR TITLE
Do not attempt to parse null or empty URLs (when processing Authorities)

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -32,6 +32,7 @@ import android.support.annotation.NonNull;
 
 import com.microsoft.identity.msal.BuildConfig;
 
+import java.net.URL;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -226,6 +227,8 @@ public final class PublicClientApplication {
     public List<User> getUsers() throws MsalClientException {
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final ApiEvent.Builder apiEventBuilder = new ApiEvent.Builder(telemetryRequestId);
+        final URL authorityURL = MsalUtils.getUrl(mAuthorityString);
+        apiEventBuilder.setAuthority(authorityURL.getProtocol() + "://" + authorityURL.getHost());
         Telemetry.getInstance().startEvent(telemetryRequestId, apiEventBuilder.getEventName());
 
         List<User> users = mTokenCache.getUsers(Authority.createAuthority(mAuthorityString, mValidateAuthority).getAuthorityHost(), mClientId, new RequestContext(UUID.randomUUID(), mComponent, telemetryRequestId));

--- a/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
@@ -44,7 +44,9 @@ final class ApiEvent extends Event {
         if (null != builder.mRequestId) {
             setProperty(EventProperty.REQUEST_ID, builder.mRequestId);
         }
-        setProperty(EventProperty.AUTHORITY_NAME, HttpEvent.sanitizeUrlForTelemetry(builder.mAuthority));
+        if (!MsalUtils.isEmpty(builder.mAuthority)) {
+            setProperty(EventProperty.AUTHORITY_NAME, HttpEvent.sanitizeUrlForTelemetry(builder.mAuthority));
+        }
         setAuthorityType(builder.mAuthorityType);
         setProperty(EventProperty.UI_BEHAVIOR, builder.mUiBehavior);
         setProperty(EventProperty.API_ID, builder.mApiId);

--- a/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
@@ -44,9 +44,7 @@ final class ApiEvent extends Event {
         if (null != builder.mRequestId) {
             setProperty(EventProperty.REQUEST_ID, builder.mRequestId);
         }
-        if (!MsalUtils.isEmpty(builder.mAuthority)) {
-            setProperty(EventProperty.AUTHORITY_NAME, HttpEvent.sanitizeUrlForTelemetry(builder.mAuthority));
-        }
+        setProperty(EventProperty.AUTHORITY_NAME, HttpEvent.sanitizeUrlForTelemetry(builder.mAuthority));
         setAuthorityType(builder.mAuthorityType);
         setProperty(EventProperty.UI_BEHAVIOR, builder.mUiBehavior);
         setProperty(EventProperty.API_ID, builder.mApiId);

--- a/msal/src/telemetry/java/com/microsoft/identity/client/HttpEvent.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/HttpEvent.java
@@ -41,7 +41,9 @@ final class HttpEvent extends Event {
         setProperty(EventProperty.HTTP_API_VERSION, builder.mApiVersion);
         setProperty(EventProperty.OAUTH_ERROR_CODE, builder.mOAuthErrorCode);
         setProperty(EventProperty.REQUEST_ID_HEADER, builder.mRequestIdHeader);
-        setHttpPath(builder.mHttpPath);
+        if (null != builder.mHttpPath) {
+            setHttpPath(builder.mHttpPath);
+        }
         setProperty(EventProperty.HTTP_RESPONSE_CODE, String.valueOf(builder.mResponseCode));
     }
 


### PR DESCRIPTION
This change seeks to quiet the amount of `Logger` output by not allowing the `MalformedURLException` to be thrown in instances where an Authority `URL` is not passed-in