### PR TITLE
getAccount(), getAccounts(), and removeUser() updated to remove environment restrictions, support authority aliases

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
@@ -25,7 +25,6 @@ package com.microsoft.identity.client;
 
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.dto.AccessToken;
-import com.microsoft.identity.common.internal.dto.IdToken;
 
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -41,18 +40,11 @@ public final class AuthenticationResult {
     private final String mRawIdToken;
     private final String mUniqueId;
 
-    //Fields for new Cache Record
-    private final ICacheRecord mCacheRecord;
     private final AccessToken mAccessToken;
-    private final IdToken mIdToken;
     private final IAccount mAccount;
 
-
     public AuthenticationResult(final ICacheRecord cacheRecord) {
-
-        mCacheRecord = cacheRecord;
-        mAccessToken = mCacheRecord.getAccessToken();
-        mIdToken = cacheRecord.getIdToken();
+        mAccessToken = cacheRecord.getAccessToken();
         mTenantId = cacheRecord.getAccount().getRealm();
         mUniqueId = cacheRecord.getAccount().getHomeAccountId();
         mRawIdToken = cacheRecord.getIdToken().getSecret();

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -153,6 +153,7 @@ public final class PublicClientApplication {
      * Unique String identifier used in logging/telemetry callbacks to identify.
      * component in the application using MSAL
      */
+    @SuppressWarnings("PMD.UnusedPrivateField") // TODO wire-up
     private String mComponent;
 
     /**
@@ -160,16 +161,7 @@ public final class PublicClientApplication {
      */
     private String mRedirectUri;
 
-    /**
-     * When set to true (default), MSAL will compare the application's authority against well-known URL
-     * templates representing well-formed authorities. It is useful when the authority is obtained at
-     * run time to prevent MSAL from displaying authentication prompts from malicious pages.
-     */
-    private boolean mValidateAuthority = true;
-
     private PublicClientApplicationConfiguration mPublicClientConfiguration;
-
-    private Boolean mInitialized = false;
 
     /**
      * @param context Application's {@link Context}. The sdk requires the application context to be passed in
@@ -312,8 +304,6 @@ public final class PublicClientApplication {
         // manifest, we cannot make the network call.
         checkInternetPermission();
         Logger.info(TAG, null, "Create new public client application.");
-
-        mInitialized = true;
     }
 
     /**
@@ -321,22 +311,6 @@ public final class PublicClientApplication {
      */
     public static String getSdkVersion() {
         return BuildConfig.VERSION_NAME;
-    }
-
-    /**
-     * @param validateAuthority True if authority validation is on, false otherwise. By default, authority
-     *                          validation is turned on.
-     * @deprecated The use of this property setter is no longer required.  Authorities will be considered valid
-     * if they are asserted by the developer via configuration or if Microsoft recognizes the cloud within which the authority exists.
-     * <p>
-     * This setter no longer controls MSAL behavior.
-     * <p>
-     * By Default, authority validation is turned on. To turn on authority validation, set
-     * {@link PublicClientApplication#setValidateAuthority(boolean)} to false.
-     */
-    @Deprecated
-    public void setValidateAuthority(final boolean validateAuthority) {
-        mValidateAuthority = validateAuthority;
     }
 
     /**
@@ -908,6 +882,7 @@ public final class PublicClientApplication {
         return params;
     }
 
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // TODO wire-up
     private ApiEvent.Builder createApiEventBuilder(final String telemetryRequestId, final String apiId) {
         // Create the ApiEvent.Builder
         ApiEvent.Builder eventBuilder =
@@ -930,6 +905,7 @@ public final class PublicClientApplication {
      * @param authenticationCallback the original consuming callback
      * @return the wrapped {@link AuthenticationCallback} instance
      */
+    @SuppressWarnings("PMD.UnusedPrivateMethod") // TODO wire-up
     private AuthenticationCallback wrapCallbackForTelemetryIntercept(
             final ApiEvent.Builder eventBinding, final AuthenticationCallback authenticationCallback) {
         if (null == authenticationCallback) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -49,7 +49,6 @@ import com.microsoft.identity.client.internal.controllers.MSALTokenCommand;
 import com.microsoft.identity.client.internal.telemetry.ApiEvent;
 import com.microsoft.identity.client.internal.telemetry.DefaultEvent;
 import com.microsoft.identity.client.internal.telemetry.Defaults;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.internal.cache.AccountCredentialCache;
@@ -61,7 +60,6 @@ import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentia
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.dto.Account;
-import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -287,7 +285,6 @@ public final class PublicClientApplication {
         mPublicClientConfiguration.getAuthorities().clear();
         mPublicClientConfiguration.getAuthorities().add(Authority.getAuthorityFromAuthorityUrl(authority));
 
-
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
     }
 
@@ -342,6 +339,7 @@ public final class PublicClientApplication {
      * @return An immutable List of IAccount objects - empty if no IAccounts exist.
      */
     public List<IAccount> getAccounts() {
+        MSALApiDispatcher.initializeDiagnosticContext();
         final List<IAccount> accountsToReturn = new ArrayList<>();
 
         // Grab the Accounts from the common cache
@@ -365,6 +363,7 @@ public final class PublicClientApplication {
      * @return The IAccount stored in the cache or null, if no such matching entry exists.
      */
     public IAccount getAccount(final String homeAccountIdentifier) {
+        MSALApiDispatcher.initializeDiagnosticContext();
         final Account accountToReturn;
 
         if (!StringUtil.isEmpty(homeAccountIdentifier)) {
@@ -391,6 +390,7 @@ public final class PublicClientApplication {
      * @return True, if the account was removed. False otherwise.
      */
     public boolean removeAccount(final IAccount account) {
+        MSALApiDispatcher.initializeDiagnosticContext();
         if (null == account
                 || null == account.getHomeAccountIdentifier()
                 || StringUtil.isEmpty(account.getHomeAccountIdentifier().getIdentifier())) {
@@ -836,13 +836,6 @@ public final class PublicClientApplication {
         } else {
             return "msal" + clientId + "://auth";
         }
-    }
-
-    static void initializeDiagnosticContext(String correlationIdStr) {
-        final com.microsoft.identity.common.internal.logging.RequestContext rc =
-                new com.microsoft.identity.common.internal.logging.RequestContext();
-        rc.put(AuthenticationConstants.AAD.CORRELATION_ID, correlationIdStr);
-        DiagnosticContext.setRequestContext(rc);
     }
 
     private MSALAcquireTokenOperationParameters getInteractiveOperationParameters(@NonNull final Activity activity,

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -371,7 +371,7 @@ public final class PublicClientApplication {
 
         // Grab the Accounts from the common cache
         final List<Account> accountsInCache = mOauth2TokenCache.getAccounts(
-                MsalUtils.getUrl(mAuthorityString).getHost(),
+                null, // * wildcard
                 mClientId
         );
 
@@ -394,7 +394,7 @@ public final class PublicClientApplication {
 
         if (!StringUtil.isEmpty(homeAccountIdentifier)) {
             accountToReturn = mOauth2TokenCache.getAccount(
-                    MsalUtils.getUrl(mAuthorityString).getHost(),
+                    null, // * wildcard
                     mClientId,
                     homeAccountIdentifier
             );
@@ -428,7 +428,7 @@ public final class PublicClientApplication {
         }
 
         return mOauth2TokenCache.removeAccount(
-                MsalUtils.getUrl(mAuthorityString).getHost(),
+                account.getEnvironment(),
                 mClientId,
                 account.getHomeAccountIdentifier().getIdentifier()
         );

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -144,20 +144,21 @@ public class PublicClientApplicationConfiguration {
     }
 
     private void checkDefaultAuthoritySpecified() {
-        if (mAuthorities != null) {
-            if (mAuthorities.size() > 1) {
-                int defaultCount = 0;
-                for (Authority authority : mAuthorities) {
-                    if (authority.getDefault()) {
-                        defaultCount++;
-                    }
+        if (mAuthorities != null && mAuthorities.size() > 1) {
+            int defaultCount = 0;
+
+            for (Authority authority : mAuthorities) {
+                if (authority.getDefault()) {
+                    defaultCount++;
                 }
-                if (defaultCount == 0) {
-                    throw new IllegalArgumentException("One authority in your configuration must be marked as default.");
-                }
-                if (defaultCount > 1) {
-                    throw new IllegalArgumentException("More than one authority in your configuration is marked as default.  Only one authority may be default.");
-                }
+            }
+
+            if (defaultCount == 0) {
+                throw new IllegalArgumentException("One authority in your configuration must be marked as default.");
+            }
+
+            if (defaultCount > 1) {
+                throw new IllegalArgumentException("More than one authority in your configuration is marked as default.  Only one authority may be default.");
             }
         }
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -96,8 +96,9 @@ public final class MsalUtils {
      * To improve test-ability with local Junit. Android.jar used for local Junit doesn't have a default implementation
      * for {@link android.text.TextUtils}.
      */
+    @SuppressWarnings("PMD.InefficientEmptyStringCheck")
     public static boolean isEmpty(final String message) {
-        return message == null || message.isEmpty();
+        return message == null || message.trim().length() == 0;
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -97,7 +97,7 @@ public final class MsalUtils {
      * for {@link android.text.TextUtils}.
      */
     public static boolean isEmpty(final String message) {
-        return message == null || message.trim().length() == 0;
+        return message == null || message.isEmpty();
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/authorities/Authority.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/authorities/Authority.java
@@ -121,6 +121,11 @@ public abstract class Authority {
         return mKnownToMicrosoft;
     }
 
+    //CHECKSTYLE:OFF
+    // This method is generated. Checkstyle and/or PMD has been disabled.
+    // This method *must* be regenerated if the class' structural definition changes through the
+    // addition/subtraction of fields.
+    @SuppressWarnings("PMD")
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -131,13 +136,20 @@ public abstract class Authority {
         if (!mAuthorityTypeString.equals(authority.mAuthorityTypeString)) return false;
         return getAuthorityURL().equals(authority.getAuthorityURL());
     }
+    //CHECKSTYLE:ON
 
+    //CHECKSTYLE:OFF
+    // This method is generated. Checkstyle and/or PMD has been disabled.
+    // This method *must* be regenerated if the class' structural definition changes through the
+    // addition/subtraction of fields.
+    @SuppressWarnings("PMD")
     @Override
     public int hashCode() {
         int result = mAuthorityTypeString.hashCode();
         result = 31 * result + getAuthorityURL().hashCode();
         return result;
     }
+    //CHECKSTYLE:ON
 
     /**
      * These are authorities that the developer based on configuration of the public client application are known and trusted by the developer using the public client

--- a/msal/src/main/java/com/microsoft/identity/client/internal/configuration/AuthorityDeserializer.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/configuration/AuthorityDeserializer.java
@@ -15,8 +15,6 @@ import java.lang.reflect.Type;
 
 public class AuthorityDeserializer implements JsonDeserializer<Authority> {
 
-    private static final String TAG = AuthorityDeserializer.class.getSimpleName();
-
     @Override
     public Authority deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
         JsonObject authorityObject = json.getAsJsonObject();

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -195,7 +195,6 @@ public class LocalMSALController extends MSALController {
         final AcquireTokenResult acquireTokenSilentResult = new AcquireTokenResult();
         final OAuth2TokenCache tokenCache = parameters.getTokenCache();
 
-        final String environment = parameters.getAuthority().getAuthorityURL().getHost();
         final String clientId = parameters.getClientId();
         final String homeAccountId =
                 parameters
@@ -204,7 +203,7 @@ public class LocalMSALController extends MSALController {
                         .getIdentifier();
 
         final Account targetAccount = tokenCache.getAccount(
-                environment,
+                null, // wildcard (*) - The request environment may not match due to aliasing
                 clientId,
                 homeAccountId
         );

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALApiDispatcher.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALApiDispatcher.java
@@ -28,11 +28,10 @@ import android.os.Handler;
 import com.microsoft.identity.client.AuthenticationResult;
 import com.microsoft.identity.client.MsalException;
 import com.microsoft.identity.client.MsalUserCancelException;
-import com.microsoft.identity.client.internal.controllers.AcquireTokenResult;
-import com.microsoft.identity.client.internal.controllers.ExceptionAdapter;
-import com.microsoft.identity.client.internal.controllers.MSALInteractiveTokenCommand;
-import com.microsoft.identity.client.internal.controllers.MSALTokenCommand;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -48,6 +47,7 @@ public class MSALApiDispatcher {
             sInteractiveExecutor.execute(new Runnable() {
                 @Override
                 public void run() {
+                    initializeDiagnosticContext();
                     sCommand = command;
                     AcquireTokenResult result = null;
                     MsalException msalException = null;
@@ -121,6 +121,7 @@ public class MSALApiDispatcher {
         sSilentExecutor.execute(new Runnable() {
             @Override
             public void run() {
+                initializeDiagnosticContext();
                 AcquireTokenResult result = null;
 
                 try {
@@ -144,4 +145,13 @@ public class MSALApiDispatcher {
         });
     }
 
+    public static String initializeDiagnosticContext() {
+        final String correlationId = UUID.randomUUID().toString();
+        final com.microsoft.identity.common.internal.logging.RequestContext rc =
+                new com.microsoft.identity.common.internal.logging.RequestContext();
+        rc.put(AuthenticationConstants.AAD.CORRELATION_ID, correlationId);
+        DiagnosticContext.setRequestContext(rc);
+
+        return correlationId;
+    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/telemetry/HttpEvent.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/telemetry/HttpEvent.java
@@ -70,17 +70,17 @@ public final class HttpEvent extends Event {
         final String[] splitArray = url.getPath().split("/");
 
         final StringBuilder logPath = new StringBuilder();
-        logPath.append(url.getProtocol());
-        logPath.append("://");
-        logPath.append(authority);
-        logPath.append("/");
+        logPath.append(url.getProtocol())
+                .append("://")
+                .append(authority)
+                .append('/');
 
         // we do not want to send tenant information
         // index 0 is blank
         // index 1 is tenant
         for (int i = 2; i < splitArray.length; i++) {
             logPath.append(splitArray[i]);
-            logPath.append("/");
+            logPath.append('/');
         }
 
         return logPath.toString();

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -133,17 +133,17 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        mContentMain = (RelativeLayout) findViewById(R.id.content_main);
+        mContentMain = findViewById(R.id.content_main);
 
-        final Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        final DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        final DrawerLayout drawerLayout = findViewById(R.id.drawer_layout);
         ActionBarDrawerToggle toggle = new ActionBarDrawerToggle(this, drawerLayout, toolbar, 0, 0);
         drawerLayout.addDrawerListener(toggle);
         toggle.syncState();
 
-        final NavigationView navigationView = (NavigationView) findViewById(R.id.nav_view);
+        final NavigationView navigationView = findViewById(R.id.nav_view);
         navigationView.setNavigationItemSelectedListener(this);
 
         if (savedInstanceState == null) {
@@ -212,7 +212,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         final FragmentManager fragmentManager = getSupportFragmentManager();
         final FragmentTransaction fragmentTransaction = fragmentManager.beginTransaction();
 
-        final DrawerLayout drawerLayout = (DrawerLayout) findViewById(R.id.drawer_layout);
+        final DrawerLayout drawerLayout = findViewById(R.id.drawer_layout);
         drawerLayout.closeDrawer(GravityCompat.START);
         fragmentTransaction.replace(mContentMain.getId(), fragment).addToBackStack(null).commit();
     }
@@ -229,7 +229,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     public void onRemoveUserClicked() {
-
         final List<IAccount> accountsToRemove = mApplication.getAccounts();
 
         for (final IAccount accountToRemove : accountsToRemove) {
@@ -308,7 +307,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         try {
-            mApplication.setValidateAuthority(true);
             mApplication.acquireToken(this, scopes, loginHint, uiBehavior, extraQueryParam, extraScope,
                     null, getAuthenticationCallback());
         } catch (IllegalArgumentException e) {


### PR DESCRIPTION
See corollary PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/228