### PR TITLE
Closes #244 - Check if CustomTabService is initialized prior to calling getCustomTabsServiceIsBound()

### DIFF
--- a/msal/src/internal/java/com/microsoft/identity/client/MsalUtils.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/MsalUtils.java
@@ -221,6 +221,7 @@ final class MsalUtils {
      */
     static String getChromePackageWithCustomTabSupport(final Context context) {
         if (context.getPackageManager() == null) {
+            Logger.warning(TAG, null, "getPackageManager() returned null.");
             return null;
         }
 
@@ -230,7 +231,7 @@ final class MsalUtils {
 
         // queryIntentServices could return null or an empty list if no matching service existed.
         if (resolveInfoList == null || resolveInfoList.isEmpty()) {
-            // TODO: add logs
+            Logger.warning(TAG, null, "No Service responded to Intent: " + CUSTOM_TABS_SERVICE_ACTION);
             return null;
         }
 
@@ -241,6 +242,7 @@ final class MsalUtils {
             }
         }
 
+        Logger.warning(TAG, null, "No pkg with CustomTab support found.");
         return null;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
@@ -111,7 +111,7 @@ public final class AuthenticationActivity extends Activity {
     @Override
     protected void onStop() {
         super.onStop();
-        if (mCustomTabsServiceConnection.getCustomTabsServiceIsBound()) {
+        if (null != mCustomTabsServiceConnection && mCustomTabsServiceConnection.getCustomTabsServiceIsBound()) {
             unbindService(mCustomTabsServiceConnection);
         }
     }


### PR DESCRIPTION
Closes #244 - Adds additional logging around `CustomTab` support queries + validation that `connection != null` prior to checking connection state.