### PR TITLE
Applies the Android Studio formatter to the MSAL module

### DIFF
--- a/msal/src/androidTest/AndroidManifest.xml
+++ b/msal/src/androidTest/AndroidManifest.xml
@@ -2,41 +2,42 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.microsoft.identity.msal"
     android:versionCode="1"
-    android:versionName="1.0" >
+    android:versionName="1.0">
 
-    <uses-sdk android:minSdkVersion="21"
-         android:targetSdkVersion="25"  />
+    <uses-sdk
+        android:minSdkVersion="21"
+        android:targetSdkVersion="25" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:label="@string/app_name"
-        android:allowBackup="false" >
+        android:allowBackup="false">
         <uses-library android:name="android.test.runner" />
 
         <activity
             android:name="com.microsoft.identity.client.AuthenticationActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize">
-        </activity>
-        <activity android:name="com.microsoft.identity.client.TestActivity">
-        </activity>
+            android:configChanges="orientation|keyboardHidden|screenSize" />
+        <activity android:name="com.microsoft.identity.client.TestActivity" />
 
-        <activity
-            android:name="com.microsoft.identity.client.BrowserTabActivity">
+        <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="msalclient-id"
-                      android:host="auth" />
+
+                <data
+                    android:scheme="msalclient-id"
+                    android:host="auth" />
             </intent-filter>
         </activity>
 
         <meta-data
             android:name="com.microsoft.identity.client.ClientId"
-            android:value="client-id"/>
-        
+            android:value="client-id" />
+
     </application>
 
 </manifest>

--- a/msal/src/androidTest/java/com/microsoft/identity/client/AdfsAuthorityTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AdfsAuthorityTest.java
@@ -102,7 +102,7 @@ public class AdfsAuthorityTest {
                     "https://fs.lindft6.com/adfs/.well-known/openid-configuration",
                     authority.performInstanceDiscovery(REQUEST_CONTEXT, mTestUPN)
             );
-        } catch (final MsalServiceException| MsalClientException | MalformedURLException e) {
+        } catch (final MsalServiceException | MsalClientException | MalformedURLException e) {
             Assert.fail();
         }
     }
@@ -119,7 +119,7 @@ public class AdfsAuthorityTest {
             mAdfsAuthority.performInstanceDiscovery(REQUEST_CONTEXT, mTestUPN);
         } catch (MalformedURLException e) {
             Assert.fail();
-        } catch (final MsalClientException| MsalServiceException e) {
+        } catch (final MsalClientException | MsalServiceException e) {
             // NOOP: expected
             return;
         }

--- a/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestMockUtil.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestMockUtil.java
@@ -34,10 +34,11 @@ import java.net.SocketTimeoutException;
  */
 public final class AndroidTestMockUtil {
     // private constructor for Util class.
-    private AndroidTestMockUtil() { }
+    private AndroidTestMockUtil() {
+    }
 
     static HttpURLConnection getMockedConnectionWithSuccessResponse(final String message) throws IOException {
-        final HttpURLConnection mockedHttpUrlConnection  = getCommonHttpUrlConnection();
+        final HttpURLConnection mockedHttpUrlConnection = getCommonHttpUrlConnection();
 
         Mockito.when(mockedHttpUrlConnection.getInputStream()).thenReturn(AndroidTestUtil.createInputStream(message));
         Mockito.when(mockedHttpUrlConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);

--- a/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationActivityTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationActivityTest.java
@@ -23,6 +23,7 @@ public final class AuthenticationActivityTest {
 
     private final ActivityTestRule mTestActivityRule = new ActivityTestRule<>(TestActivity.class,
             true, false);
+
     @Before
     public void setUp() {
         mAppContext = InstrumentationRegistry.getInstrumentation().getTargetContext();

--- a/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationResultTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationResultTest.java
@@ -25,9 +25,12 @@ package com.microsoft.identity.client;
 
 import android.support.test.runner.AndroidJUnit4;
 import android.test.suitebuilder.annotation.SmallTest;
+
 import junit.framework.Assert;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/InteractiveRequestTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/InteractiveRequestTest.java
@@ -59,6 +59,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import static org.mockito.Mockito.mock;
 
 /**
@@ -194,7 +195,7 @@ public final class InteractiveRequestTest extends AndroidTestCase {
     }
 
     @Test
-    public void testGetAuthorizationUriContainsSessionContinuationParams()throws UnsupportedEncodingException, MsalClientException {
+    public void testGetAuthorizationUriContainsSessionContinuationParams() throws UnsupportedEncodingException, MsalClientException {
         final User user = new User(AndroidTestUtil.PREFERRED_USERNAME, "name", AndroidTestUtil.ISSUER, AndroidTestUtil.UID, AndroidTestUtil.UTID);
         final InteractiveRequest interactiveRequest = new InteractiveRequest(Mockito.mock(Activity.class), getAuthenticationParams(AUTHORITY,
                 UiBehavior.CONSENT, user), null);

--- a/msal/src/androidTest/java/com/microsoft/identity/client/LoggerTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/LoggerTest.java
@@ -70,7 +70,7 @@ public final class LoggerTest {
         Logger.getInstance().setEnablePII(false);
     }
 
-    @Test (expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void testLoggerOverride() {
         Logger.getInstance().setExternalLogger(new ILoggerCallback() {
             @Override
@@ -310,7 +310,7 @@ public final class LoggerTest {
     }
 
     /**
-     * Test log response class to get the log message. 
+     * Test log response class to get the log message.
      */
     static final class LogResponse {
         private String mTag;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/MsalUtilTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/MsalUtilTest.java
@@ -62,6 +62,7 @@ import java.util.Set;
 public final class MsalUtilTest {
     static final int EXPECTED_SINGLE_SCOPE_SIZE = 1;
     static final int EXPECTED_MULTI_SCOPE_SIZE = 3;
+
     @Test
     public void testNullMessage() {
         Assert.assertTrue(MsalUtils.isEmpty(null));
@@ -268,7 +269,7 @@ public final class MsalUtilTest {
 
         // The three chrome package all exists on the device, return the stable chrome package name.
         Mockito.when(mockedPackageManager.getPackageInfo(Matchers.refEq(MsalUtils.CHROME_PACKAGE),
-                    Matchers.eq(PackageManager.GET_ACTIVITIES))).thenReturn(Mockito.mock(PackageInfo.class));
+                Matchers.eq(PackageManager.GET_ACTIVITIES))).thenReturn(Mockito.mock(PackageInfo.class));
 
         Assert.assertTrue(MsalUtils.getChromePackage(mockedContext).equals(MsalUtils.CHROME_PACKAGE));
     }
@@ -313,7 +314,7 @@ public final class MsalUtilTest {
     @Test
     public void testConvertStringToSet() {
         final String scope1 = "scope1";
-        final String[] scopes = new String[] {" ", scope1, "   "};
+        final String[] scopes = new String[]{" ", scope1, "   "};
         final Set<String> convertedScope = MsalUtils.convertArrayToSet(scopes);
 
         Assert.assertNotNull(convertedScope);
@@ -322,7 +323,7 @@ public final class MsalUtilTest {
 
         final String scope2 = "scope2";
         final String scope3 = "scope3";
-        final String[] scopesTest2 = new String[] {scope1, scope2, scope3};
+        final String[] scopesTest2 = new String[]{scope1, scope2, scope3};
         final Set<String> convertedScope2 = MsalUtils.convertArrayToSet(scopesTest2);
 
         Assert.assertNotNull(convertedScope2);

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -395,7 +395,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
 
     }
 
-    @Test (expected = IllegalArgumentException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void testAcquireTokenInteractiveScopeWithEmptyString() throws PackageManager.NameNotFoundException, IOException,
             InterruptedException {
         new GetTokenBaseTestCase() {
@@ -412,7 +412,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
             void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
                                       final Activity activity,
                                       final CountDownLatch releaseLock) {
-                publicClientApplication.acquireToken(activity, new String[] {" "}, new AuthenticationCallback() {
+                publicClientApplication.acquireToken(activity, new String[]{" "}, new AuthenticationCallback() {
                     @Override
                     public void onSuccess(AuthenticationResult authenticationResult) {
                         Assert.assertTrue(AndroidTestUtil.ACCESS_TOKEN.equals(authenticationResult.getAccessToken()));

--- a/msal/src/androidTest/java/com/microsoft/identity/client/SilentRequestTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/SilentRequestTest.java
@@ -95,6 +95,7 @@ public final class SilentRequestTest extends AndroidTestCase {
 
         new SilentRequest(mAppContext, getRequestParameters(scopes), false, mDefaultUser);
     }
+
     /**
      * Verify that correct exception is thrown if device is not connected to the network.
      */

--- a/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheKeyTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheKeyTest.java
@@ -110,7 +110,7 @@ public final class TokenCacheKeyTest {
         final RefreshTokenCacheItem item = new RefreshTokenCacheItem(AUTHORITY_HOST, CLIENT_ID, response);
 
         Assert.assertTrue(item.extractTokenCacheKey().toString().equals(MsalUtils.base64UrlEncodeToString(AUTHORITY_HOST) + "$"
-                + MsalUtils.base64UrlEncodeToString(CLIENT_ID)  + "$" + MsalUtils.getUniqueUserIdentifier(AndroidTestUtil.UID, AndroidTestUtil.UTID)));
+                + MsalUtils.base64UrlEncodeToString(CLIENT_ID) + "$" + MsalUtils.getUniqueUserIdentifier(AndroidTestUtil.UID, AndroidTestUtil.UTID)));
     }
 
     @Test

--- a/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/TokenCacheTest.java
@@ -605,7 +605,7 @@ public final class TokenCacheTest extends AndroidTestCase {
 
         return new TokenResponse(accessToken, idToken, refreshToken, expiresOn,
                 expiresOn, AndroidTestUtil.getExpirationDate(AndroidTestUtil.TOKEN_EXPIRATION_IN_MINUTES * 2), scopesInResponse, "Bearer", rawClientInfo);
-    };
+    }
 
     static TokenResponse getTokenResponseForDifferentUser(final String accessToken, final String refreshToken, final String scopesInResponse,
                                                           final Date expiresOn, final String clientInfo)

--- a/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AadAuthority.java
@@ -43,7 +43,7 @@ class AadAuthority extends Authority {
 
     static final String DEPRECATED_AAD_AUTHORITY_HOST = "login.windows.net";
     static final String AAD_AUTHORITY_HOST = "login.microsoftonline.com";
-    static final String[] TRUSTED_HOSTS = new String[] {
+    static final String[] TRUSTED_HOSTS = new String[]{
             AAD_AUTHORITY_HOST, // Microsoft Azure Worldwide
             "login.chinacloudapi.cn", // Microsoft Azure China
             "login.microsoftonline.de", // Microsoft Azure Germany
@@ -73,7 +73,7 @@ class AadAuthority extends Authority {
     }
 
     @Override
-    String performInstanceDiscovery(final RequestContext requestContext, final String userPrincipalName) throws MsalServiceException, MsalClientException  {
+    String performInstanceDiscovery(final RequestContext requestContext, final String userPrincipalName) throws MsalServiceException, MsalClientException {
         Logger.info(TAG, requestContext, "Passed in authority " + mAuthorityUrl.toString() + " is AAD authority. "
                 + "Start doing Instance discovery.");
         if (!mValidateAuthority || TRUSTED_HOST_SET.contains(mAuthorityUrl.getAuthority())) {

--- a/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/AdfsAuthority.java
@@ -129,7 +129,7 @@ final class AdfsAuthority extends Authority {
     }
 
     private DrsMetadata loadDRSMetadata(final RequestContext requestContext, final String userPrincipalName)
-            throws MsalClientException, MsalServiceException  {
+            throws MsalClientException, MsalServiceException {
         final DRSMetadataRequestor drsRequestor = new DRSMetadataRequestor(requestContext);
         return drsRequestor.requestMetadata(getDomainFromUPN(userPrincipalName));
     }

--- a/msal/src/authority/java/com/microsoft/identity/client/Authority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/Authority.java
@@ -128,6 +128,7 @@ abstract class Authority {
      * endpoint will be returned otherwise exception will be thrown. Returned tenant discovery endpoint will be used for
      * tenant discovery to get authorize and token endpoint. Developer could turn off authority validation, but for all the
      * authority, we'll do tenant discovery.
+     *
      * @param requestContext {@link RequestContext} for the authority validation and tenant discovery.
      * @throws MsalException If error happens during authority or tenant discovery.
      */

--- a/msal/src/authority/java/com/microsoft/identity/client/B2cAuthority.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/B2cAuthority.java
@@ -41,6 +41,7 @@ final class B2cAuthority extends AadAuthority {
 
     /**
      * B2C authority will be in the format of https://<host>/tfp/<tenant>/<policy>/...
+     *
      * @param authority The passed in B2C authority
      * @return updated authority with only host/tfp/tenant/policy
      */

--- a/msal/src/authority/java/com/microsoft/identity/client/DrsMetadataRequestor.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/DrsMetadataRequestor.java
@@ -74,8 +74,8 @@ class DRSMetadataRequestor extends AbstractMetadataRequestor<DrsMetadata, String
      *
      * @param domain the domain to validate
      * @return the DRS discovery metadata
-     * @throws UnknownHostException    if the on-prem enrollment server cannot be resolved
-     * @throws MsalException if there exists an enrollment/domain mismatch (lack of trust)
+     * @throws UnknownHostException if the on-prem enrollment server cannot be resolved
+     * @throws MsalException        if there exists an enrollment/domain mismatch (lack of trust)
      */
     private DrsMetadata requestOnPrem(final String domain)
             throws UnknownHostException, MsalClientException, MsalServiceException {
@@ -89,7 +89,7 @@ class DRSMetadataRequestor extends AbstractMetadataRequestor<DrsMetadata, String
      * @param domain the domain to validate
      * @return the DRS discovery metadata
      * @throws MsalException if there exists an enrollment/domain mismatch (lack of trust)
-     *                                 or the trust cannot be verified
+     *                       or the trust cannot be verified
      */
     private DrsMetadata requestCloud(final String domain) throws MsalClientException, MsalServiceException {
         Logger.verbose(TAG, getRequestContext(), "Requesting DRS discovery (cloud)");

--- a/msal/src/authority/java/com/microsoft/identity/client/InstanceDiscoveryResponse.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/InstanceDiscoveryResponse.java
@@ -34,6 +34,7 @@ final class InstanceDiscoveryResponse extends BaseOauth2Response {
 
     /**
      * Constructor for creating the success response of instance discovery.
+     *
      * @param tenantDiscoveryEndpoint The tenant discovery endpoint.
      */
     InstanceDiscoveryResponse(final String tenantDiscoveryEndpoint) {
@@ -44,9 +45,10 @@ final class InstanceDiscoveryResponse extends BaseOauth2Response {
 
     /**
      * Constructor for creating the failure response of instance discovery.
-     * @param error Error code representing the failure.
+     *
+     * @param error            Error code representing the failure.
      * @param errorDescription Detailed error description.
-     * @param statusCode The http status code related with the request.
+     * @param statusCode       The http status code related with the request.
      */
     InstanceDiscoveryResponse(final String error, final String errorDescription, final int statusCode) {
         super(error, errorDescription, statusCode);

--- a/msal/src/authority/java/com/microsoft/identity/client/TenantDiscoveryResponse.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/TenantDiscoveryResponse.java
@@ -55,6 +55,7 @@ final class TenantDiscoveryResponse extends BaseOauth2Response {
 
     /**
      * Constructor for creating the {@link TenantDiscoveryResponse} with error.
+     *
      * @param response
      */
     TenantDiscoveryResponse(final BaseOauth2Response response) {

--- a/msal/src/authority/java/com/microsoft/identity/client/WebFingerMetadataRequestParameters.java
+++ b/msal/src/authority/java/com/microsoft/identity/client/WebFingerMetadataRequestParameters.java
@@ -29,7 +29,7 @@ import java.net.URL;
  * Encapsulates parameters used to request {@link WebFingerMetadata}.
  */
 final class WebFingerMetadataRequestParameters {
-    
+
     private final URL mDomain;
 
     private final DrsMetadata mMetadata;

--- a/msal/src/cache/java/com/microsoft/identity/client/AccessTokenCacheItem.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/AccessTokenCacheItem.java
@@ -59,7 +59,7 @@ final class AccessTokenCacheItem extends BaseTokenCacheItem {
      */
     AccessTokenCacheItem(final String authority, final String clientId, final TokenResponse response)
             throws MsalClientException {
-        super(clientId,response.getRawClientInfo());
+        super(clientId, response.getRawClientInfo());
 
         mAuthority = authority;
         mAccessToken = response.getAccessToken();

--- a/msal/src/cache/java/com/microsoft/identity/client/BaseTokenCacheItem.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/BaseTokenCacheItem.java
@@ -80,7 +80,7 @@ abstract class BaseTokenCacheItem {
         mUser = user;
     }
 
-    String getVersion () {
+    String getVersion() {
         return mVersion;
     }
 

--- a/msal/src/cache/java/com/microsoft/identity/client/TokenCache.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/TokenCache.java
@@ -248,7 +248,7 @@ class TokenCache {
      * An immutable list of signed-in users for the given client id.
      *
      * @param environment
-     * @param clientId The application client id that is used to retrieve for all the signed in users.
+     * @param clientId       The application client id that is used to retrieve for all the signed in users.
      * @param requestContext the RequestContext initiating this call
      * @return The list of signed in users for the given client id.
      */
@@ -362,7 +362,7 @@ class TokenCache {
     /**
      * @return List of all {@link AccessTokenCacheItem}s that exist in the cache.
      */
-    List<AccessTokenCacheItem> getAllAccessTokens(final RequestContext requestContext){
+    List<AccessTokenCacheItem> getAllAccessTokens(final RequestContext requestContext) {
         final Collection<String> accessTokensAsString = mTokenCacheAccessor.getAllAccessTokens(requestContext.getTelemetryRequestId());
         if (accessTokensAsString == null) {
             Logger.verbose(TAG, requestContext, "No access tokens existed in the token cache.");
@@ -382,7 +382,7 @@ class TokenCache {
      * @param clientId Client id that is used to filter all {@link RefreshTokenCacheItem}s that exist in the cache.
      * @return The unmodifiable List of {@link RefreshTokenCacheItem}s that match the given client id.
      */
-    private  List<RefreshTokenCacheItem> getAllRefreshTokenForApp(final String clientId, final RequestContext requestContext) {
+    private List<RefreshTokenCacheItem> getAllRefreshTokenForApp(final String clientId, final RequestContext requestContext) {
         final List<RefreshTokenCacheItem> allRTs = getAllRefreshTokens(requestContext);
 
         final List<RefreshTokenCacheItem> allRTsForApp = new ArrayList<>(allRTs.size());

--- a/msal/src/cache/java/com/microsoft/identity/client/TokenCacheAccessor.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/TokenCacheAccessor.java
@@ -46,6 +46,7 @@ final class TokenCacheAccessor {
 
     /**
      * Constructor for {@link TokenCacheAccessor}. Access token and refresh token will be stored separately.
+     *
      * @param context
      */
     TokenCacheAccessor(final Context context) {
@@ -131,6 +132,7 @@ final class TokenCacheAccessor {
 
     /**
      * Delete the refresh token item.
+     *
      * @param refreshTokenCacheKey The string value of the refresh token cache item key to remove.
      */
     void deleteRefreshToken(final String refreshTokenCacheKey, final RequestContext requestContext) {

--- a/msal/src/http/java/com/microsoft/identity/client/HttpConstants.java
+++ b/msal/src/http/java/com/microsoft/identity/client/HttpConstants.java
@@ -24,7 +24,7 @@
 package com.microsoft.identity.client;
 
 final class HttpConstants {
-    
+
     /**
      * HTTP header fields.
      */

--- a/msal/src/http/java/com/microsoft/identity/client/HttpRequest.java
+++ b/msal/src/http/java/com/microsoft/identity/client/HttpRequest.java
@@ -44,7 +44,9 @@ final class HttpRequest {
     private static final String TAG = HttpRequest.class.getSimpleName();
 
     private static final String HOST = "Host";
-    /** The waiting time before doing retry to prevent hitting the server immediately failure. */
+    /**
+     * The waiting time before doing retry to prevent hitting the server immediately failure.
+     */
     private static final int RETRY_TIME_WAITING_PERIOD_MSEC = 1000;
     private static final int STREAM_BUFFER_SIZE = 1024;
 
@@ -63,7 +65,8 @@ final class HttpRequest {
 
     /**
      * Constructor for {@link HttpRequest} with request {@link URL} and request headers.
-     * @param requestUrl The {@link URL} to make the http request.
+     *
+     * @param requestUrl     The {@link URL} to make the http request.
      * @param requestHeaders Headers used to send the http request.
      */
     private HttpRequest(final URL requestUrl, final Map<String, String> requestHeaders, final String requestMethod, final RequestContext requestContext) {
@@ -73,9 +76,10 @@ final class HttpRequest {
     /**
      * Constructor for {@link HttpRequest} with request {@link URL}, headers, post message and the request content
      * type.
-     * @param requestUrl The {@link URL} to make the http request.
-     * @param requestHeaders Headers used to send the http request.
-     * @param requestContent Post message sent in the post request.
+     *
+     * @param requestUrl         The {@link URL} to make the http request.
+     * @param requestHeaders     Headers used to send the http request.
+     * @param requestContent     Post message sent in the post request.
      * @param requestContentType Request content type.
      */
     private HttpRequest(final URL requestUrl, final Map<String, String> requestHeaders,
@@ -94,9 +98,10 @@ final class HttpRequest {
 
     /**
      * Send post request {@link URL}, headers, post message and the request content type.
-     * @param requestUrl The {@link URL} to make the http request.
-     * @param requestHeaders Headers used to send the http request.
-     * @param requestContent Post message sent in the post request.
+     *
+     * @param requestUrl         The {@link URL} to make the http request.
+     * @param requestHeaders     Headers used to send the http request.
+     * @param requestContent     Post message sent in the post request.
      * @param requestContentType Request content type.
      */
     public static HttpResponse sendPost(final URL requestUrl, final Map<String, String> requestHeaders,
@@ -111,7 +116,8 @@ final class HttpRequest {
 
     /**
      * Send Get request {@link URL} and request headers.
-     * @param requestUrl The {@link URL} to make the http request.
+     *
+     * @param requestUrl     The {@link URL} to make the http request.
      * @param requestHeaders Headers used to send the http request.
      */
     public static HttpResponse sendGet(final URL requestUrl, final Map<String, String> requestHeaders,
@@ -295,6 +301,7 @@ final class HttpRequest {
 
     /**
      * Check if the given status code is the retryable status code(500/503/504).
+     *
      * @param statusCode The status to check.
      * @return True if the status code is 500, 503 or 504, false otherwise.
      */

--- a/msal/src/http/java/com/microsoft/identity/client/HttpResponse.java
+++ b/msal/src/http/java/com/microsoft/identity/client/HttpResponse.java
@@ -36,8 +36,9 @@ final class HttpResponse {
 
     /**
      * Constructor for {@link HttpResponse}.
-     * @param statusCode The status code from the server response.
-     * @param responseBody Raw response body.
+     *
+     * @param statusCode      The status code from the server response.
+     * @param responseBody    Raw response body.
      * @param responseHeaders Response headers from the connection sent to the server.
      */
     public HttpResponse(final int statusCode, final String responseBody,

--- a/msal/src/http/java/com/microsoft/identity/client/HttpUrlConnectionFactory.java
+++ b/msal/src/http/java/com/microsoft/identity/client/HttpUrlConnectionFactory.java
@@ -39,10 +39,12 @@ final class HttpUrlConnectionFactory {
     /**
      * Private constructor to prevent the class from being initiated.
      */
-    private HttpUrlConnectionFactory() { }
+    private HttpUrlConnectionFactory() {
+    }
 
     /**
      * Used by tests to add mocked connection into the queue.
+     *
      * @param mockedConnection The mocked {@link HttpURLConnection} to put in the queue.
      */
     static void addMockedConnection(final HttpURLConnection mockedConnection) {
@@ -58,6 +60,7 @@ final class HttpUrlConnectionFactory {
 
     /**
      * Used by test to get the current number of mocked connections in the queue.
+     *
      * @return The number of mocked connections in the queue.
      */
     static int getMockedConnectionCountInQueue() {
@@ -66,6 +69,7 @@ final class HttpUrlConnectionFactory {
 
     /**
      * Creates the {@link HttpURLConnection} with the given url.
+     *
      * @param url The request URL used to create the connection.
      * @return {@link HttpURLConnection} with the provided URL.
      * @throws IOException if it fails to open connection with the provided URL.

--- a/msal/src/internal/java/com/microsoft/identity/client/Constants.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/Constants.java
@@ -29,7 +29,8 @@ package com.microsoft.identity.client;
 final class Constants {
 
     // Private constructor to prevent class from being initialized.
-    private Constants() { }
+    private Constants() {
+    }
 
     public static final String REQUEST_URL_KEY = "com.microsoft.identity.request.url.key";
 

--- a/msal/src/internal/java/com/microsoft/identity/client/IdToken.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/IdToken.java
@@ -45,6 +45,7 @@ final class IdToken {
 
     /**
      * Constructor to create a new {@link IdToken}. Will parse the raw id token.
+     *
      * @param rawIdToken The raw Id token used to create the {@link IdToken}.
      */
     IdToken(final String rawIdToken) throws MsalClientException {

--- a/msal/src/internal/java/com/microsoft/identity/client/OauthConstants.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/OauthConstants.java
@@ -73,10 +73,14 @@ final class OauthConstants {
      */
     static final class OauthHeader {
 
-        /** String representing the correlation_id sent in the header. */
+        /**
+         * String representing the correlation_id sent in the header.
+         */
         static final String CORRELATION_ID = "client-request-id";
 
-        /** String representing the correlation id returned from server response. */
+        /**
+         * String representing the correlation id returned from server response.
+         */
         static final String CORRELATION_ID_IN_RESPONSE = "return-client-request-id";
     }
 

--- a/msal/src/internal/java/com/microsoft/identity/client/PlatformIdHelper.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/PlatformIdHelper.java
@@ -37,7 +37,8 @@ final class PlatformIdHelper {
     /**
      * Private constructor to prevent a help class from being initiated.
      */
-    private PlatformIdHelper() { }
+    private PlatformIdHelper() {
+    }
 
     static Map<String, String> getPlatformIdParameters() {
         final Map<String, String> platformParameters = new HashMap<>();

--- a/msal/src/internal/java/com/microsoft/identity/client/TokenResponse.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/TokenResponse.java
@@ -159,6 +159,7 @@ final class TokenResponse extends BaseOauth2Response {
 
     /**
      * Set additional data returned in the server response.
+     *
      * @param additionalData The additional data in the JSON response.
      */
     public void setAdditionalData(final Map<String, String> additionalData) {

--- a/msal/src/main/AndroidManifest.xml
+++ b/msal/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.microsoft.identity.msal"
-          android:versionCode="1"
-          android:versionName="1.0.0">
+    package="com.microsoft.identity.msal"
+    android:versionCode="1"
+    android:versionName="1.0.0">
 
     <uses-sdk
         android:minSdkVersion="21"
@@ -15,13 +15,11 @@
         <!-- MSAL activity that will be used to process all the auth related logic  -->
         <activity
             android:name="com.microsoft.identity.client.AuthenticationActivity"
-            android:configChanges="orientation|keyboardHidden|screenSize">
-        </activity>
+            android:configChanges="orientation|keyboardHidden|screenSize" />
 
         <!-- MSAL will use system webview (custom tab) to render the sign-in page, BrowserTabActivity is to get response back from System Webview. Multiple apps on the device could integrate MSAL, OS will check which BrowserTabActivity can handle the intent based on the intent filter declared, so this activity has to be exported.-->
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"
-            android:exported="true">
-        </activity>
+            android:exported="true" />
     </application>
 </manifest>

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
@@ -184,6 +184,7 @@ public final class AuthenticationActivity extends Activity {
 
         /**
          * Gets the {@link CustomTabsSession} associated to this CustomTabs connection.
+         *
          * @return the session.
          */
         CustomTabsSession getCustomTabsSession() {
@@ -223,7 +224,7 @@ public final class AuthenticationActivity extends Activity {
 
         mRestarted = true;
 
-        mRequestUrl =  this.getIntent().getStringExtra(Constants.REQUEST_URL_KEY);
+        mRequestUrl = this.getIntent().getStringExtra(Constants.REQUEST_URL_KEY);
 
         Logger.infoPII(TAG, null, "Request to launch is: " + mRequestUrl);
         if (mChromePackageWithCustomTabSupport != null) {

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationCallback.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationCallback.java
@@ -30,12 +30,14 @@ public interface AuthenticationCallback {
 
     /**
      * Authentication finishes successfully.
+     *
      * @param authenticationResult {@link AuthenticationResult} that contains the success response.
      */
     void onSuccess(final AuthenticationResult authenticationResult);
 
     /**
      * Error occurs during the authentication.
+     *
      * @param exception The {@link MsalException} contains the error code, error message and cause if applicable. The exception
      *                  returned in the callback could be {@link MsalClientException}, {@link MsalServiceException} or
      *                  {@link MsalUiRequiredException}.

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
@@ -79,7 +79,7 @@ public final class AuthenticationResult {
     /**
      * @return The unique identifier of the user.
      */
-    public String getUniqueId () {
+    public String getUniqueId() {
         return mUniqueId;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
@@ -31,7 +31,7 @@ import android.os.Bundle;
  * MSAL activity class (needs to be public in order to be discoverable by the os) to get the browser redirect with auth code from authorize
  * endpoint. This activity has to be exposed by "android:exported=true", and intent filter has to be declared in the
  * manifest for the activity.
- *
+ * <p>
  * When chrome custom tab is launched, and we're redirected back with the redirect
  * uri (the redirect must be unique across apps on a device), the os will fire an intent with the redirect,
  * and the BrowserTabActivity will be launched.

--- a/msal/src/main/java/com/microsoft/identity/client/ILoggerCallback.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ILoggerCallback.java
@@ -25,16 +25,17 @@ package com.microsoft.identity.client;
 
 
 /**
- * Interface for apps to configure the external logging and implement the callback to designate the 
+ * Interface for apps to configure the external logging and implement the callback to designate the
  * output of the log messages.
  */
 public interface ILoggerCallback {
     /**
      * Interface method for apps to hand off each log message as it's generated.
-     * @param tag The TAG for the log message. The sdk send the component name (the class where the
-     *            log is generated).
-     * @param logLevel The {@link Logger.LogLevel} for the generated message.
-     * @param message The detailed message. Will not contain any PII info.
+     *
+     * @param tag         The TAG for the log message. The sdk send the component name (the class where the
+     *                    log is generated).
+     * @param logLevel    The {@link Logger.LogLevel} for the generated message.
+     * @param message     The detailed message. Will not contain any PII info.
      * @param containsPII True if the log message contains PII, false otherwise. If enablePII is not set
      *                    on the {@link Logger},
      */

--- a/msal/src/main/java/com/microsoft/identity/client/Logger.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Logger.java
@@ -85,6 +85,7 @@ public final class Logger {
 
     /**
      * Set the log level for diagnostic purpose. By default, the sdk enables the verbose level logging.
+     *
      * @param logLevel The {@link LogLevel} to be enabled for the diagnostic logging.
      */
     public void setLogLevel(final LogLevel logLevel) {
@@ -94,8 +95,9 @@ public final class Logger {
     /**
      * Set the custom logger. Configures external logging to configure a callback that
      * the sdk will use to pass each log message. Overriding the logger callback is not allowed.
+     *
      * @param externalLogger The reference to the {@link ILoggerCallback} that can
-     * output the logs to the designated places.
+     *                       output the logs to the designated places.
      * @throws IllegalStateException if external logger is already set, and the caller is trying to set it again.
      */
     public void setExternalLogger(final ILoggerCallback externalLogger) {
@@ -112,6 +114,7 @@ public final class Logger {
 
     /**
      * Enable/Disable the Android logcat logging. By default, the sdk enables it.
+     *
      * @param enableLogcatLog True if enabling the logcat logging, false otherwise.
      */
     public void setEnableLogcatLog(final boolean enableLogcatLog) {
@@ -120,6 +123,7 @@ public final class Logger {
 
     /**
      * Enable log message with PII (personal identifiable information) info. By default, MSAL doesn't log any PII.
+     *
      * @param enablePII True if enabling PII info to be logged, false otherwise.
      */
     public void setEnablePII(final boolean enablePII) {
@@ -278,7 +282,7 @@ public final class Logger {
     }
 
     /**
-     * Enum class for LogLevel that the sdk recognizes. 
+     * Enum class for LogLevel that the sdk recognizes.
      */
     public enum LogLevel {
         /**

--- a/msal/src/main/java/com/microsoft/identity/client/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalClientException.java
@@ -26,29 +26,29 @@ package com.microsoft.identity.client;
 /**
  * This exception class represents general errors that are local to the library. Below is the table of proposed codes and a short description of each.
  * <p>
- *     Set of error codes that could be returned from this exception:
- *     <ul>
- *         <li>multiple_matching_tokens_detected: There are multiple cache entries found and the sdk cannot identify the correct access
- *         or refresh token from the cache. This usually indicates a bug in the sdk for storing tokens or the authority is
- *         not provided in the silent request and multiple matching tokens found. </li>
- *         <li>device_network_not_available: No active network is available on the device. </li>
- *         <li>json_parse_failure: The sdk failed to parse the JSON format.</li>
- *         <li>io_error: IOException happened, could be the device/network errors. </li>
- *         <li>malformed_url: The url is malformed. Likely caused when constructing the auth request, authority, or redirect URI. </li>
- *         <li>unsupported_encoding: The encoding is not supported by the device. </li>
- *         <li>no_such_algorithm: The algorithm used to generate pkce challenge is not supported. </li>
- *         <li>invalid_jwt: JWT returned by the server is not valid, empty or malformed. </li>
- *         <li>state_mismatch: State from authorization response did not match the state in the authorization request.
-*          For authorization requests, the sdk will verify the state returned from redirect and the one sent in the request. </li>
- *         <li>unresolvable_intent: The intent to launch {@link AuthenticationActivity} is not resolvable by the OS or the intent
- *         doesn't contain the required data. </li>
- *         <li>unsupported_url: Unsupported url, cannot perform ADFS authority validation. </li>
- *         <li>authority_validation_not_supported: The authority is not supported for authority validation. The sdk supports
- *         b2c authorities, but doesn't support b2c authority validation. Only well-known host will be supported. </li>
- *         <li>chrome_not_installed: Chrome is not installed on the device. The sdk uses chrome custom tab for
- *         authorization requests if available, and will fall back to chrome browser. </li>
- *         <li>user_mismatch: The user provided in the acquire token request doesn't match the user returned from server.</li>
- *     </ul>
+ * Set of error codes that could be returned from this exception:
+ * <ul>
+ * <li>multiple_matching_tokens_detected: There are multiple cache entries found and the sdk cannot identify the correct access
+ * or refresh token from the cache. This usually indicates a bug in the sdk for storing tokens or the authority is
+ * not provided in the silent request and multiple matching tokens found. </li>
+ * <li>device_network_not_available: No active network is available on the device. </li>
+ * <li>json_parse_failure: The sdk failed to parse the JSON format.</li>
+ * <li>io_error: IOException happened, could be the device/network errors. </li>
+ * <li>malformed_url: The url is malformed. Likely caused when constructing the auth request, authority, or redirect URI. </li>
+ * <li>unsupported_encoding: The encoding is not supported by the device. </li>
+ * <li>no_such_algorithm: The algorithm used to generate pkce challenge is not supported. </li>
+ * <li>invalid_jwt: JWT returned by the server is not valid, empty or malformed. </li>
+ * <li>state_mismatch: State from authorization response did not match the state in the authorization request.
+ * For authorization requests, the sdk will verify the state returned from redirect and the one sent in the request. </li>
+ * <li>unresolvable_intent: The intent to launch {@link AuthenticationActivity} is not resolvable by the OS or the intent
+ * doesn't contain the required data. </li>
+ * <li>unsupported_url: Unsupported url, cannot perform ADFS authority validation. </li>
+ * <li>authority_validation_not_supported: The authority is not supported for authority validation. The sdk supports
+ * b2c authorities, but doesn't support b2c authority validation. Only well-known host will be supported. </li>
+ * <li>chrome_not_installed: Chrome is not installed on the device. The sdk uses chrome custom tab for
+ * authorization requests if available, and will fall back to chrome browser. </li>
+ * <li>user_mismatch: The user provided in the acquire token request doesn't match the user returned from server.</li>
+ * </ul>
  * </p>
  */
 public final class MsalClientException extends MsalException {
@@ -95,7 +95,7 @@ public final class MsalClientException extends MsalException {
     public final static String INVALID_JWT = "invalid_jwt";
 
     /**
-     * State from authorization response did not match the state in the authorization request.  
+     * State from authorization response did not match the state in the authorization request.
      * For authorization requests, the sdk will verify the state returned from redirect and the one sent in the request.
      */
     public final static String STATE_MISMATCH = "state_mismatch";
@@ -118,7 +118,7 @@ public final class MsalClientException extends MsalException {
 
     /**
      * chrome_not_installed: Chrome is not installed on the device. The sdk uses chrome custom tab for
-     * authorization requests if available, and will fall back to chrome browser. 
+     * authorization requests if available, and will fall back to chrome browser.
      */
     public final static String CHROME_NOT_INSTALLED = "chrome_not_installed";
 

--- a/msal/src/main/java/com/microsoft/identity/client/MsalException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalException.java
@@ -26,7 +26,7 @@ package com.microsoft.identity.client;
 /**
  * {@link MsalException} thrown or sent back via callback, representing the detailed exception
  * thrown by the sdk. It will contain the error code, error description (could be null) or
- *  throwable (could be null).
+ * throwable (could be null).
  */
 public class MsalException extends Exception {
     private String mErrorCode;
@@ -34,10 +34,12 @@ public class MsalException extends Exception {
     /**
      * Default constructor.
      */
-    MsalException() { }
+    MsalException() {
+    }
 
     /**
      * Initiates the detailed error code.
+     *
      * @param errorCode The error code contained in the exception.
      */
     MsalException(final String errorCode) {
@@ -46,7 +48,8 @@ public class MsalException extends Exception {
 
     /**
      * Initiates the {@link MsalException} with error code and error message.
-     * @param errorCode The error code contained in the exception.
+     *
+     * @param errorCode    The error code contained in the exception.
      * @param errorMessage The error message contained in the exception.
      */
     MsalException(final String errorCode, final String errorMessage) {
@@ -56,12 +59,13 @@ public class MsalException extends Exception {
 
     /**
      * Initiates the {@link MsalException} with error code, error message and throwable.
-     * @param errorCode The error code contained in the exception.
+     *
+     * @param errorCode    The error code contained in the exception.
      * @param errorMessage The error message contained in the exception.
-     * @param throwable The {@link Throwable} contains the cause for the exception.
+     * @param throwable    The {@link Throwable} contains the cause for the exception.
      */
     MsalException(final String errorCode, final String errorMessage,
-                         final Throwable throwable) {
+                  final Throwable throwable) {
         super(errorMessage, throwable);
         mErrorCode = errorCode;
     }

--- a/msal/src/main/java/com/microsoft/identity/client/MsalServiceException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalServiceException.java
@@ -26,29 +26,29 @@ package com.microsoft.identity.client;
 /**
  * This exception class represents errors when communicating to the service, can be from the authorize or token endpoints.
  * MSAL reads the error and error_description from the server response. Generally, these errors are resolved by fixing app
- * configurations either in code or in the app registration portal. 
+ * configurations either in code or in the app registration portal.
  * <p>
- *     Set of error codes that could be returned from this exception:
- *     <ul>
- *         <li>invalid_request: This request is missing a required parameter, includes an invalid parameter, includes a parameter more than
- *         once, or is otherwise malformed.</li>
- *         <li>unauthorized_client: The client is not authorized to request an authorization code. </li>
- *         <li>access_denied: The resource owner or authorization server denied the request.</li>
- *         <li>invalid_scope: The request scope is invalid, unknown or malformed. </li>
- *         <li>service_not_available: Represents 500/503/504 error codes. </li>
- *         <li>request_timeout: Represents {@link java.net.SocketTimeoutException}. </li>
- *         <li>invalid_instance: Authority validation failed. </li>
- *         <li>unknown_error: Request to server failed, but no error and error_description was returned from the service. </li>
- *     </ul>
+ * Set of error codes that could be returned from this exception:
+ * <ul>
+ * <li>invalid_request: This request is missing a required parameter, includes an invalid parameter, includes a parameter more than
+ * once, or is otherwise malformed.</li>
+ * <li>unauthorized_client: The client is not authorized to request an authorization code. </li>
+ * <li>access_denied: The resource owner or authorization server denied the request.</li>
+ * <li>invalid_scope: The request scope is invalid, unknown or malformed. </li>
+ * <li>service_not_available: Represents 500/503/504 error codes. </li>
+ * <li>request_timeout: Represents {@link java.net.SocketTimeoutException}. </li>
+ * <li>invalid_instance: Authority validation failed. </li>
+ * <li>unknown_error: Request to server failed, but no error and error_description was returned from the service. </li>
+ * </ul>
  * </p>
  * <p>
  * Note: {@link MsalServiceException} provides one extra API:
  * </p>
-
+ * <p>
  * <ul>
- *     <li>
- *         {@link MsalServiceException#getHttpStatusCode()} : indicates the http status code for the failed request.
- *     </li>
+ * <li>
+ * {@link MsalServiceException#getHttpStatusCode()} : indicates the http status code for the failed request.
+ * </li>
  * </ul>
  */
 public final class MsalServiceException extends MsalException {

--- a/msal/src/main/java/com/microsoft/identity/client/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalUiRequiredException.java
@@ -24,13 +24,13 @@
 package com.microsoft.identity.client;
 
 /**
- * This exception indicates that UI is required for authentication to succeed. 
+ * This exception indicates that UI is required for authentication to succeed.
  * <p>
- *     Error codes that can be returned from this exception:
- *     <ul>
- *         <li>invalid_grant: The refresh token used to redeem access token is invalid, expired or revoked. </li>
- *         <li>no_tokens_found: Access token doesn't exist and no refresh token can be found to redeem access token. </li>
- *     </ul>
+ * Error codes that can be returned from this exception:
+ * <ul>
+ * <li>invalid_grant: The refresh token used to redeem access token is invalid, expired or revoked. </li>
+ * <li>no_tokens_found: Access token doesn't exist and no refresh token can be found to redeem access token. </li>
+ * </ul>
  * </p>
  */
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -63,7 +63,7 @@ import static com.microsoft.identity.client.EventConstants.ApiId.API_ID_ACQUIRE_
  * </p>
  * <p>
  * Developer <b>MUST</b> have {@link BrowserTabActivity} declared in their manifest, which must have the correct intent-filter configured. If the wrong scheme and host is provided, the sdk will fail the {@link PublicClientApplication} creation.
- *
+ * <p>
  * Expected format will be:
  * <pre>
  * &lt;activity
@@ -80,16 +80,16 @@ import static com.microsoft.identity.client.EventConstants.ApiId.API_ID_ACQUIRE_
  * </p>
  * <p>Other Terminology:</p>
  * <p>
- *    <p><b>Scopes:</b>Permissions that the developers wants included in the access token received . Not all scopes are
- *     guaranteed to be included in the access token returned.
- *     </p>
- *     <p>
- *         <b>Login Hint:</b> Usually an email, to pass to the service at the beginning of the interactive authentication flow.
- *     </p>
- *     <p>
- *         <b>Extra Scopes to Consent:</b>  Permissions you want the user to consent to in the same authentication flow,
- *         but won't be included in the returned access token.
- *     </p>
+ * <p><b>Scopes:</b>Permissions that the developers wants included in the access token received . Not all scopes are
+ * guaranteed to be included in the access token returned.
+ * </p>
+ * <p>
+ * <b>Login Hint:</b> Usually an email, to pass to the service at the beginning of the interactive authentication flow.
+ * </p>
+ * <p>
+ * <b>Extra Scopes to Consent:</b>  Permissions you want the user to consent to in the same authentication flow,
+ * but won't be included in the returned access token.
+ * </p>
  * </p>
  */
 public final class PublicClientApplication {
@@ -104,25 +104,32 @@ public final class PublicClientApplication {
     private final Context mAppContext;
     private final TokenCache mTokenCache;
 
-    /** The authority the application will use to obtain tokens */
+    /**
+     * The authority the application will use to obtain tokens
+     */
     private String mAuthorityString;
 
-    /** The client ID of the application. This should come from the app developer portal */
+    /**
+     * The client ID of the application. This should come from the app developer portal
+     */
     private String mClientId;
 
-    /** Unique String identifier used in logging/telemetry callbacks to identify
+    /**
+     * Unique String identifier used in logging/telemetry callbacks to identify
      * component in the application using MSAL
      */
     private String mComponent;
 
-    /** The redirect URI for the application */
+    /**
+     * The redirect URI for the application
+     */
     private String mRedirectUri;
 
     /**
-    * When set to true (default), MSAL will compare the application's authority against well-known URL
-    * templates representing well-formed authorities. It is useful when the authority is obtained at
-    * run time to prevent MSAL from displaying authentication prompts from malicious pages.
-    */
+     * When set to true (default), MSAL will compare the application's authority against well-known URL
+     * templates representing well-formed authorities. It is useful when the authority is obtained at
+     * run time to prevent MSAL from displaying authentication prompts from malicious pages.
+     */
     private boolean mValidateAuthority = true;
     private String mSliceParameters = "";
 
@@ -130,13 +137,13 @@ public final class PublicClientApplication {
      * {@link PublicClientApplication#PublicClientApplication(Context)} will read the client id (which must be set) from manifest, and if authority
      * is not set, default authority(https://login.microsoftonline.com/common) will be used.
      * <p>
-     *      Client id <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
-     *      if client id is not provided), name for client id in the metadata is: "com.microsoft.identity.client.ClientId".
-     *
-     *      Redirect uri <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
-     *      if client id is not provided), name for redirect uri in metadata is: "com.microsoft.identity.client.RedirectUri".
-     *
-     *      Authority can be set in the meta data, if not provided, the sdk will use the default authority https://login.microsoftonline.com/common.
+     * Client id <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
+     * if client id is not provided), name for client id in the metadata is: "com.microsoft.identity.client.ClientId".
+     * <p>
+     * Redirect uri <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
+     * if client id is not provided), name for redirect uri in metadata is: "com.microsoft.identity.client.RedirectUri".
+     * <p>
+     * Authority can be set in the meta data, if not provided, the sdk will use the default authority https://login.microsoftonline.com/common.
      * </p>
      *
      * @param context Application's {@link Context}. The sdk requires the application context to be passed in
@@ -162,12 +169,13 @@ public final class PublicClientApplication {
     /**
      * {@link PublicClientApplication#PublicClientApplication(Context, String)} allows the client id to be passed instead of
      * providing through the AndroidManifest metadata. If this constructor is called, the default authority https://login.microsoftonline.com/common will be used.
-     * @param context Application's {@link Context}. The sdk requires the application context to be passed in
-     *                {@link PublicClientApplication}. Cannot be null.
-     *                <p>
-     *                Note: The {@link Context} should be the application context instead of the running activity's context, which could potentially make the sdk hold a
-     *                strong reference to the activity, thus preventing correct garbage collection and causing bugs.
-     *                </p>
+     *
+     * @param context  Application's {@link Context}. The sdk requires the application context to be passed in
+     *                 {@link PublicClientApplication}. Cannot be null.
+     *                 <p>
+     *                 Note: The {@link Context} should be the application context instead of the running activity's context, which could potentially make the sdk hold a
+     *                 strong reference to the activity, thus preventing correct garbage collection and causing bugs.
+     *                 </p>
      * @param clientId The application's client id.
      */
     public PublicClientApplication(@NonNull final Context context, @NonNull final String clientId) {
@@ -191,13 +199,13 @@ public final class PublicClientApplication {
      * {@link PublicClientApplication#PublicClientApplication(Context, String, String)} allows the client id and authority to be passed instead of
      * providing them through metadata.
      *
-     * @param context Application's {@link Context}. The sdk requires the application context to be passed in
-     *                {@link PublicClientApplication}. Cannot be null.
-     *                <p>
-     *                Note: The {@link Context} should be the application context instead of an running activity's context, which could potentially make the sdk hold a
-     *                strong reference to the activity, thus preventing correct garbage collection and causing bugs.
-     *                </p>
-     * @param clientId The application client id.
+     * @param context   Application's {@link Context}. The sdk requires the application context to be passed in
+     *                  {@link PublicClientApplication}. Cannot be null.
+     *                  <p>
+     *                  Note: The {@link Context} should be the application context instead of an running activity's context, which could potentially make the sdk hold a
+     *                  strong reference to the activity, thus preventing correct garbage collection and causing bugs.
+     *                  </p>
+     * @param clientId  The application client id.
      * @param authority The default authority to be used for the authority.
      */
     public PublicClientApplication(@NonNull final Context context, @NonNull final String clientId, @NonNull final String authority) {
@@ -235,6 +243,7 @@ public final class PublicClientApplication {
     /**
      * By Default, authority validation is turned on. To turn on authority validation, set
      * {@link PublicClientApplication#setValidateAuthority(boolean)} to false.
+     *
      * @param validateAuthority True if authority validation is on, false otherwise. By default, authority
      *                          validation is turned on.
      */
@@ -247,6 +256,7 @@ public final class PublicClientApplication {
      * This is intended for libraries that consume MSAL which are embedded in apps that might also be using MSAL
      * as well. This allows logging, telemetry apps, or library developers to differentiate MSAL usage
      * from the app to MSAL usage by component libraries.
+     *
      * @param component The component identifier string passed into MSAL when creating the application object
      */
     public void setComponent(final String component) {
@@ -256,14 +266,16 @@ public final class PublicClientApplication {
     /**
      * Custom query parameters which maybe sent to the STS for dogfood testing. This parameter should not be set by developers as it may
      * have adverse effect on the application.
+     *
      * @param sliceParameters The custom query parameters(for dogfood testing) sent to token and authorize endpoint.
      */
     public void setSliceParameters(final String sliceParameters) {
         mSliceParameters = sliceParameters;
     }
-  
+
     /**
-     * Returns the list of {@link User}s we have tokens in the cache. 
+     * Returns the list of {@link User}s we have tokens in the cache.
+     *
      * @return Immutable List of {@link User}.
      * @throws MsalClientException If failed to retrieve users from the cache.
      */
@@ -283,6 +295,7 @@ public final class PublicClientApplication {
 
     /**
      * Returns the {@link User} that is matching the provided user identifier.
+     *
      * @param userIdentifier The unique identifier for a {@link User} across tenant.
      * @return The {@link User} matching the provided user identifier.
      * @throws MsalClientException If failed to retrieve users from the cache.
@@ -305,23 +318,26 @@ public final class PublicClientApplication {
     /**
      * MSAL requires the calling app to pass an {@link Activity} which <b> MUST </b> call this method to get the auth
      * code passed back correctly.
+     *
      * @param requestCode The request code for interactive request.
-     * @param resultCode The result code for the request to get auth code.
-     * @param data {@link Intent} either contains the url with auth code as query string or the errors.
+     * @param resultCode  The result code for the request to get auth code.
+     * @param data        {@link Intent} either contains the url with auth code as query string or the errors.
      */
     public void handleInteractiveRequestRedirect(int requestCode, int resultCode, final Intent data) {
         InteractiveRequest.onActivityResult(requestCode, resultCode, data);
     }
 
     // Interactive APIs. Will launch the system browser with web UI.
+
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
      * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link AuthenticationActivity}.
      *                 All apps doing an interactive request are required to call the
      *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
      *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
+     * @param scopes   The non-null array of scopes to be requested for the access token.
      *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param callback The {@link AuthenticationCallback} to receive the result back.
      *                 1) If user cancels the flow by pressing the device back button, the result will be sent
@@ -342,21 +358,22 @@ public final class PublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param activity Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All the apps doing interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     *
+     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                  All the apps doing interactive request are required to call the
+     *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                  activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
      *                  which will have the UPN pre-populated.
-     * @param callback The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                  back via {@link AuthenticationCallback#onCancel()}.
+     *                  2) If the sdk successfully receives the token back, result will be sent back via
+     *                  {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                  3) All the other errors will be sent back via
+     *                  {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final String loginHint,
                              @NonNull final AuthenticationCallback callback) {
@@ -370,23 +387,24 @@ public final class PublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param activity Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All the apps doing interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param uiBehavior The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
      * @param extraQueryParameters Optional. The extra query parameters sent to authorize endpoint.
-     * @param callback The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final String loginHint, final UiBehavior uiBehavior,
                              final String extraQueryParameters, @NonNull final AuthenticationCallback callback) {
@@ -400,23 +418,24 @@ public final class PublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param activity Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All the apps doing interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param user Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
-     *             error will be returned.
-     * @param uiBehavior The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity            Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                            All the apps doing interactive request are required to call the
+     *                            {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                            activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes              The non-null array of scopes to be requested for the access token.
+     *                            MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param user                Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
+     *                            error will be returned.
+     * @param uiBehavior          The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
      * @param extraQueryParameter Optional. The extra query parameter sent to authorize endpoint.
-     * @param callback The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @param callback            The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                            1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                            back via {@link AuthenticationCallback#onCancel()}.
+     *                            2) If the sdk successfully receives the token back, result will be sent back via
+     *                            {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                            3) All the other errors will be sent back via
+     *                            {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final User user, final UiBehavior uiBehavior,
                              final String extraQueryParameter, @NonNull final AuthenticationCallback callback) {
@@ -430,25 +449,26 @@ public final class PublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param activity Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All the apps doing interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param uiBehavior The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParams Optional. The extra query parameter sent to authorize endpoint.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParams     Optional. The extra query parameter sent to authorize endpoint.
      * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority Optional. Can be passed to override the configured authority.
-     * @param callback The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final String loginHint, final UiBehavior uiBehavior,
                              final String extraQueryParams, final String[] extraScopesToConsent, final String authority,
@@ -463,25 +483,26 @@ public final class PublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param activity Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All the apps doing interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param user Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
-     *             will be returned.
-     * @param uiBehavior The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParams Optional. The extra query parameter sent to authorize endpoint.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param user                 Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
+     *                             will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParams     Optional. The extra query parameter sent to authorize endpoint.
      * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority Optional. Can be passed to override the configured authority.
-     * @param callback The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final User user, final UiBehavior uiBehavior,
                              final String extraQueryParams, final String[] extraScopesToConsent, final String authority,
@@ -494,17 +515,19 @@ public final class PublicClientApplication {
     }
 
     // Silent call APIs.
+
     /**
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
+     *
+     * @param scopes   The non-null array of scopes to be requested for the access token.
      *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param user {@link User} represents the user to silently request tokens.
+     * @param user     {@link User} represents the user to silently request tokens.
      * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                                               sent back via {@link AuthenticationCallback#onSuccess(AuthenticationResult)}.
-     *                                               Failure case will be sent back via {
-     *                                               @link AuthenticationCallback#onError(MsalException)}.
+     *                 sent back via {@link AuthenticationCallback#onSuccess(AuthenticationResult)}.
+     *                 Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireTokenSilentAsync(@NonNull final String[] scopes, @NonNull final User user,
                                         @NonNull final AuthenticationCallback callback) {
@@ -518,15 +541,16 @@ public final class PublicClientApplication {
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
-     * @param scopes The non-null array of scopes to be requested for the access token. 
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param user {@link User} represents the user to silently request tokens.
-     * @param authority Optional. Can be passed to override the configured authority.
+     *
+     * @param scopes       The non-null array of scopes to be requested for the access token.
+     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param user         {@link User} represents the user to silently request tokens.
+     * @param authority    Optional. Can be passed to override the configured authority.
      * @param forceRefresh True if the request is forced to refresh, false otherwise.
-     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                                               sent back via {@link AuthenticationCallback#onSuccess(AuthenticationResult)}.
-     *                                               Failure case will be sent back via {
-     *                                               @link AuthenticationCallback#onError(MsalException)}.
+     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                     sent back via {@link AuthenticationCallback#onSuccess(AuthenticationResult)}.
+     *                     Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireTokenSilentAsync(@NonNull final String[] scopes, @NonNull final User user, final String authority,
                                         final boolean forceRefresh,
@@ -540,6 +564,7 @@ public final class PublicClientApplication {
 
     /**
      * Deletes all matching tokens (access & refresh tokens) for the {@link User} instance from the application cache.
+     *
      * @param user {@link User} whose tokens should be deleted.
      */
     public void remove(final User user) {
@@ -559,6 +584,7 @@ public final class PublicClientApplication {
 
     /**
      * Keep this method internal only to make it easy for MS apps to do serialize/deserialize on the family tokens.
+     *
      * @return The {@link TokenCache} that is used to persist token items for the running app.
      */
     TokenCache getTokenCache() {

--- a/msal/src/main/java/com/microsoft/identity/client/UiBehavior.java
+++ b/msal/src/main/java/com/microsoft/identity/client/UiBehavior.java
@@ -35,12 +35,12 @@ public enum UiBehavior {
     SELECT_ACCOUNT,
 
     /**
-     * AcquireToken will send prompt=login to the authorize endpoint.  The user will always be prompted for credentials by the service. 
+     * AcquireToken will send prompt=login to the authorize endpoint.  The user will always be prompted for credentials by the service.
      */
     FORCE_LOGIN,
 
     /**
-     * AcquireToken will send prompt=consent to the authorize endpoint.  The user will be prompted to consent even if consent was granted before. 
+     * AcquireToken will send prompt=consent to the authorize endpoint.  The user will be prompted to consent even if consent was granted before.
      */
     CONSENT
 }

--- a/msal/src/main/java/com/microsoft/identity/client/package-info.java
+++ b/msal/src/main/java/com/microsoft/identity/client/package-info.java
@@ -24,8 +24,7 @@
 /**
  * Provides the classes necessary to create a client for Azure Active Directory to get tokens.
  *
- *
- * @since 1.0
  * @see java.awt
+ * @since 1.0
  */
 package com.microsoft.identity.client;

--- a/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
@@ -52,8 +52,9 @@ abstract class BaseRequest {
 
     /**
      * Abstract method, implemented by subclass for its own logic before the token request.
+     *
      * @throws MsalUserCancelException If pre token request fails as user cancels the flow.
-     * @throws MsalException If error happens during the pre-process.
+     * @throws MsalException           If error happens during the pre-process.
      */
     void preTokenRequest() throws MsalUiRequiredException, MsalUserCancelException,
             MsalServiceException, MsalClientException {
@@ -65,13 +66,15 @@ abstract class BaseRequest {
 
     /**
      * Abstract method to set the additional body parameters for specific request.
+     *
      * @param oauth2Client
      */
     abstract void setAdditionalOauthParameters(final Oauth2Client oauth2Client);
 
     /**
      * Constructor for abstract {@link BaseRequest}.
-     * @param appContext The app running context.
+     *
+     * @param appContext                      The app running context.
      * @param authenticationRequestParameters The {@link AuthenticationRequestParameters} used to create request.
      */
     BaseRequest(final Context appContext, final AuthenticationRequestParameters authenticationRequestParameters) {
@@ -95,6 +98,7 @@ abstract class BaseRequest {
      * If there is a RT returned, we should use it to token acquisition.
      * 2. performTokenRequest. Use either auth code or RT found in the preTokenRequest to get a new token.
      * 3. Post token request, store the returned token into cache.
+     *
      * @param callback The {@link AuthenticationCallback} to deliver the result back.
      */
     void getToken(final AuthenticationCallback callback) {
@@ -125,6 +129,7 @@ abstract class BaseRequest {
     /**
      * Get the decorated scopes. Will combine the input scope and the reserved scope. If client id is provided as scope,
      * it will be removed from the combined scopes.
+     *
      * @param inputScopes The input scopes to decorate.
      * @return The combined scopes.
      */
@@ -140,6 +145,7 @@ abstract class BaseRequest {
     /**
      * Validate the input scopes. The input scope cannot have reserved scopes, if client id is provided as the scope it
      * should be a single scope.
+     *
      * @param inputScopes The input set of scope to validate.
      */
     void validateInputScopes(final Set<String> inputScopes) {
@@ -160,6 +166,7 @@ abstract class BaseRequest {
 
     /**
      * Perform the token request sent to token endpoint.
+     *
      * @throws MsalException If there is error happened in the request.
      */
     void performTokenRequest() throws MsalClientException, MsalServiceException {
@@ -185,6 +192,7 @@ abstract class BaseRequest {
      * so, return the stored token. Otherwise read the token response, and send Interaction_required back to calling app.
      * Silent flow will also remove token if receiving invalid_grant from token endpoint.
      * Interactive request will read the response, and send error back with code as oauth_error.
+     *
      * @throws MsalException
      */
     AuthenticationResult postTokenRequest() throws MsalUiRequiredException, MsalServiceException, MsalClientException {
@@ -243,6 +251,7 @@ abstract class BaseRequest {
 
     /**
      * Build request parameters, containing header, query parameters and request body.
+     *
      * @param oauth2Client
      */
     private void buildRequestParameters(final Oauth2Client oauth2Client) {

--- a/msal/src/request/java/com/microsoft/identity/client/InteractiveRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/InteractiveRequest.java
@@ -60,7 +60,7 @@ final class InteractiveRequest extends BaseRequest {
      *
      * @param activity              {@link Activity} used to launch the {@link AuthenticationActivity}.
      * @param authRequestParameters {@link AuthenticationRequestParameters} that is holding all the parameters for oauth request.
-     * @param extraScopesToConsent       An array of extra scopes.
+     * @param extraScopesToConsent  An array of extra scopes.
      */
     InteractiveRequest(final Activity activity, final AuthenticationRequestParameters authRequestParameters,
                        final String[] extraScopesToConsent) {
@@ -140,7 +140,7 @@ final class InteractiveRequest extends BaseRequest {
     @Override
     AuthenticationResult postTokenRequest() throws MsalUiRequiredException, MsalServiceException, MsalClientException {
         if (!isAccessTokenReturned()) {
-           throwExceptionFromTokenResponse(mTokenResponse);
+            throwExceptionFromTokenResponse(mTokenResponse);
         }
 
         return super.postTokenRequest();

--- a/msal/src/request/java/com/microsoft/identity/client/SilentRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/SilentRequest.java
@@ -55,7 +55,7 @@ final class SilentRequest extends BaseRequest {
         // lookup AT first.
         if (!mForceRefresh) {
             final AccessTokenCacheItem accessTokenCacheItem = mIsAuthorityProvided ? tokenCache.findAccessToken(mAuthRequestParameters, mUser)
-                    :tokenCacheItemAuthorityNotProvided;
+                    : tokenCacheItemAuthorityNotProvided;
 
             if (accessTokenCacheItem != null) {
                 Logger.info(TAG, mAuthRequestParameters.getRequestContext(), "Access token is found, returning cached AT.");

--- a/msal/src/test/java/com/microsoft/identity/client/HttpResponseTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/HttpResponseTest.java
@@ -26,6 +26,7 @@ package com.microsoft.identity.client;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
 import java.net.HttpURLConnection;
 import java.util.Collections;
 import java.util.List;

--- a/msal/src/test/java/com/microsoft/identity/client/MockUtil.java
+++ b/msal/src/test/java/com/microsoft/identity/client/MockUtil.java
@@ -34,10 +34,11 @@ import java.net.SocketTimeoutException;
  */
 public final class MockUtil {
     // private constructor for Util class.
-    private MockUtil() { }
+    private MockUtil() {
+    }
 
     static HttpURLConnection getMockedConnectionWithSuccessResponse(final String message) throws IOException {
-        final HttpURLConnection mockedHttpUrlConnection  = getCommonHttpUrlConnection();
+        final HttpURLConnection mockedHttpUrlConnection = getCommonHttpUrlConnection();
 
         Mockito.when(mockedHttpUrlConnection.getInputStream()).thenReturn(Util.createInputStream(message));
         Mockito.when(mockedHttpUrlConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);

--- a/msal/src/test/java/com/microsoft/identity/client/Util.java
+++ b/msal/src/test/java/com/microsoft/identity/client/Util.java
@@ -36,7 +36,8 @@ public final class Util {
     /**
      * Private constructor to prevent Util class from being initiated.
      */
-    private Util() { }
+    private Util() {
+    }
 
     static final String VALID_AUTHORITY = "https://login.microsoftonline.com/common";
 


### PR DESCRIPTION
This PR applies the Android Studio formatter to the `msal` gradle module.

Some of these changes I think we'll all find pretty agreeable, others less so (for instance, it doesn't seem to format html very nicely).

For those html changes, see:
- `PublicClientApplication`
- `MsalUiRequiredException`
- `MsalServiceException`
- `MsalClientException`