### PR TITLE
Integrates common logger w/ correlationId & threadId tracking

### DIFF
--- a/msal/src/cache/java/com/microsoft/identity/client/TokenCache.java
+++ b/msal/src/cache/java/com/microsoft/identity/client/TokenCache.java
@@ -105,7 +105,9 @@ class TokenCache {
     AccessTokenCacheItem saveTokensToCommonCache(
             final URL authority,
             final String clientId,
-            final TokenResponse msalTokenResponse) throws MsalClientException {
+            final TokenResponse msalTokenResponse,
+            final String correlationId) throws MsalClientException {
+        PublicClientApplication.initializeDiagnosticContext(correlationId);
         // TODO where is the displayable id? Why is it missing?
         final AccessTokenCacheItem newAccessToken = new AccessTokenCacheItem(authority.toString(), clientId, msalTokenResponse);
 

--- a/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
+++ b/msal/src/request/java/com/microsoft/identity/client/BaseRequest.java
@@ -210,7 +210,8 @@ abstract class BaseRequest {
             tokenCache.saveTokensToCommonCache(
                     authority.getAuthorityUrl(),
                     mAuthRequestParameters.getClientId(),
-                    mTokenResponse
+                    mTokenResponse,
+                    mAuthRequestParameters.getRequestContext().getCorrelationId().toString()
             );
 
             // Because the token retrieval API hasn't been written yet, also sync the tokens to the legacy cache for *actual* retrieval


### PR DESCRIPTION
Adds `correlationId` & `threadId` tracking to logs

Example below from `TRACE`
```
V/CacheKeyValueDelegate:  [2018-05-08 15:47:35 - {"thread_id":"22936","correlation_id":"a31dc58b-15d7-4cfb-b0c5-1c6ce5f7d2e9"}] ^sanitizeNull(String=login.microsoftonline.com) Android 27
V/CacheKeyValueDelegate:  [2018-05-08 15:47:35 - {"thread_id":"22936","correlation_id":"a31dc58b-15d7-4cfb-b0c5-1c6ce5f7d2e9"}] $sanitizeNull(result=login.microsoftonline.com) Android 27
```