### PR TITLE
Removing setter call (moved to AAD child-class)

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/CoreAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/CoreAdapter.java
@@ -15,7 +15,6 @@ public class CoreAdapter {
         responseOut.setRefreshToken(responseIn.getRefreshToken());
         responseOut.setScope(responseIn.getScope());
         responseOut.setIdToken(responseIn.getRawIdToken());
-        responseOut.setExpiresOn(responseIn.getExpiresOn());
         responseOut.setExpiresIn(responseIn.getExpiresIn());
         responseOut.setExtExpiresOn(responseIn.getExtendedExpiresOn());
         responseOut.setExtExpiresIn(responseIn.getExtExpiresIn());


### PR DESCRIPTION
Corollary PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/215