### PR TITLE
Update travis to set up emulator and run instrumentation tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,26 @@ android:
     - extra
     - extra-android-m2repository
     - extra-google-m2repository
+    - addon-google_apis-google-21
+    #system images
+    - sys-img-armeabi-v7a-addon-google_apis-google-21
 
 env:
+    global:
+      # This is to guaratee a clean gradle log
+      - TERM=dumb
     matrix:
       - ANDROID_SDKS=android-25 ANDROID_TARGET=android-25
 
 before_install:
   - chmod +x gradlew
 
+before_script:
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
 script:
   - cd $PWD
-  - ./gradlew clean build --info
+  - ./gradlew clean build connectedAndroidTest -PdisablePreDex


### PR DESCRIPTION
Set up the emulator with sdk 21 (it's not stable to start emulator 23+ on travis which will cause build to be error out more often), and enable test run for travis CI. Disable predex. 