### PR TITLE
Telemetry Events now tracked in a single Map + tests (#186)

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
@@ -51,6 +51,9 @@ public class ApiEventTest {
     static final String TEST_LOGIN_HINT = "user@contoso.com";
     static final boolean TEST_API_CALL_WAS_SUCCESSFUL = true;
     static final String TEST_API_ERROR_CODE = "test_error_code";
+    static final Long TEST_START_TIME = 0L;
+    static final Long TEST_STOP_TIME = 1L;
+    static final Long TEST_ELAPSED_TIME = TEST_STOP_TIME - TEST_START_TIME;
 
     // Authorities
     private static final String TEST_AUTHORITY_WITH_IDENTIFIER = AndroidTestUtil.DEFAULT_AUTHORITY_WITH_TENANT;
@@ -63,6 +66,9 @@ public class ApiEventTest {
 
     static ApiEvent.Builder getTestApiEventBuilder(final String requestId, final String authority) {
         return new ApiEvent.Builder(requestId)
+                .setStartTime(0L)
+                .setStopTime(1L)
+                .setElapsedTime(1L)
                 .setAuthority(authority)
                 .setAuthorityType(TEST_AUTHORITY_TYPE)
                 .setUiBehavior(TEST_UI_BEHAVIOR)
@@ -101,6 +107,9 @@ public class ApiEventTest {
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final ApiEvent apiEvent = getTestApiEvent(telemetryRequestId, TEST_AUTHORITY);
         Assert.assertEquals(telemetryRequestId, apiEvent.getRequestId());
+        Assert.assertEquals(TEST_START_TIME, apiEvent.getStartTime());
+        Assert.assertEquals(TEST_STOP_TIME, apiEvent.getStopTime());
+        Assert.assertEquals(TEST_ELAPSED_TIME, apiEvent.getElapsedTime());
         Assert.assertEquals(TEST_AUTHORITY, apiEvent.getAuthority());
         Assert.assertEquals(EventProperty.Value.AUTHORITY_TYPE_AAD, apiEvent.getAuthorityType());
         Assert.assertEquals(TEST_UI_BEHAVIOR, apiEvent.getUiBehavior());

--- a/msal/src/androidTest/java/com/microsoft/identity/client/TelemetryTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/TelemetryTest.java
@@ -87,7 +87,7 @@ public class TelemetryTest {
         // create some Telemetry data
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final HttpEvent.Builder httpEventBuilder = HttpEventTest.getTestHttpEventBuilder();
-        mTestInstance.startEvent(telemetryRequestId, httpEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId, httpEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId, httpEventBuilder);
 
         // flush the data to the receiver
@@ -139,7 +139,7 @@ public class TelemetryTest {
         // create some Telemetry data
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final HttpEvent.Builder httpEventBuilder = HttpEventTest.getTestHttpEventBuilder();
-        mTestInstance.startEvent(telemetryRequestId, httpEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId, httpEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId, httpEventBuilder);
 
         // flush the data to the receiver
@@ -176,12 +176,12 @@ public class TelemetryTest {
         // create some Telemetry data
         final String telemetryRequestId1 = Telemetry.generateNewRequestId();
         final HttpEvent.Builder httpEventBuilder = HttpEventTest.getTestHttpEventBuilder();
-        mTestInstance.startEvent(telemetryRequestId1, httpEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId1, httpEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId1, httpEventBuilder);
 
         final String telemetryRequestId2 = Telemetry.generateNewRequestId();
         final CacheEvent.Builder cacheEventBuilder = CacheEventTest.getTestCacheEventBuilder(EventConstants.EventName.TOKEN_CACHE_LOOKUP, "bearer");
-        mTestInstance.startEvent(telemetryRequestId2, cacheEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId2, cacheEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId2, cacheEventBuilder);
 
         // flush the data to the receiver
@@ -228,9 +228,9 @@ public class TelemetryTest {
         final CacheEvent.Builder cacheEventBuilder = new CacheEvent.Builder(EventConstants.EventName.TOKEN_CACHE_LOOKUP)
                 .setTokenType("bearer");
 
-        mTestInstance.startEvent(telemetryRequestId1, apiEventBuilder.getEventName());
-        mTestInstance.startEvent(telemetryRequestId1, uiEventBuilder.getEventName());
-        mTestInstance.startEvent(telemetryRequestId1, cacheEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId1, apiEventBuilder);
+        mTestInstance.startEvent(telemetryRequestId1, uiEventBuilder);
+        mTestInstance.startEvent(telemetryRequestId1, cacheEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId1, cacheEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId1, uiEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId1, apiEventBuilder);
@@ -261,9 +261,9 @@ public class TelemetryTest {
         final CacheEvent.Builder cacheEventBuilder2 = new CacheEvent.Builder(EventConstants.EventName.TOKEN_CACHE_LOOKUP)
                 .setTokenType("bearer");
 
-        mTestInstance.startEvent(telemetryRequestId2, apiEventBuilder2.getEventName());
-        mTestInstance.startEvent(telemetryRequestId2, uiEventBuilder2.getEventName());
-        mTestInstance.startEvent(telemetryRequestId2, cacheEventBuilder2.getEventName());
+        mTestInstance.startEvent(telemetryRequestId2, apiEventBuilder2);
+        mTestInstance.startEvent(telemetryRequestId2, uiEventBuilder2);
+        mTestInstance.startEvent(telemetryRequestId2, cacheEventBuilder2);
         mTestInstance.stopEvent(telemetryRequestId2, cacheEventBuilder2);
         mTestInstance.stopEvent(telemetryRequestId2, uiEventBuilder2);
         mTestInstance.stopEvent(telemetryRequestId2, apiEventBuilder2);
@@ -296,9 +296,9 @@ public class TelemetryTest {
         final CacheEvent.Builder cacheEventBuilder = new CacheEvent.Builder(EventConstants.EventName.TOKEN_CACHE_LOOKUP)
                 .setTokenType("bearer").setIsAT(true);
 
-        mTestInstance.startEvent(telemetryRequestId1, apiEventBuilder.getEventName());
-        mTestInstance.startEvent(telemetryRequestId1, uiEventBuilder.getEventName());
-        mTestInstance.startEvent(telemetryRequestId1, cacheEventBuilder.getEventName());
+        mTestInstance.startEvent(telemetryRequestId1, apiEventBuilder);
+        mTestInstance.startEvent(telemetryRequestId1, uiEventBuilder);
+        mTestInstance.startEvent(telemetryRequestId1, cacheEventBuilder);
         mTestInstance.stopEvent(telemetryRequestId1, cacheEventBuilder);
         // Do not stop the UiEvent...
         //mTestInstance.stopEvent(uiEventBuilder.build());

--- a/msal/src/cache/java/com/microsoft/identity/client/TokenCacheAccessor.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/TokenCacheAccessor.java
@@ -77,7 +77,7 @@ final class TokenCacheAccessor {
 
     private static CacheEvent.Builder createAndStartNewCacheEvent(final String telemetryRequestId, final String eventName, final boolean isRT) {
         final CacheEvent.Builder cacheEventBuilder = createNewCacheEventBuilder(eventName, isRT);
-        Telemetry.getInstance().startEvent(telemetryRequestId, eventName);
+        Telemetry.getInstance().startEvent(telemetryRequestId, cacheEventBuilder);
         return cacheEventBuilder;
     }
 

--- a/msal/src/http/java/com/microsoft/identity/client/HttpRequest.java
+++ b/msal/src/http/java/com/microsoft/identity/client/HttpRequest.java
@@ -173,7 +173,7 @@ final class HttpRequest {
                         .setHttpPath(mRequestUrl)
                         .setHttpMethod(mRequestMethod)
                         .setQueryParameters(mRequestUrl.getQuery());
-        Telemetry.getInstance().startEvent(mRequestContext.getTelemetryRequestId(), httpEventBuilder.getEventName());
+        Telemetry.getInstance().startEvent(mRequestContext.getTelemetryRequestId(), httpEventBuilder);
         final HttpURLConnection urlConnection = setupConnection();
         urlConnection.setRequestMethod(mRequestMethod);
         setRequestBody(urlConnection, mRequestContent, mRequestContentType);

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
@@ -97,7 +97,7 @@ public final class AuthenticationActivity extends Activity {
 
         mTelemetryRequestId = data.getStringExtra(Constants.TELEMETRY_REQUEST_ID);
         mUiEventBuilder = new UiEvent.Builder();
-        Telemetry.getInstance().startEvent(mTelemetryRequestId, mUiEventBuilder.getEventName());
+        Telemetry.getInstance().startEvent(mTelemetryRequestId, mUiEventBuilder);
     }
 
     @Override

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -272,12 +272,12 @@ public final class PublicClientApplication {
         final ApiEvent.Builder apiEventBuilder = new ApiEvent.Builder(telemetryRequestId);
         final URL authorityURL = MsalUtils.getUrl(mAuthorityString);
         apiEventBuilder.setAuthority(authorityURL.getProtocol() + "://" + authorityURL.getHost());
-        Telemetry.getInstance().startEvent(telemetryRequestId, apiEventBuilder.getEventName());
+        Telemetry.getInstance().startEvent(telemetryRequestId, apiEventBuilder);
 
         List<User> users = mTokenCache.getUsers(Authority.createAuthority(mAuthorityString, mValidateAuthority).getAuthorityHost(), mClientId, new RequestContext(UUID.randomUUID(), mComponent, telemetryRequestId));
 
         apiEventBuilder.setApiCallWasSuccessful(true);
-        stopTelemetryEventAndFlush(apiEventBuilder.build());
+        stopTelemetryEventAndFlush(apiEventBuilder);
         return users;
     }
 
@@ -547,14 +547,14 @@ public final class PublicClientApplication {
         final ApiEvent.Builder apiEventBuilder = new ApiEvent.Builder(telemetryRequestId);
         final URL authorityURL = MsalUtils.getUrl(mAuthorityString);
         apiEventBuilder.setAuthority(authorityURL.getProtocol() + "://" + authorityURL.getHost());
-        Telemetry.getInstance().startEvent(telemetryRequestId, EventConstants.EventName.API_EVENT);
+        Telemetry.getInstance().startEvent(telemetryRequestId, apiEventBuilder);
 
         final RequestContext requestContext = new RequestContext(UUID.randomUUID(), mComponent, telemetryRequestId);
         mTokenCache.deleteRefreshTokenByUser(user, requestContext);
         mTokenCache.deleteAccessTokenByUser(user, requestContext);
 
         apiEventBuilder.setApiCallWasSuccessful(true);
-        stopTelemetryEventAndFlush(apiEventBuilder.build());
+        stopTelemetryEventAndFlush(apiEventBuilder);
     }
 
     /**
@@ -697,7 +697,7 @@ public final class PublicClientApplication {
                         .setAuthority(mAuthorityString);
 
         // Start the Event on our Telemetry instance
-        Telemetry.getInstance().startEvent(telemetryRequestId, EventConstants.EventName.API_EVENT);
+        Telemetry.getInstance().startEvent(telemetryRequestId, eventBuilder);
 
         // Return the Builder
         return eventBuilder;
@@ -720,7 +720,7 @@ public final class PublicClientApplication {
             @Override
             public void onSuccess(final AuthenticationResult authenticationResult) {
                 eventBinding.setApiCallWasSuccessful(true);
-                stopTelemetryEventAndFlush(eventBinding.build());
+                stopTelemetryEventAndFlush(eventBinding);
                 authenticationCallback.onSuccess(authenticationResult);
             }
 
@@ -728,21 +728,22 @@ public final class PublicClientApplication {
             public void onError(final MsalException exception) {
                 eventBinding.setApiCallWasSuccessful(false);
                 eventBinding.setApiErrorCode(exception.getErrorCode());
-                stopTelemetryEventAndFlush(eventBinding.build());
+                stopTelemetryEventAndFlush(eventBinding);
                 authenticationCallback.onError(exception);
             }
 
             @Override
             public void onCancel() {
-                stopTelemetryEventAndFlush(eventBinding.build());
+                stopTelemetryEventAndFlush(eventBinding);
                 authenticationCallback.onCancel();
             }
         };
     }
 
     @SuppressWarnings("PMD.UnusedPrivateMethod")
-    private void stopTelemetryEventAndFlush(final ApiEvent event) {
-        Telemetry.getInstance().stopEvent(event.getRequestId(), event.getEventName(), event);
+    private void stopTelemetryEventAndFlush(final ApiEvent.Builder builder) {
+        final ApiEvent event = builder.build();
+        Telemetry.getInstance().stopEvent(event.getRequestId(), builder);
         Telemetry.getInstance().flush(event.getRequestId());
     }
 }

--- a/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
@@ -46,6 +46,15 @@ class Event extends ArrayList<Pair<String, String>> {
         if (!EventConstants.EventName.DEFAULT_EVENT.equals(builder.mEventName)) {
             setProperty(EventProperty.EVENT_NAME, builder.mEventName);
         }
+        if (null != builder.mEventStartTime) {
+            setProperty(EventProperty.START_TIME, String.valueOf(builder.mEventStartTime));
+        }
+        if (null != builder.mEventStartTime) {
+            setProperty(EventProperty.STOP_TIME, String.valueOf(builder.mEventStopTime));
+        }
+        if (null != builder.mEventElapsedTime) {
+            setProperty(EventProperty.ELAPSED_TIME, String.valueOf(builder.mEventElapsedTime));
+        }
     }
 
     void setProperty(final String propertyName, final String propertyValue) {
@@ -74,6 +83,33 @@ class Event extends ArrayList<Pair<String, String>> {
     }
 
     /**
+     * Gets the Event startTime.
+     *
+     * @return the startTime to get.
+     */
+    Long getStartTime() {
+        return Long.valueOf(getProperty(EventProperty.START_TIME));
+    }
+
+    /**
+     * Gets the Event stopTime.
+     *
+     * @return the stopTime to get.
+     */
+    Long getStopTime() {
+        return Long.valueOf(getProperty(EventProperty.STOP_TIME));
+    }
+
+    /**
+     * Gets the Event elapsedTime.
+     *
+     * @return the elapsedTime to get.
+     */
+    Long getElapsedTime() {
+        return Long.valueOf(getProperty(EventProperty.ELAPSED_TIME));
+    }
+
+    /**
      * Builder object used for Events.
      *
      * @param <T> generic type parameter for Builder subtypes.
@@ -81,6 +117,10 @@ class Event extends ArrayList<Pair<String, String>> {
     abstract static class Builder<T extends Builder> {
 
         private final String mEventName;
+        private Long mEventStartTime;
+        private Long mEventStopTime;
+        private Long mEventElapsedTime;
+        private boolean mIsCompleted;
 
         Builder(final String name) {
             mEventName = name;
@@ -93,6 +133,68 @@ class Event extends ArrayList<Pair<String, String>> {
          */
         final String getEventName() {
             return mEventName;
+        }
+
+        /**
+         * Gets the startTime.
+         *
+         * @return the startTime to get.
+         */
+        final Long getStartTime() {
+            return mEventStartTime;
+        }
+
+        /**
+         * Gets the completion status.
+         *
+         * @return the completion status to get.
+         */
+        final boolean getIsCompleted() {
+            return mIsCompleted;
+        }
+
+        /**
+         * Sets the startTime of this Builder.
+         *
+         * @param startTime the startTime to set.
+         * @return the Builder instance.
+         */
+        final T setStartTime(final long startTime) {
+            mEventStartTime = startTime;
+            return (T) this;
+        }
+
+        /**
+         * Sets the stopTime of this Builder.
+         *
+         * @param stopTime the stopTime to set.
+         * @return the Builder instance.
+         */
+        final T setStopTime(final long stopTime) {
+            mEventStopTime = stopTime;
+            return (T) this;
+        }
+
+        /**
+         * Sets the elapsedTime of this Builder.
+         *
+         * @param elapsedTime the elapsedTime to set.
+         * @return the Builder instance.
+         */
+        final T setElapsedTime(final long elapsedTime) {
+            mEventElapsedTime = elapsedTime;
+            return (T) this;
+        }
+
+        /**
+         * Sets the isCompleted flag of this Builder.
+         *
+         * @param isCompleted the isCompleted status to set.
+         * @return the Builder instance.
+         */
+        final T setIsCompleted(final boolean isCompleted) {
+            mIsCompleted = isCompleted;
+            return (T) this;
         }
 
         /**


### PR DESCRIPTION
This change removes `Telemetry#mEventsInProgress` and `Telemetry#mCompletedEvents` in favor of tracking telemetry `Event` data in a single `Map` instance.

Events are now tracked via their `Event.Builder` subclasses; a field `mIsCompleted` has been added. The completed status is updated in `Telemetry#stopEvent()`.

`Event` `startTime` and `stopTime` are tracked in `Telemetry#startEvent()` and `Telemetry#stopEvent()` respectively.

`Event.Builder` instances are built when `Telemetry#flush(String)` is called. `OrphanedEvents` are determined to be `Events` whose `flush()` has been called without first calling `stopEvent()`.