### PR TITLE
Make CI use same PAT as local

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Load credentials for VSTS Maven
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsADALAndroidInternalGradleAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
@@ -24,8 +24,8 @@ allprojects {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username project.findProperty("vstsUsername")
-                password project.findProperty("vstsADALAndroidInternalGradleAccessToken")
+                username project.vstsUsername
+                password project.vstsPassword
             }
         }
     }


### PR DESCRIPTION
Missed this in my review of #347 -- CI/local builds should resolve using the same PAT: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/347/files#r215788352