### PR TITLE
Force Travis-CI to use Ubuntu Precise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # ./travis.yml for MSAL android
 
 language: android
+dist: precise
 
 jdk:
   - oraclejdk8


### PR DESCRIPTION
This PR is a workaround for #209 (as suggested by #214).

These changes should be reverted/unwound once #209 is resolved.