### PR TITLE
move pom task under dependency to correctly generate dependency in pom

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -100,6 +100,25 @@ task sourcesJar(type: Jar) {
     destinationDir = reporting.file("$project.buildDir/outputs/jar/")
 }
 
+dependencies {
+    compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:appcompat-v7:25.1.0'
+    compile 'com.android.support:customtabs:25.1.0'
+    compile 'com.google.code.gson:gson:2.2.4'
+
+    // test dependencies
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.mockito:mockito-core:1.10.19'
+
+    // instrumentation test dependencies
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    // Set this dependency to use JUnit 4 rules
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'org.mockito:mockito-core:1.10.19'
+    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
+    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
+}
+
 task createPom {
     pom {
         project {
@@ -136,25 +155,6 @@ task createPom {
             }
         }
     }.writeTo("${archivesBaseName}-${version}.pom")
-}
-
-dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:25.1.0'
-    compile 'com.android.support:customtabs:25.1.0'
-    compile 'com.google.code.gson:gson:2.2.4'
-
-    // test dependencies
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-
-    // instrumentation test dependencies
-    androidTestCompile 'com.android.support.test:runner:0.5'
-    // Set this dependency to use JUnit 4 rules
-    androidTestCompile 'com.android.support.test:rules:0.5'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
-    androidTestCompile 'com.google.dexmaker:dexmaker:1.2'
-    androidTestCompile 'com.google.dexmaker:dexmaker-mockito:1.2'
 }
 
 def configDir = new File(buildscript.sourceFile.parentFile.parentFile, 'config')


### PR DESCRIPTION
Move pom task after dependency to correctly generate dependency section in pom file. 