### PR TITLE
Update the version number and changelog | Pre-release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Add to your app's Build.Gradle:
         mavenCentral()
     }
     dependencies {
-        compile('com.microsoft.identity.client:msal:0.1.1') {
+        compile('com.microsoft.identity.client:msal:0.1.2') {
             // if your app includes android support
             // libraries or GSON in its dependencies
             // uncomment below

--- a/changelog
+++ b/changelog
@@ -1,3 +1,20 @@
+Version 0.1.2
+----------------------------
+1. GDPR compliance to Telemetry and Logger
+2. Fix the bug on CustomTabService checking when calling getCustomTabsServiceIsBound()
+3. Update Telemetry to track telemetry Event data in a single Map instance
+4. Specifies thrown Exception classes in AbstractMetadataRequestor
+5. Create "no-args" constructor for GSON POJOs to prevent using "sun.misc.Unsafe" 
+6. Specifies the default locale to UTF_8 to guarantee consistent behavior across all Android devices.
+7. Use versions.gradle to aggregate versions across subproject
+8. Update Gradle to 4.1
+9. Update Gson to 2.8.0
+
+Version 0.1.1
+----------------------------
+* This release contains the preview for Microsoft Authentication library (MSAL) for Android.
+Re-tag to fix the dependencies pulling issue from jcenter.
+
 Version 0.1.0
 ----------------------------
 * Initial preview release for MSAL

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -13,7 +13,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 0
-        versionName '0.1.1'
+        versionName '0.1.2'
         project.archivesBaseName = "msal"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
* Update the version number
* Update the changelog
1. GDPR compliance to Telemetry and Logger
2. Fix the bug on CustomTabService checking when calling getCustomTabsServiceIsBound()
3. Update Telemetry to track telemetry Event data in a single Map instance
4. Specifies thrown Exception classes in AbstractMetadataRequestor
5. Create "no-args" constructor for GSON POJOs to prevent using "sun.misc.Unsafe" 
6. Specifies the default locale to UTF_8 to guarantee consistent behavior across all Android devices.
7. Use versions.gradle to aggregate versions across subproject
8. Update Gradle to 4.1
9. Update Gson to 2.8.0