### PR TITLE
adding emulator to run android test and enable gradle cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ language: android
 jdk:
   - oraclejdk8
 
+# Don't use the Travis Container-Based Infrastructure
+sudo: true
+
 android:
   components:
     # Travis has a bug that we need to workaround to use sdk 25
@@ -17,14 +20,35 @@ android:
     - extra
     - extra-android-m2repository
     - extra-google-m2repository
+    - addon-google_apis-google-21
+    #system images
+    - sys-img-armeabi-v7a-addon-google_apis-google-21
 
 env:
+    global:
+      # This is to guaratee a clean gradle log
+      - TERM=dumb
     matrix:
       - ANDROID_SDKS=android-25 ANDROID_TARGET=android-25
 
 before_install:
   - chmod +x gradlew
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache
+
+before_script:
+  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+
 script:
   - cd $PWD
-  - ./gradlew clean build --info
+  - ./gradlew clean assembleRelease connectedAndroidTest -PdisablePreDex

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -24,6 +24,7 @@ android {
             testCoverageEnabled true
         }
         release {
+            testCoverageEnabled true
             minifyEnabled false
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
Adding emulator for travis CI to run android instrumental tests as part of build process, also enable gradle cache to speed up the build process. 