### PR TITLE
update error message when reserved scopes are provided as the scopes parameter

### DIFF
--- a/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
@@ -147,13 +147,13 @@ abstract class BaseRequest {
         // fail if the input scopes contains the reserved scopes.
         // retainAll removes all the objects that are not contained in the reserved scopes.
         if (!scopes.retainAll(reservedScopes)) {
-            throw new IllegalArgumentException("Reserved scopes "
-                    + OauthConstants.Oauth2Value.RESERVED_SCOPES.toString() + " cannot be provided as scopes.");
+            throw new IllegalArgumentException("MSAL always sends the scopes 'openid profile offline_access'. They cannot be suppressed as they are required for the "
+                    + "library to function. Do not include any of these in the scopes parameter.");
         }
 
         // client id can only be provided as a single scope.
         if (inputScopes.contains(mAuthRequestParameters.getClientId())) {
-            throw new IllegalArgumentException("Client id can only be provided as scope.");
+            throw new IllegalArgumentException("Client id cannot be provided as scope.");
         }
     }
 


### PR DESCRIPTION
Per slack conversation, we should update the exception message when reserved scopes are provided as the scope parameter. 