### PR TITLE
Closes #216 (Makes get/set property methods `final`)

### DIFF
--- a/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
@@ -57,13 +57,13 @@ class Event extends ArrayList<Pair<String, String>> {
         }
     }
 
-    void setProperty(final String propertyName, final String propertyValue) {
+    final void setProperty(final String propertyName, final String propertyValue) {
         if (!MsalUtils.isEmpty(propertyName) && !MsalUtils.isEmpty(propertyValue)) {
             add(new Pair<>(propertyName, propertyValue));
         }
     }
 
-    String getProperty(final String propertyName) {
+    final String getProperty(final String propertyName) {
         String propertyValue = null;
         for (final Pair<String, String> property : this) {
             if (property.first.equals(propertyName)) {


### PR DESCRIPTION
See #216 - This changes resolves the security issue by making constructor-invoked methods `final`