### PR TITLE
Fix the build of test apps by disabling the testCoverageEnabled property

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -21,10 +21,10 @@ android {
 
     buildTypes {
         debug {
-            testCoverageEnabled true
+            testCoverageEnabled false
         }
         release {
-            testCoverageEnabled true
+            testCoverageEnabled false
             minifyEnabled false
             debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'


### PR DESCRIPTION
The test app builds failed with error "cannot find the MainActivity" which is caused by the test coverage scan. 