### PR TITLE
Closes #229 - Adds GDPR compliance to Telemetry

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/ApiEventTest.java
@@ -57,7 +57,7 @@ public class ApiEventTest {
 
     // Authorities
     private static final String TEST_AUTHORITY_WITH_IDENTIFIER = AndroidTestUtil.DEFAULT_AUTHORITY_WITH_TENANT;
-    private static final String TEST_AUTHORITY_COMMON = "https://login.microsoftonline.com/common";
+    static final String TEST_AUTHORITY_COMMON = "https://login.microsoftonline.com/common";
     private static final String TEST_AUTHORITY_B2C = "https://login.microsoftonline.com/tfp/tenant/policy";
 
     static ApiEvent.Builder getRandomTestApiEventBuilder() {
@@ -104,6 +104,7 @@ public class ApiEventTest {
 
     @Test
     public void testApiEventInitializes() throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        Telemetry.setAllowPii(true);
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final ApiEvent apiEvent = getTestApiEvent(telemetryRequestId, TEST_AUTHORITY);
         Assert.assertEquals(telemetryRequestId, apiEvent.getRequestId());
@@ -119,14 +120,17 @@ public class ApiEventTest {
         Assert.assertEquals(MsalUtils.createHash(TEST_LOGIN_HINT), apiEvent.getLoginHint());
         Assert.assertEquals(Boolean.valueOf(TEST_API_CALL_WAS_SUCCESSFUL), apiEvent.wasSuccessful());
         Assert.assertEquals(TEST_API_ERROR_CODE, apiEvent.getApiErrorCode());
+        Telemetry.setAllowPii(false);
     }
 
     @Test
-    public void testIdTokenParsing() {
+    public void testIdTokenParsing() throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        Telemetry.setAllowPii(true);
         final String telemetryRequestId = Telemetry.generateNewRequestId();
         final ApiEvent apiEvent = getTestApiEvent(telemetryRequestId, TEST_AUTHORITY);
         Assert.assertEquals(TEST_IDP, apiEvent.getIdpName());
         Assert.assertEquals(TEST_TENANT_ID, apiEvent.getTenantId());
-        Assert.assertEquals(TEST_USER_ID, apiEvent.getUserId());
+        Assert.assertEquals(MsalUtils.createHash(TEST_USER_ID), apiEvent.getUserId());
+        Telemetry.setAllowPii(false);
     }
 }

--- a/msal/src/androidTest/java/com/microsoft/identity/client/TelemetryPrivacyComplianceTests.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/TelemetryPrivacyComplianceTests.java
@@ -1,0 +1,118 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Pair;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.UnsupportedEncodingException;
+import java.security.NoSuchAlgorithmException;
+
+import static com.microsoft.identity.client.ApiEventTest.TEST_AUTHORITY_COMMON;
+import static com.microsoft.identity.client.ApiEventTest.getTestApiEvent;
+import static com.microsoft.identity.client.CacheEventTest.TEST_TOKEN_TYPE;
+import static com.microsoft.identity.client.CacheEventTest.getTestCacheEvent;
+import static com.microsoft.identity.client.HttpEventTest.getTestHttpEvent;
+import static com.microsoft.identity.client.UiEventTest.getTestUiEvent;
+
+@RunWith(AndroidJUnit4.class)
+public class TelemetryPrivacyComplianceTests {
+
+    @Test
+    public void testApiEventPrivacyCompliance() {
+        final ApiEvent apiEvent = getTestApiEvent(Telemetry.generateNewRequestId(), TEST_AUTHORITY_COMMON);
+        populateWithPii(apiEvent);
+        verifyDoesntContainPii(apiEvent);
+    }
+
+    @Test
+    public void testCacheEventPrivacyCompliance() {
+        final String eventName = EventConstants.EventName.TOKEN_CACHE_DELETE;
+        final CacheEvent cacheEvent = getTestCacheEvent(eventName, TEST_TOKEN_TYPE);
+        populateWithPii(cacheEvent);
+        verifyDoesntContainPii(cacheEvent);
+    }
+
+    @Test
+    public void testHttpEventPrivacyCompliance() {
+        final HttpEvent httpEvent = getTestHttpEvent();
+        populateWithPii(httpEvent);
+        verifyDoesntContainPii(httpEvent);
+    }
+
+    @Test
+    public void testOrphanedEventPrivacyCompliance() {
+        final Event orphanedEvent =
+                new OrphanedEvent.Builder(
+                        EventConstants.EventName.API_EVENT,
+                        1L
+                ).build();
+        populateWithPii(orphanedEvent);
+        verifyDoesntContainPii(orphanedEvent);
+    }
+
+    @Test
+    public void testUiEventPrivacyCompliance() {
+        final UiEvent uiEvent = getTestUiEvent();
+        populateWithPii(uiEvent);
+        verifyDoesntContainPii(uiEvent);
+    }
+
+    @Test
+    public void testApiEventWithPiiCompliance() throws UnsupportedEncodingException, NoSuchAlgorithmException {
+        Telemetry.setAllowPii(true);
+        final ApiEvent apiEvent = new ApiEvent.Builder(Telemetry.generateNewRequestId()).build();
+        populateWithPii(apiEvent);
+        for (final Pair<String, String> eventKeyPair : apiEvent) {
+            if (TelemetryUtils.GDPR_FILTERED_FIELDS.contains(eventKeyPair.first)) {
+                Assert.assertEquals("sample_value", eventKeyPair.second);
+            }
+        }
+        Telemetry.setAllowPii(false);
+    }
+
+    private void populateWithPii(final Event event) {
+        for (final String key : TelemetryUtils.GDPR_FILTERED_FIELDS) {
+            event.setProperty(key, "sample_value");
+        }
+    }
+
+    private void verifyDoesntContainPii(final Event event) {
+        for (final Pair<String, String> eventKeyPair : event) {
+            if (TelemetryUtils.GDPR_FILTERED_FIELDS.contains(eventKeyPair.first)) {
+                throw new AssertionError(
+                        "Event contains PII/OII protected pair: "
+                                + eventKeyPair.first
+                                + " : "
+                                + eventKeyPair.second
+                );
+            }
+        }
+    }
+}

--- a/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/Event.java
@@ -58,7 +58,7 @@ class Event extends ArrayList<Pair<String, String>> {
     }
 
     final void setProperty(final String propertyName, final String propertyValue) {
-        if (!MsalUtils.isEmpty(propertyName) && !MsalUtils.isEmpty(propertyValue)) {
+        if (!MsalUtils.isEmpty(propertyName) && !MsalUtils.isEmpty(propertyValue) && isPrivacyCompliant(propertyName)) {
             add(new Pair<>(propertyName, propertyValue));
         }
     }
@@ -107,6 +107,15 @@ class Event extends ArrayList<Pair<String, String>> {
      */
     Long getElapsedTime() {
         return Long.valueOf(getProperty(EventProperty.ELAPSED_TIME));
+    }
+
+    /**
+     * Tests supplied EventStrings for privacy compliance.
+     * @param fieldName The EventString to evaluate.
+     * @return True, if the field can be reported. False otherwise.
+     */
+    static boolean isPrivacyCompliant(final String fieldName) {
+        return Telemetry.getAllowPii() || !TelemetryUtils.GDPR_FILTERED_FIELDS.contains(fieldName);
     }
 
     /**

--- a/msal/src/telemetry/java/com/microsoft/identity/client/Telemetry.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/Telemetry.java
@@ -41,6 +41,8 @@ public final class Telemetry {
 
     private static boolean sDisableForTest;
 
+    private static boolean mAllowPii = false;
+
     private final Map<String, List<Event.Builder>> mEvents;
 
     private EventDispatcher mPublisher;
@@ -86,6 +88,25 @@ public final class Telemetry {
      */
     static void disableForTest(final boolean disabled) {
         sDisableForTest = disabled;
+    }
+
+    /**
+     * Sets the PII/OII allow flag. If set to true, PII/OII fields will not be explicitly blocked
+     * in Telemetry data.
+     *
+     * @param allowFlag true, if PII/OII should be allowed in Telemetry data. False otherwise.
+     */
+    public static void setAllowPii(final boolean allowFlag) {
+        mAllowPii = allowFlag;
+    }
+
+    /**
+     * Gets the state of the PII/OII allow flag.
+     *
+     * @return the flag state.
+     */
+    public static boolean getAllowPii() {
+        return mAllowPii;
     }
 
     public synchronized void registerReceiver(IMsalEventReceiver receiver) {

--- a/msal/src/telemetry/java/com/microsoft/identity/client/TelemetryUtils.java
+++ b/msal/src/telemetry/java/com/microsoft/identity/client/TelemetryUtils.java
@@ -1,0 +1,33 @@
+package com.microsoft.identity.client;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.microsoft.identity.client.EventConstants.EventProperty.LOGIN_HINT;
+import static com.microsoft.identity.client.EventConstants.EventProperty.TENANT_ID;
+import static com.microsoft.identity.client.EventConstants.EventProperty.USER_ID;
+
+class TelemetryUtils {
+
+    final static Set<String> GDPR_FILTERED_FIELDS = new HashSet<>();
+
+    static {
+        initializeGdprFilteredFields();
+    }
+
+    private TelemetryUtils() {
+        // Intentionally left blank.
+    }
+
+    private static void initializeGdprFilteredFields() {
+        GDPR_FILTERED_FIELDS.addAll(
+                Arrays.asList(
+                        LOGIN_HINT,
+                        USER_ID,
+                        TENANT_ID
+                )
+        );
+    }
+
+}


### PR DESCRIPTION
These changes close #229 - modified `setProperty(String, String)` to omit telemetry fields declared as excluded by `TelemetryUtils#GDPR_FILTERED_FIELDS`.

A switch is also added to override this exclusion: `Telemetry#setAllowPii(boolean)`