### PR TITLE
Adds api_error_code to ApiEvent

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
@@ -50,6 +50,7 @@ public class ApiEventTest {
     static final String TEST_VALIDATION_STATUS = EventProperty.Value.AUTHORITY_VALIDATION_SUCCESS;
     static final String TEST_LOGIN_HINT = "user@contoso.com";
     static final boolean TEST_API_CALL_WAS_SUCCESSFUL = true;
+    static final String TEST_API_ERROR_CODE = "test_error_code";
 
     // Authorities
     private static final String TEST_AUTHORITY_WITH_IDENTIFIER = AndroidTestUtil.DEFAULT_AUTHORITY_WITH_TENANT;
@@ -69,6 +70,7 @@ public class ApiEventTest {
                 .setValidationStatus(TEST_VALIDATION_STATUS)
                 .setRawIdToken(TEST_ID_TOKEN)
                 .setLoginHint(TEST_LOGIN_HINT)
+                .setApiErrorCode(TEST_API_ERROR_CODE)
                 .setApiCallWasSuccessful(TEST_API_CALL_WAS_SUCCESSFUL);
     }
 
@@ -107,6 +109,7 @@ public class ApiEventTest {
         // Testing token parsing in another test....
         Assert.assertEquals(MsalUtils.createHash(TEST_LOGIN_HINT), apiEvent.getLoginHint());
         Assert.assertEquals(Boolean.valueOf(TEST_API_CALL_WAS_SUCCESSFUL), apiEvent.wasSuccessful());
+        Assert.assertEquals(TEST_API_ERROR_CODE, apiEvent.getApiErrorCode());
     }
 
     @Test

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -671,6 +671,7 @@ public final class PublicClientApplication {
             @Override
             public void onError(final MsalException exception) {
                 eventBinding.setApiCallWasSuccessful(false);
+                eventBinding.setApiErrorCode(exception.getErrorCode());
                 stopTelemetryEventAndFlush(eventBinding.build());
                 authenticationCallback.onError(exception);
             }

--- a/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/ApiEvent.java
@@ -52,6 +52,7 @@ final class ApiEvent extends Event {
         setIdToken(builder.mRawIdToken);
         setLoginHint(builder.mLoginHint);
         setProperty(EventProperty.WAS_SUCCESSFUL, String.valueOf(builder.mWasApiCallSuccessful));
+        setProperty(EventProperty.API_ERROR_CODE, builder.mApiErrorCode);
     }
 
     private void setAuthorityType(Authority.AuthorityType type) {
@@ -149,6 +150,10 @@ final class ApiEvent extends Event {
         return getProperty(EventProperty.AUTHORITY_TYPE);
     }
 
+    String getApiErrorCode() {
+        return getProperty(EventProperty.API_ERROR_CODE);
+    }
+
     /**
      * Builder object for ApiEvents.
      */
@@ -164,6 +169,7 @@ final class ApiEvent extends Event {
         private boolean mWasApiCallSuccessful;
         private UUID mCorrelationId;
         private String mRequestId;
+        private String mApiErrorCode;
 
         Builder(final String requestId) {
             super(EventConstants.EventName.API_EVENT);
@@ -256,10 +262,21 @@ final class ApiEvent extends Event {
          * Sets the correlationId of the api call.
          *
          * @param correlationId the correlationId to set
-         * @return the Builder instance
+         * @return the Builder instance.
          */
         Builder setCorrelationId(final UUID correlationId) {
             mCorrelationId = correlationId;
+            return this;
+        }
+
+        /**
+         * Sets the api error code.
+         *
+         * @param errorCode the error code to set.
+         * @return the Builder instance.
+         */
+        Builder setApiErrorCode(final String errorCode) {
+            mApiErrorCode = errorCode;
             return this;
         }
 

--- a/msal/src/telemetry/java/com/microsoft/identity/client/EventConstants.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/EventConstants.java
@@ -108,6 +108,7 @@ final class EventConstants {
         static final String TENANT_ID = EVENT_PREFIX + "tenant_id";
         static final String LOGIN_HINT = EVENT_PREFIX + "login_hint";
         static final String USER_ID = EVENT_PREFIX + "user_id";
+        static final String API_ERROR_CODE = EVENT_PREFIX + "api_error_code";
 
         // CacheEvent
         static final String TOKEN_TYPE = EVENT_PREFIX + "token_type";


### PR DESCRIPTION
This closes #127 - grabs error codes from `MsalException` and sets them on `ApiEvent#setApiErrorCode(String)`