### PR TITLE
Coverage file is now found via wildcard

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -68,8 +68,9 @@ task jacocoTestReport(type: JacocoReport, dependsOn: 'testDebugUnitTest') {
 
     sourceDirectories = files([mainSrc])
     classDirectories = files([debugTree])
-    executionData = files(["${buildDir}/jacoco/testDebugUnitTest.exec",
-                           "${buildDir}/outputs/code-coverage/connected/coverage.ec"
+    executionData = fileTree(dir: "$buildDir", includes: [
+            "jacoco/testDebugUnitTest.exec",
+            "outputs/code-coverage/connected/*coverage.ec"
     ])
 }
 


### PR DESCRIPTION
Gradle `2.2+` generates the `.ec` coverage file per scheme `<device> - <major_ver>-coverage.ec`

This PR updates `task jacocoTestReport` to accept a wildcard `*coverage.ec` file.