### PR TITLE
Adding config to Logger + tests

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationActivityTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AuthenticationActivityTest.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.content.Context;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/DiscoveryTests.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/DiscoveryTests.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/Oauth2ClientTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/Oauth2ClientTest.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.support.test.runner.AndroidJUnit4;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.app.Activity;

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.content.Context;
@@ -261,6 +283,72 @@ public class PublicClientConfigurationTest {
     public void testNullRedirectUrlException() {
         final PublicClientApplicationConfiguration configWithoutRedirect = loadConfig(R.raw.test_pcaconfig_missing_redirect);
         configWithoutRedirect.validateConfiguration();
+    }
+
+    /**
+     * Test that the verbose log level can be set via config.
+     */
+    @Test
+    public void testVerboseLogLevel() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_verbose);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertEquals(Logger.LogLevel.VERBOSE, config.mLoggerConfiguration.getLogLevel());
+    }
+
+    /**
+     * Test that the verbose info level can be set via config.
+     */
+    @Test
+    public void testInfoLogLevel() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_info);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertEquals(Logger.LogLevel.INFO, config.mLoggerConfiguration.getLogLevel());
+    }
+
+    /**
+     * Test that the warning log level can be set via config.
+     */
+    @Test
+    public void testWarningLogLevel() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_warning);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertEquals(Logger.LogLevel.WARNING, config.mLoggerConfiguration.getLogLevel());
+    }
+
+    /**
+     * Test that the error log level can be set via config.
+     */
+    @Test
+    public void testErrorLogLevel() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_error);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertEquals(Logger.LogLevel.ERROR, config.mLoggerConfiguration.getLogLevel());
+    }
+
+    /**
+     * Test that PII logging can be enabled via config.
+     */
+    @Test
+    public void testPiiOn() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_info);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertTrue(config.mLoggerConfiguration.isPiiEnabled());
+    }
+
+    /**
+     * Test that PII logging can be disabled via config.
+     */
+    @Test
+    public void testPiiOff() {
+        final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_error);
+        assertNotNull(config);
+        assertNotNull(config.mLoggerConfiguration);
+        assertFalse(config.mLoggerConfiguration.isPiiEnabled());
     }
 
     private PublicClientApplicationConfiguration loadConfig(final int resourceId) {

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_error.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_error.json
@@ -1,22 +1,21 @@
 {
-    "authorities": [
-      {
-        "type": "AAD",
-        "audience": {
-          "type": "AzureADMyOrg"
-        },
-        "default": true
-      }
-    ],
-    "authorization_user_agent": "DEFAULT",
-    "http": {
-      "connect_timeout": 10000,
-      "read_timeout": 30000
-    },
-    "logging": {
-      "log_level": "error",
-      "pii_enabled": "false"
-    },
-    "token_expiration_buffer": 5000
-  }
-  
+  "authorities": [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg"
+      },
+      "default": true
+    }
+  ],
+  "authorization_user_agent": "DEFAULT",
+  "http": {
+    "connect_timeout": 10000,
+    "read_timeout": 30000
+  },
+  "logging": {
+    "log_level": "error",
+    "pii_enabled": "false"
+  },
+  "token_expiration_buffer": 5000
+}

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_error.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_error.json
@@ -1,0 +1,22 @@
+{
+    "authorities": [
+      {
+        "type": "AAD",
+        "audience": {
+          "type": "AzureADMyOrg"
+        },
+        "default": true
+      }
+    ],
+    "authorization_user_agent": "DEFAULT",
+    "http": {
+      "connect_timeout": 10000,
+      "read_timeout": 30000
+    },
+    "logging": {
+      "log_level": "error",
+      "pii_enabled": "false"
+    },
+    "token_expiration_buffer": 5000
+  }
+  

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_info.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_info.json
@@ -1,0 +1,22 @@
+{
+    "authorities": [
+      {
+        "type": "AAD",
+        "audience": {
+          "type": "AzureADMyOrg"
+        },
+        "default": true
+      }
+    ],
+    "authorization_user_agent": "DEFAULT",
+    "http": {
+      "connect_timeout": 10000,
+      "read_timeout": 30000
+    },
+    "logging": {
+      "log_level": "info",
+      "pii_enabled": "true"
+    },
+    "token_expiration_buffer": 5000
+  }
+  

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_info.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_info.json
@@ -1,22 +1,21 @@
 {
-    "authorities": [
-      {
-        "type": "AAD",
-        "audience": {
-          "type": "AzureADMyOrg"
-        },
-        "default": true
-      }
-    ],
-    "authorization_user_agent": "DEFAULT",
-    "http": {
-      "connect_timeout": 10000,
-      "read_timeout": 30000
-    },
-    "logging": {
-      "log_level": "info",
-      "pii_enabled": "true"
-    },
-    "token_expiration_buffer": 5000
-  }
-  
+  "authorities": [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg"
+      },
+      "default": true
+    }
+  ],
+  "authorization_user_agent": "DEFAULT",
+  "http": {
+    "connect_timeout": 10000,
+    "read_timeout": 30000
+  },
+  "logging": {
+    "log_level": "info",
+    "pii_enabled": "true"
+  },
+  "token_expiration_buffer": 5000
+}

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_verbose.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_verbose.json
@@ -1,22 +1,21 @@
 {
-    "authorities": [
-      {
-        "type": "AAD",
-        "audience": {
-          "type": "AzureADMyOrg"
-        },
-        "default": true
-      }
-    ],
-    "authorization_user_agent": "DEFAULT",
-    "http": {
-      "connect_timeout": 10000,
-      "read_timeout": 30000
-    },
-    "logging": {
-      "log_level": "verbose",
-      "pii_enabled": "false"
-    },
-    "token_expiration_buffer": 5000
-  }
-  
+  "authorities": [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg"
+      },
+      "default": true
+    }
+  ],
+  "authorization_user_agent": "DEFAULT",
+  "http": {
+    "connect_timeout": 10000,
+    "read_timeout": 30000
+  },
+  "logging": {
+    "log_level": "verbose",
+    "pii_enabled": "false"
+  },
+  "token_expiration_buffer": 5000
+}

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_verbose.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_verbose.json
@@ -1,0 +1,22 @@
+{
+    "authorities": [
+      {
+        "type": "AAD",
+        "audience": {
+          "type": "AzureADMyOrg"
+        },
+        "default": true
+      }
+    ],
+    "authorization_user_agent": "DEFAULT",
+    "http": {
+      "connect_timeout": 10000,
+      "read_timeout": 30000
+    },
+    "logging": {
+      "log_level": "verbose",
+      "pii_enabled": "false"
+    },
+    "token_expiration_buffer": 5000
+  }
+  

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_warning.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_warning.json
@@ -1,0 +1,22 @@
+{
+    "authorities": [
+      {
+        "type": "AAD",
+        "audience": {
+          "type": "AzureADMyOrg"
+        },
+        "default": true
+      }
+    ],
+    "authorization_user_agent": "DEFAULT",
+    "http": {
+      "connect_timeout": 10000,
+      "read_timeout": 30000
+    },
+    "logging": {
+      "log_level": "warning",
+      "pii_enabled": "false"
+    },
+    "token_expiration_buffer": 5000
+  }
+  

--- a/msal/src/androidTest/res/raw/test_pcaconfig_log_warning.json
+++ b/msal/src/androidTest/res/raw/test_pcaconfig_log_warning.json
@@ -1,22 +1,21 @@
 {
-    "authorities": [
-      {
-        "type": "AAD",
-        "audience": {
-          "type": "AzureADMyOrg"
-        },
-        "default": true
-      }
-    ],
-    "authorization_user_agent": "DEFAULT",
-    "http": {
-      "connect_timeout": 10000,
-      "read_timeout": 30000
-    },
-    "logging": {
-      "log_level": "warning",
-      "pii_enabled": "false"
-    },
-    "token_expiration_buffer": 5000
-  }
-  
+  "authorities": [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg"
+      },
+      "default": true
+    }
+  ],
+  "authorization_user_agent": "DEFAULT",
+  "http": {
+    "connect_timeout": 10000,
+    "read_timeout": 30000
+  },
+  "logging": {
+    "log_level": "warning",
+    "pii_enabled": "false"
+  },
+  "token_expiration_buffer": 5000
+}

--- a/msal/src/internal/java/com/microsoft/identity/client/internal/configuration/AzureActiveDirectoryAudienceDeserializer.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/internal/configuration/AzureActiveDirectoryAudienceDeserializer.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client.internal.configuration;
 
 import com.google.gson.JsonDeserializationContext;

--- a/msal/src/internal/java/com/microsoft/identity/client/internal/configuration/LogLevelDeserializer.java
+++ b/msal/src/internal/java/com/microsoft/identity/client/internal/configuration/LogLevelDeserializer.java
@@ -20,44 +20,25 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client;
+package com.microsoft.identity.client.internal.configuration;
 
-import com.google.gson.annotations.SerializedName;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.microsoft.identity.client.Logger;
 
-import static com.microsoft.identity.client.LoggerConfiguration.SerializedNames.LOG_LEVEL;
-import static com.microsoft.identity.client.LoggerConfiguration.SerializedNames.PII_ENABLED;
+import java.lang.reflect.Type;
+import java.util.Locale;
 
-public class LoggerConfiguration {
+import static com.microsoft.identity.client.Logger.LogLevel;
 
-    /**
-     * Field names used for serialization by Gson.
-     */
-    public static final class SerializedNames {
-        public static final String PII_ENABLED = "pii_enabled";
-        public static final String LOG_LEVEL = "log_level";
-    }
+public class LogLevelDeserializer implements JsonDeserializer<Logger.LogLevel> {
 
-    @SerializedName(PII_ENABLED)
-    private boolean mPiiEnabled;
-
-    @SerializedName(LOG_LEVEL)
-    private Logger.LogLevel mLogLevel;
-
-    /**
-     * Gets the Pii Enabled state.
-     *
-     * @return True if Pii logging is allowed. False otherwise.
-     */
-    public boolean isPiiEnabled() {
-        return mPiiEnabled;
-    }
-
-    /**
-     * Gets the {@link Logger.LogLevel} to use.
-     *
-     * @return The LogLevel.
-     */
-    public Logger.LogLevel getLogLevel() {
-        return mLogLevel;
+    @Override
+    public Logger.LogLevel deserialize(final JsonElement json,
+                                       final Type typeOfT,
+                                       final JsonDeserializationContext context) throws JsonParseException {
+        return LogLevel.valueOf(json.getAsString().toUpperCase(Locale.US));
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/Logger.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Logger.java
@@ -20,7 +20,6 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-
 package com.microsoft.identity.client;
 
 import java.util.concurrent.atomic.AtomicReference;

--- a/msal/src/main/java/com/microsoft/identity/client/LoggerConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/LoggerConfiguration.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 public class LoggerConfiguration {

--- a/msal/src/main/java/com/microsoft/identity/client/LoggerConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/LoggerConfiguration.java
@@ -1,0 +1,4 @@
+package com.microsoft.identity.client;
+
+public class LoggerConfiguration {
+}

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.client.authorities.Authority;
 import com.microsoft.identity.client.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.client.internal.configuration.AuthorityDeserializer;
 import com.microsoft.identity.client.internal.configuration.AzureActiveDirectoryAudienceDeserializer;
+import com.microsoft.identity.client.internal.configuration.LogLevelDeserializer;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.internal.dto.Account;
 import com.microsoft.identity.common.internal.logging.DiagnosticContext;
@@ -884,6 +885,7 @@ public final class PublicClientApplication {
         Gson gson = new GsonBuilder()
                 .registerTypeAdapter(Authority.class, new AuthorityDeserializer())
                 .registerTypeAdapter(AzureActiveDirectoryAudience.class, new AzureActiveDirectoryAudienceDeserializer())
+                .registerTypeAdapter(Logger.LogLevel.class, new LogLevelDeserializer())
                 .create();
 
         return gson;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -33,69 +33,92 @@ import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 
 import java.util.List;
 
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORITIES;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_USER_AGENT;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CLIENT_ID;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.HTTP;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.LOGGING;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REDIRECT_URI;
+
 public class PublicClientApplicationConfiguration {
 
-    static final String CLIENT_ID_KEY = "client_id";
-    static final String REDIRECT_URI_KEY = "redirect_uri";
-    static final String AUTHORITIES_KEY = "authorities";
-    static final String AUTHORIZATION_USER_AGENT_KEY = "authorization_user_agent";
-    static final String HTTP_KEY = "http";
+    public static final class SerializedNames {
+        static final String CLIENT_ID = "client_id";
+        static final String REDIRECT_URI = "redirect_uri";
+        static final String AUTHORITIES = "authorities";
+        static final String AUTHORIZATION_USER_AGENT = "authorization_user_agent";
+        static final String HTTP = "http";
+        static final String LOGGING = "logging";
+    }
 
-    @SerializedName(PublicClientApplicationConfiguration.CLIENT_ID_KEY)
+    @SerializedName(CLIENT_ID)
     String mClientId;
 
-    @SerializedName(PublicClientApplicationConfiguration.REDIRECT_URI_KEY)
+    @SerializedName(REDIRECT_URI)
     String mRedirectUri;
 
-    @SerializedName(PublicClientApplicationConfiguration.AUTHORITIES_KEY)
+    @SerializedName(AUTHORITIES)
     List<Authority> mAuthorities;
 
-    @SerializedName(PublicClientApplicationConfiguration.AUTHORIZATION_USER_AGENT_KEY)
+    @SerializedName(AUTHORIZATION_USER_AGENT)
     AuthorizationAgent mAuthorizationAgent;
 
-    @SerializedName(PublicClientApplicationConfiguration.HTTP_KEY)
+    @SerializedName(HTTP)
     HttpConfiguration mHttpConfiguration;
 
+    @SerializedName(LOGGING)
+    LoggerConfiguration mLoggerConfiguration;
+
     /**
-     * Gets the currently configured client id for the public client application
+     * Gets the currently configured client id for the PublicClientApplication.
      *
-     * @return
+     * @return The configured clientId.
      */
     public String getClientId() {
         return mClientId;
     }
 
     /**
-     * Gets the list of authorities configured by the developer for use with the public client application
+     * Gets the list of authorities configured by the developer for use with the
+     * PublicClientApplication.
      *
-     * @return
+     * @return The List of current Authorities.
      */
     public List<Authority> getAuthorities() {
         return mAuthorities;
     }
 
     /**
-     * Gets the currently configured HTTP_KEY configuration for the public client application
+     * Gets the currently configured {@link HttpConfiguration} for the PublicClientApplication.
      *
-     * @return
+     * @return The HttpConfiguration to use.
      */
     public HttpConfiguration getHttpConfiguration() {
         return this.mHttpConfiguration;
     }
 
     /**
-     * Gets the currently configured redirect uri for the public client application
+     * Gets the currently configured {@link LoggerConfiguration} for the PublicClientApplication.
      *
-     * @return
+     * @return The LoggerConfiguration to use.
+     */
+    public LoggerConfiguration getLoggerConfiguration() {
+        return mLoggerConfiguration;
+    }
+
+    /**
+     * Gets the currently configured redirect uri for the PublicClientApplication.
+     *
+     * @return The redirectUri to use.
      */
     public String getRedirectUri() {
         return this.mRedirectUri;
     }
 
     /**
-     * Gets the currently configured authorization agent for the public client application
+     * Gets the currently configured {@link AuthorizationAgent} for the PublicClientApplication.
      *
-     * @return
+     * @return The AuthorizationAgent to use.
      */
     public AuthorizationAgent getAuthorizationAgent() {
         return this.mAuthorizationAgent;
@@ -110,8 +133,8 @@ public class PublicClientApplicationConfiguration {
     }
 
     void validateConfiguration() {
-        nullConfigurationCheck(PublicClientApplicationConfiguration.REDIRECT_URI_KEY, mRedirectUri);
-        nullConfigurationCheck(PublicClientApplicationConfiguration.CLIENT_ID_KEY, mClientId);
+        nullConfigurationCheck(REDIRECT_URI, mRedirectUri);
+        nullConfigurationCheck(CLIENT_ID, mClientId);
 
         for (final Authority authority : mAuthorities) {
             if (authority instanceof UnknownAuthority) {


### PR DESCRIPTION
Tests that various `Logger` configurations can be specified by the `PublicClientApplicationConfiguration`

- Verbose logging
- Info logging
- Error logging
- Warning logging
- Pii on/off