### PR TITLE
#141: update authority validation

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/AdfsAuthorityTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AdfsAuthorityTest.java
@@ -78,15 +78,15 @@ public class AdfsAuthorityTest {
     @Ignore
     @Test
     public void testExistsInValidatedAuthorityCache() {
-        mAdfsAuthority.addToValidatedAuthorityCache(mTestUPN);
-        Assert.assertTrue(mAdfsAuthority.existsInValidatedAuthorityCache(mTestUPN));
+        mAdfsAuthority.addToResolvedAuthorityCache(mTestUPN);
+        Assert.assertTrue(mAdfsAuthority.existsInResolvedAuthorityCache(mTestUPN));
     }
 
     // ADFS is not a supported instance for BUILD.
     @Ignore
     @Test
     public void testDoesntExistInValidatedAuthorityCache() {
-        Assert.assertFalse(mAdfsAuthority.existsInValidatedAuthorityCache(mTestUPN));
+        Assert.assertFalse(mAdfsAuthority.existsInResolvedAuthorityCache(mTestUPN));
     }
 
     // ADFS is not a supported instance for BUILD.

--- a/msal/src/androidTest/java/com/microsoft/identity/client/InteractiveRequestTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/InteractiveRequestTest.java
@@ -96,7 +96,7 @@ public final class InteractiveRequestTest extends AndroidTestCase {
         InstrumentationRegistry.getContext().getCacheDir();
         System.setProperty("dexmaker.dexcache",
                 InstrumentationRegistry.getContext().getCacheDir().getPath());
-        Authority.VALIDATED_AUTHORITY.clear();
+        Authority.RESOLVED_AUTHORITY.clear();
 
         mAppContext = new MockContext(InstrumentationRegistry.getContext().getApplicationContext());
         resolveAuthenticationActivity(mAppContext, true);

--- a/msal/src/androidTest/java/com/microsoft/identity/client/SilentRequestTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/SilentRequestTest.java
@@ -67,7 +67,7 @@ public final class SilentRequestTest extends AndroidTestCase {
         System.setProperty("dexmaker.dexcache",
                 InstrumentationRegistry.getContext().getCacheDir().getPath());
 
-        Authority.VALIDATED_AUTHORITY.clear();
+        Authority.RESOLVED_AUTHORITY.clear();
         AndroidTestMockUtil.mockSuccessTenantDiscovery(AUTHORIZE_ENDPOINT, TOKEN_ENDPOINT);
 
         mAppContext = new InteractiveRequestTest.MockContext(InstrumentationRegistry.getContext().getApplicationContext());

--- a/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
@@ -103,18 +103,19 @@ class AadAuthority extends Authority {
             throw new MsalServiceException(response.getError(), response.getErrorDescription(), response.getHttpStatusCode(), null);
         }
 
+        mIsAuthorityValidated = true;
         Logger.info(TAG, requestContext, "Instance discovery succeeded. Tenant discovery endpoint is: "
                 + response.getTenantDiscoveryEndpoint());
         return response.getTenantDiscoveryEndpoint();
     }
 
     @Override
-    boolean existsInValidatedAuthorityCache(final String userPrincipalName) {
-        return VALIDATED_AUTHORITY.containsKey(mAuthorityUrl.toString());
+    boolean existsInResolvedAuthorityCache(final String userPrincipalName) {
+        return RESOLVED_AUTHORITY.containsKey(mAuthorityUrl.toString());
     }
 
     @Override
-    void addToValidatedAuthorityCache(final String userPrincipalName) {
-        VALIDATED_AUTHORITY.put(mAuthorityUrl.toString(), this);
+    void addToResolvedAuthorityCache(final String userPrincipalName) {
+        RESOLVED_AUTHORITY.put(mAuthorityUrl.toString(), this);
     }
 }

--- a/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
@@ -109,9 +109,10 @@ final class AdfsAuthority extends Authority {
                 // TODO: we need to read the error and error description, the current error code is not exposed yet.
                 throw new MsalClientException(MsalClientException.ADFS_AUTHORITY_VALIDATION_FAILED, "Realm is not trusted, adfs authority validation failed.");
             }
+
+            mIsAuthorityValidated = true;
         }
 
-        mIsAuthorityValidated = true;
         return getDefaultOpenIdConfigurationEndpoint();
     }
 

--- a/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
@@ -58,12 +58,12 @@ final class AdfsAuthority extends Authority {
     }
 
     @Override
-    boolean existsInValidatedAuthorityCache(final String userPrincipalName) {
+    boolean existsInResolvedAuthorityCache(final String userPrincipalName) {
         if (MsalUtils.isEmpty(userPrincipalName)) {
             throw new IllegalArgumentException("userPrincipalName cannot be null or blank");
         }
 
-        final Map<String, Authority> authorityMap = Authority.VALIDATED_AUTHORITY;
+        final Map<String, Authority> authorityMap = Authority.RESOLVED_AUTHORITY;
         final String authorityUrlStr = mAuthorityUrl.toString();
 
         return authorityMap.containsKey(authorityUrlStr)
@@ -74,20 +74,20 @@ final class AdfsAuthority extends Authority {
     }
 
     @Override
-    void addToValidatedAuthorityCache(final String userPrincipalName) {
+    void addToResolvedAuthorityCache(final String userPrincipalName) {
         AdfsAuthority adfsInstance = this;
 
         final String authorityUrlStr = mAuthorityUrl.toString();
 
-        if (Authority.VALIDATED_AUTHORITY.containsKey(authorityUrlStr)) {
-            adfsInstance = (AdfsAuthority) VALIDATED_AUTHORITY.get(authorityUrlStr);
+        if (Authority.RESOLVED_AUTHORITY.containsKey(authorityUrlStr)) {
+            adfsInstance = (AdfsAuthority) RESOLVED_AUTHORITY.get(authorityUrlStr);
         }
 
         adfsInstance
                 .getADFSValidatedAuthorities()
                 .add(getDomainFromUPN(userPrincipalName));
 
-        Authority.VALIDATED_AUTHORITY.put(authorityUrlStr, adfsInstance);
+        Authority.RESOLVED_AUTHORITY.put(authorityUrlStr, adfsInstance);
     }
 
     @Override
@@ -111,6 +111,7 @@ final class AdfsAuthority extends Authority {
             }
         }
 
+        mIsAuthorityValidated = true;
         return getDefaultOpenIdConfigurationEndpoint();
     }
 


### PR DESCRIPTION
#141: update authority validation. When using the resolved endpoints from cache, we should check if authority is validated. If authority validation is turned on and the cached authority has not been validated yet, we should do instance discovery and tenant discovery. 