### PR TITLE
Add support for session continuation, modifies extra qp api

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -36,6 +36,7 @@ import android.os.Bundle;
 import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 import android.test.AndroidTestCase;
+import android.util.Pair;
 
 import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.client.internal.controllers.MSALApiDispatcher;
@@ -337,7 +338,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
     }
 
     /**
-     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, String, String[],
+     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, List, String[],
      * String, AuthenticationCallback)}. Also check if authority is set on the manifest, we read the authority
      * from manifest meta-data.
      * <p>
@@ -413,7 +414,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
     }
 
     /**
-     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, String, String[], String, AuthenticationCallback)}.
+     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, List, String[], String, AuthenticationCallback)}.
      */
     // TODO: suppress the test. The purpose is that the API call will eventually send back the cancel to caller.
     @Ignore
@@ -432,7 +433,10 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
             void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
                                       final Activity activity,
                                       final CountDownLatch releaseLock) {
-                publicClientApplication.acquireToken(activity, SCOPE, "somehint", UiBehavior.FORCE_LOGIN, "extra=param",
+                publicClientApplication.acquireToken(activity, SCOPE, "somehint", UiBehavior.FORCE_LOGIN,
+                        new ArrayList<Pair<String, String>>() {{
+                            add(new Pair<>("extra", "param"));
+                        }},
                         null, null, new AuthenticationCallback() {
                             @Override
                             public void onSuccess(AuthenticationResult authenticationResult) {
@@ -492,7 +496,10 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
             void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
                                       final Activity activity,
                                       final CountDownLatch releaseLock) {
-                publicClientApplication.acquireToken(activity, SCOPE, "somehint", UiBehavior.FORCE_LOGIN, "extra=param",
+                publicClientApplication.acquireToken(activity, SCOPE, "somehint", UiBehavior.FORCE_LOGIN,
+                        new ArrayList<Pair<String, String>>() {{
+                            add(new Pair<>("extra", "param"));
+                        }},
                         null, null, new AuthenticationCallback() {
                             @Override
                             public void onSuccess(AuthenticationResult authenticationResult) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -469,7 +469,7 @@ public final class PublicClientApplication {
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
-                             final String loginHint,
+                             @Nullable final String loginHint,
                              @NonNull final AuthenticationCallback callback) {
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
@@ -517,8 +517,8 @@ public final class PublicClientApplication {
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
-                             final String loginHint,
-                             final UiBehavior uiBehavior,
+                             @Nullable final String loginHint,
+                             @NonNull final UiBehavior uiBehavior,
                              @Nullable final List<Pair<String, String>> extraQueryParameters,
                              @NonNull final AuthenticationCallback callback) {
         final MSALAcquireTokenOperationParameters params =
@@ -567,19 +567,27 @@ public final class PublicClientApplication {
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
-                             final IAccount account, // TODO wire-up
-                             final UiBehavior uiBehavior,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
                              @Nullable final List<Pair<String, String>> extraQueryParameters,
                              @NonNull final AuthenticationCallback callback) {
+        String loginHint = null;
+        String authority = null;
+
+        if (null != account) {
+            loginHint = account.getUsername();
+            authority = account.getEnvironment();
+        }
+
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
                         activity,
                         scopes,
-                        null, // TODO should this be the login hint from the account?
+                        loginHint,
                         uiBehavior,
                         extraQueryParameters,
                         null,
-                        null,
+                        authority,
                         account
                 );
 
@@ -673,17 +681,23 @@ public final class PublicClientApplication {
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
-                             final IAccount account, // TODO wire-up
-                             final UiBehavior uiBehavior,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
                              @Nullable final List<Pair<String, String>> extraQueryParameters,
                              @Nullable final String[] extraScopesToConsent,
                              @Nullable final String authority,
                              @NonNull final AuthenticationCallback callback) {
+        String loginHint = null;
+
+        if (null != account) {
+            loginHint = account.getUsername();
+        }
+
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
                         activity,
                         scopes,
-                        null, // TODO should I use the login hint from the account?
+                        loginHint,
                         uiBehavior,
                         extraQueryParameters,
                         extraScopesToConsent,

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -148,13 +148,6 @@ public final class PublicClientApplication {
     private String mClientId;
 
     /**
-     * Unique String identifier used in logging/telemetry callbacks to identify.
-     * component in the application using MSAL
-     */
-    @SuppressWarnings("PMD.UnusedPrivateField") // TODO wire-up
-    private String mComponent;
-
-    /**
      * The redirect URI for the application.
      */
     private String mRedirectUri;
@@ -322,18 +315,6 @@ public final class PublicClientApplication {
     }
 
     /**
-     * Specify the string identifier to identify the component that consumes MSAL.
-     * This is intended for libraries that consume MSAL which are embedded in apps that might also be using MSAL
-     * as well. This allows logging, telemetry apps, or library developers to differentiate MSAL usage
-     * from the app to MSAL usage by component libraries.
-     *
-     * @param component The component identifier string passed into MSAL when creating the application object
-     */
-    public void setComponent(final String component) {
-        mComponent = component;
-    }
-
-    /**
      * Returns a List of {@link IAccount} objects for which this application has RefreshTokens.
      *
      * @return An immutable List of IAccount objects - empty if no IAccounts exist.
@@ -442,8 +423,24 @@ public final class PublicClientApplication {
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
-        MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, null, UiBehavior.SELECT_ACCOUNT, null, null, null);
-        MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        null,
+                        UiBehavior.SELECT_ACCOUNT,
+                        null,
+                        null,
+                        null
+                );
+
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
     }
 
@@ -471,8 +468,24 @@ public final class PublicClientApplication {
                              @NonNull final String[] scopes,
                              final String loginHint,
                              @NonNull final AuthenticationCallback callback) {
-        MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, loginHint, UiBehavior.SELECT_ACCOUNT, null, null, null);
-        MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        loginHint,
+                        UiBehavior.SELECT_ACCOUNT,
+                        null,
+                        null,
+                        null
+                );
+
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
     }
 
@@ -504,8 +517,24 @@ public final class PublicClientApplication {
                              final UiBehavior uiBehavior,
                              final String extraQueryParameters,
                              @NonNull final AuthenticationCallback callback) {
-        MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, loginHint, uiBehavior, extraQueryParameters, null, null);
-        MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        loginHint,
+                        uiBehavior,
+                        extraQueryParameters,
+                        null,
+                        null
+                );
+
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
     }
 
@@ -531,13 +560,31 @@ public final class PublicClientApplication {
      *                            3) All the other errors will be sent back via
      *                            {@link AuthenticationCallback#onError(MsalException)}.
      */
-    public void acquireToken(@NonNull final Activity activity, @NonNull final String[] scopes, final IAccount account, final UiBehavior uiBehavior,
-                             final String extraQueryParameter, @NonNull final AuthenticationCallback callback) {
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String[] scopes,
+                             final IAccount account, // TODO wire-up
+                             final UiBehavior uiBehavior,
+                             final String extraQueryParameter,// TODO wire-up
+                             @NonNull final AuthenticationCallback callback) {
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        null,
+                        uiBehavior,
+                        null,
+                        null,
+                        null
+                );
 
-        MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, null, uiBehavior, null, null, null);
-        MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
-
     }
 
     /**
@@ -572,9 +619,24 @@ public final class PublicClientApplication {
                              final String[] extraScopesToConsent,
                              final String authority,
                              @NonNull final AuthenticationCallback callback) {
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        loginHint,
+                        uiBehavior,
+                        extraQueryParams,
+                        extraScopesToConsent,
+                        authority
+                );
 
-        final MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, loginHint, uiBehavior, extraQueryParams, extraScopesToConsent, authority);
-        final MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
     }
 
@@ -604,14 +666,30 @@ public final class PublicClientApplication {
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
-                             final IAccount account,
+                             final IAccount account, // TODO wire-up
                              final UiBehavior uiBehavior,
                              final String extraQueryParams,
                              final String[] extraScopesToConsent,
                              final String authority,
                              @NonNull final AuthenticationCallback callback) {
-        MSALAcquireTokenOperationParameters params = getInteractiveOperationParameters(activity, scopes, null, uiBehavior, extraQueryParams, extraScopesToConsent, authority);
-        MSALInteractiveTokenCommand command = new MSALInteractiveTokenCommand(mAppContext, params, new LocalMSALController(), callback);
+        final MSALAcquireTokenOperationParameters params =
+                getInteractiveOperationParameters(
+                        activity,
+                        scopes,
+                        null,
+                        uiBehavior,
+                        extraQueryParams,
+                        extraScopesToConsent,
+                        authority
+                );
+
+        final MSALInteractiveTokenCommand command =
+                new MSALInteractiveTokenCommand(
+                        mAppContext,
+                        params,
+                        new LocalMSALController(),
+                        callback
+                );
         MSALApiDispatcher.beginInteractive(command);
     }
 
@@ -698,15 +776,11 @@ public final class PublicClientApplication {
                                                                                    final boolean forceRefresh,
                                                                                    final IAccount account) {
         final MSALAcquireTokenSilentOperationParameters parameters = new MSALAcquireTokenSilentOperationParameters();
-
-        Authority authority = Authority.getAuthorityFromAuthorityUrl(authorityStr);
-        // TODO Confirm that it is a known authority?
-
         parameters.setAppContext(mAppContext);
         parameters.setScopes(Arrays.asList(scopes));
         parameters.setClientId(mClientId);
         parameters.setTokenCache(mOauth2TokenCache);
-        parameters.setAuthority(authority);
+        parameters.setAuthority(Authority.getAuthorityFromAuthorityUrl(authorityStr));
         parameters.setAccount(account);
         parameters.setForceRefresh(forceRefresh);
 
@@ -721,6 +795,7 @@ public final class PublicClientApplication {
 
         // read authority from manifest.
         final String authority = applicationInfo.metaData.getString(AUTHORITY_META_DATA);
+
         if (!MsalUtils.isEmpty(authority)) {
             mAuthorityString = authority;
             mPublicClientConfiguration.getAuthorities().clear();
@@ -732,17 +807,18 @@ public final class PublicClientApplication {
 
         // read client id from manifest
         final String clientId = applicationInfo.metaData.getString(CLIENT_ID_META_DATA);
+
         if (MsalUtils.isEmpty(clientId)) {
             throw new IllegalArgumentException("client id missing from manifest");
         }
+
         mClientId = clientId;
         mPublicClientConfiguration.mClientId = clientId;
-
     }
 
     private void setupConfiguration(final int configResourceId) {
-        PublicClientApplicationConfiguration developerConfig = loadConfiguration(mAppContext, configResourceId);
-        PublicClientApplicationConfiguration defaultConfig = loadDefaultConfiguration(mAppContext);
+        final PublicClientApplicationConfiguration developerConfig = loadConfiguration(mAppContext, configResourceId);
+        final PublicClientApplicationConfiguration defaultConfig = loadDefaultConfiguration(mAppContext);
         defaultConfig.mergeConfiguration(developerConfig);
         mPublicClientConfiguration = defaultConfig;
 
@@ -759,7 +835,6 @@ public final class PublicClientApplication {
         } else {
             mAuthorityString = DEFAULT_AUTHORITY;
         }
-
     }
 
     private void setupConfiguration() {
@@ -769,7 +844,6 @@ public final class PublicClientApplication {
     @VisibleForTesting
     static PublicClientApplicationConfiguration loadConfiguration(@NonNull final Context context,
                                                                   final int configResourceId) {
-
         InputStream configStream = context.getResources().openRawResource(configResourceId);
         byte[] buffer;
 
@@ -784,13 +858,10 @@ public final class PublicClientApplication {
             }
         }
 
-        String config = new String(buffer);
+        final String config = new String(buffer);
+        final Gson gson = getGsonForLoadingConfiguration();
 
-        Gson gson = getGsonForLoadingConfiguration();
-
-        PublicClientApplicationConfiguration configObject = gson.fromJson(config, PublicClientApplicationConfiguration.class);
-
-        return configObject;
+        return gson.fromJson(config, PublicClientApplicationConfiguration.class);
     }
 
     private PublicClientApplicationConfiguration loadDefaultConfiguration(@NonNull final Context context) {
@@ -798,15 +869,12 @@ public final class PublicClientApplication {
     }
 
     private static Gson getGsonForLoadingConfiguration() {
-        final Gson gson = new GsonBuilder()
+        return new GsonBuilder()
                 .registerTypeAdapter(Authority.class, new AuthorityDeserializer())
                 .registerTypeAdapter(AzureActiveDirectoryAudience.class, new AzureActiveDirectoryAudienceDeserializer())
                 .registerTypeAdapter(Logger.LogLevel.class, new LogLevelDeserializer())
                 .create();
-
-        return gson;
     }
-
 
     // TODO: if no more input validation is needed, this could be moved back to the constructor.
     private void checkIntentFilterAddedToAppManifest() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -292,7 +292,7 @@ public final class PublicClientApplication {
         // Since network request is sent from the sdk, if calling app doesn't declare the internet permission in the
         // manifest, we cannot make the network call.
         checkInternetPermission();
-        Logger.info(TAG, null, "Create new public client application.");
+        com.microsoft.identity.common.internal.logging.Logger.info(TAG, "Create new public client application.");
     }
 
     /**
@@ -397,7 +397,9 @@ public final class PublicClientApplication {
      * @param resultCode  The result code for the request to get auth code.
      * @param data        {@link Intent} either contains the url with auth code as query string or the errors.
      */
-    public void handleInteractiveRequestRedirect(int requestCode, int resultCode, final Intent data) {
+    public void handleInteractiveRequestRedirect(final int requestCode,
+                                                 final int resultCode,
+                                                 final Intent data) {
         MSALApiDispatcher.completeInteractive(requestCode, resultCode, data);
     }
 
@@ -426,11 +428,11 @@ public final class PublicClientApplication {
                 getInteractiveOperationParameters(
                         activity,
                         scopes,
-                        null,
+                        null, // login hint
                         UiBehavior.SELECT_ACCOUNT,
-                        null,
-                        null,
-                        null
+                        null, // extra query params
+                        null, // extra scopes to consent
+                        null // authority
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -473,9 +475,9 @@ public final class PublicClientApplication {
                         scopes,
                         loginHint,
                         UiBehavior.SELECT_ACCOUNT,
-                        null,
-                        null,
-                        null
+                        null, // extra query params
+                        null, // extra scopes to consent
+                        null // authority
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -571,7 +573,7 @@ public final class PublicClientApplication {
                         scopes,
                         null,
                         uiBehavior,
-                        null,
+                        extraQueryParameter,
                         null,
                         null
                 );
@@ -907,11 +909,11 @@ public final class PublicClientApplication {
 
     private MSALAcquireTokenOperationParameters getInteractiveOperationParameters(@NonNull final Activity activity,
                                                                                   @NonNull final String[] scopes,
-                                                                                  final String loginHint,
+                                                                                  @Nullable final String loginHint,
                                                                                   final UiBehavior uiBehavior,
-                                                                                  final String extraQueryParams,
-                                                                                  final String[] extraScopesToConsent,
-                                                                                  final String authority) {
+                                                                                  @Nullable final String extraQueryParams,
+                                                                                  @Nullable final String[] extraScopesToConsent,
+                                                                                  @Nullable final String authority) {
         final MSALAcquireTokenOperationParameters params = new MSALAcquireTokenOperationParameters();
 
         if (StringUtil.isEmpty(authority)) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -345,6 +345,11 @@ public final class PublicClientApplication {
      */
     public IAccount getAccount(final String homeAccountIdentifier) {
         MSALApiDispatcher.initializeDiagnosticContext();
+        final Account accountToReturn = getAccountInternal(homeAccountIdentifier);
+        return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
+    }
+
+    private com.microsoft.identity.common.internal.dto.Account getAccountInternal(final String homeAccountIdentifier) {
         final Account accountToReturn;
 
         if (!StringUtil.isEmpty(homeAccountIdentifier)) {
@@ -361,7 +366,7 @@ public final class PublicClientApplication {
             accountToReturn = null;
         }
 
-        return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
+        return accountToReturn;
     }
 
     /**
@@ -803,7 +808,13 @@ public final class PublicClientApplication {
         parameters.setClientId(mClientId);
         parameters.setTokenCache(mOauth2TokenCache);
         parameters.setAuthority(Authority.getAuthorityFromAuthorityUrl(authorityStr));
-        parameters.setAccount(account);
+        if (null != account) {
+            parameters.setAccount(
+                    getAccountInternal(
+                            account.getHomeAccountIdentifier().getIdentifier()
+                    )
+            );
+        }
         parameters.setForceRefresh(forceRefresh);
 
         return parameters;
@@ -962,7 +973,13 @@ public final class PublicClientApplication {
         );
         params.setUIBehavior(uiBehavior);
         params.setAppContext(mAppContext);
-        params.setAccount(account);
+        if (null != account) {
+            params.setAccount(
+                    getAccountInternal(
+                            account.getHomeAccountIdentifier().getIdentifier()
+                    )
+            );
+        }
 
         return params;
     }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -31,6 +31,7 @@ import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Pair;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -432,7 +433,8 @@ public final class PublicClientApplication {
                         UiBehavior.SELECT_ACCOUNT,
                         null, // extra query params
                         null, // extra scopes to consent
-                        null // authority
+                        null, // authority
+                        null // account
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -477,7 +479,8 @@ public final class PublicClientApplication {
                         UiBehavior.SELECT_ACCOUNT,
                         null, // extra query params
                         null, // extra scopes to consent
-                        null // authority
+                        null, // authority,
+                        null
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -516,7 +519,7 @@ public final class PublicClientApplication {
                              @NonNull final String[] scopes,
                              final String loginHint,
                              final UiBehavior uiBehavior,
-                             final String extraQueryParameters,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
                              @NonNull final AuthenticationCallback callback) {
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
@@ -525,6 +528,7 @@ public final class PublicClientApplication {
                         loginHint,
                         uiBehavior,
                         extraQueryParameters,
+                        null,
                         null,
                         null
                 );
@@ -543,39 +547,40 @@ public final class PublicClientApplication {
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
      *
-     * @param activity            Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                            All the apps doing interactive request are required to call the
-     *                            {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                            activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes              The non-null array of scopes to be requested for the access token.
-     *                            MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account             Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
-     *                            error will be returned.
-     * @param uiBehavior          The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameter Optional. The extra query parameter sent to authorize endpoint.
-     * @param callback            The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                            1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                            back via {@link AuthenticationCallback#onCancel()}.
-     *                            2) If the sdk successfully receives the token back, result will be sent back via
-     *                            {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
-     *                            3) All the other errors will be sent back via
-     *                            {@link AuthenticationCallback#onError(MsalException)}.
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
+     *                             error will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(AuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
      */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              final IAccount account, // TODO wire-up
                              final UiBehavior uiBehavior,
-                             final String extraQueryParameter,// TODO wire-up
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
                              @NonNull final AuthenticationCallback callback) {
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
                         activity,
                         scopes,
-                        null,
+                        null, // TODO should this be the login hint from the account?
                         uiBehavior,
-                        extraQueryParameter,
+                        extraQueryParameters,
                         null,
-                        null
+                        null,
+                        account
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -601,7 +606,7 @@ public final class PublicClientApplication {
      * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
      *                             which will have the UPN pre-populated.
      * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParams     Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
      * @param extraScopesToConsent Optional. The extra scopes to request consent.
      * @param authority            Optional. Can be passed to override the configured authority.
      * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
@@ -616,7 +621,7 @@ public final class PublicClientApplication {
                              @NonNull final String[] scopes,
                              final String loginHint,
                              final UiBehavior uiBehavior,
-                             final String extraQueryParams,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
                              final String[] extraScopesToConsent,
                              final String authority,
                              @NonNull final AuthenticationCallback callback) {
@@ -626,9 +631,10 @@ public final class PublicClientApplication {
                         scopes,
                         loginHint,
                         uiBehavior,
-                        extraQueryParams,
+                        extraQueryParameters,
                         extraScopesToConsent,
-                        authority
+                        authority,
+                        null // account
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -654,7 +660,7 @@ public final class PublicClientApplication {
      * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
      *                             will be returned.
      * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParams     Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
      * @param extraScopesToConsent Optional. The extra scopes to request consent.
      * @param authority            Optional. Can be passed to override the configured authority.
      * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
@@ -669,19 +675,20 @@ public final class PublicClientApplication {
                              @NonNull final String[] scopes,
                              final IAccount account, // TODO wire-up
                              final UiBehavior uiBehavior,
-                             final String extraQueryParams,
-                             final String[] extraScopesToConsent,
-                             final String authority,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @Nullable final String[] extraScopesToConsent,
+                             @Nullable final String authority,
                              @NonNull final AuthenticationCallback callback) {
         final MSALAcquireTokenOperationParameters params =
                 getInteractiveOperationParameters(
                         activity,
                         scopes,
-                        null,
+                        null, // TODO should I use the login hint from the account?
                         uiBehavior,
-                        extraQueryParams,
+                        extraQueryParameters,
                         extraScopesToConsent,
-                        authority
+                        authority,
+                        account
                 );
 
         final MSALInteractiveTokenCommand command =
@@ -911,9 +918,10 @@ public final class PublicClientApplication {
                                                                                   @NonNull final String[] scopes,
                                                                                   @Nullable final String loginHint,
                                                                                   final UiBehavior uiBehavior,
-                                                                                  @Nullable final String extraQueryParams,
+                                                                                  @Nullable List<Pair<String, String>> extraQueryParameters,
                                                                                   @Nullable final String[] extraScopesToConsent,
-                                                                                  @Nullable final String authority) {
+                                                                                  @Nullable final String authority,
+                                                                                  @Nullable final IAccount account) {
         final MSALAcquireTokenOperationParameters params = new MSALAcquireTokenOperationParameters();
 
         if (StringUtil.isEmpty(authority)) {
@@ -932,7 +940,7 @@ public final class PublicClientApplication {
         params.setActivity(activity);
         params.setLoginHint(loginHint);
         params.setTokenCache(mOauth2TokenCache);
-        params.setExtraQueryStringParameters(extraQueryParams);
+        params.setExtraQueryStringParameters(extraQueryParameters);
         params.setExtraScopesToConsent(
                 null != extraScopesToConsent
                         ? Arrays.asList(extraScopesToConsent)
@@ -940,6 +948,7 @@ public final class PublicClientApplication {
         );
         params.setUIBehavior(uiBehavior);
         params.setAppContext(mAppContext);
+        params.setAccount(account);
 
         return params;
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -29,12 +29,15 @@ import android.net.NetworkInfo;
 import android.text.TextUtils;
 
 import com.microsoft.identity.client.AuthenticationResult;
+import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.MsalClientException;
 import com.microsoft.identity.client.MsalUiRequiredException;
 import com.microsoft.identity.client.internal.authorities.Authority;
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.dto.Account;
+import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationConfiguration;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResponse;
@@ -135,11 +138,37 @@ public class LocalMSALController extends MSALController {
             // Add additional fields to the AuthorizationRequest.Builder to support interactive
             request.setLoginHint(
                     acquireTokenOperationParameters.getLoginHint()
-            ).setExtraQueryParam(
+            ).setExtraQueryParams(
                     acquireTokenOperationParameters.getExtraQueryStringParameters()
             ).setPrompt(
                     acquireTokenOperationParameters.getUIBehavior().toString()
             );
+
+            // Set fields for session continuation, if applicable
+            if (request instanceof MicrosoftStsAuthorizationRequest.Builder
+                    && null != parameters.getAccount()) {
+                MicrosoftStsAuthorizationRequest.Builder msStsRequestBuilder =
+                        (MicrosoftStsAuthorizationRequest.Builder) request;
+
+                final IAccount requestAccount = parameters.getAccount();
+                final String homeAccountId = requestAccount
+                        .getHomeAccountIdentifier()
+                        .getIdentifier();
+
+                // Split this value by its parts... <uid>.<utid>
+                final int EXPECTED_LENGTH = 2;
+                final int INDEX_UID = 0;
+                final int INDEX_UTID = 1;
+
+                final String[] uidUtidPair = homeAccountId.split("\\.");
+
+                if (EXPECTED_LENGTH == uidUtidPair.length
+                        && !StringExtensions.isNullOrBlank(uidUtidPair[INDEX_UID])
+                        && !StringExtensions.isNullOrBlank(uidUtidPair[INDEX_UTID])) {
+                    msStsRequestBuilder.setUid(uidUtidPair[INDEX_UID]);
+                    msStsRequestBuilder.setUtid(uidUtidPair[INDEX_UTID]);
+                }
+            }
         }
 
         return request.build();

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALAcquireTokenOperationParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALAcquireTokenOperationParameters.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client.internal.controllers;
 
 import android.app.Activity;
+import android.util.Pair;
 
 import com.microsoft.identity.client.UiBehavior;
 
@@ -33,7 +34,7 @@ public class MSALAcquireTokenOperationParameters extends MSALOperationParameters
     private Activity mActivity;
     private String mLoginHint;
     private UiBehavior mUIBehavior;
-    private String mExtraQueryStringParameters;
+    private List<Pair<String, String>> mExtraQueryStringParameters;
     private List<String> mExtraScopesToConsent;
 
     public Activity getActivity() {
@@ -52,11 +53,11 @@ public class MSALAcquireTokenOperationParameters extends MSALOperationParameters
         this.mUIBehavior = mUIBehavior;
     }
 
-    public String getExtraQueryStringParameters() {
+    public List<Pair<String, String>> getExtraQueryStringParameters() {
         return mExtraQueryStringParameters;
     }
 
-    public void setExtraQueryStringParameters(String mExtraQueryStringParameters) {
+    public void setExtraQueryStringParameters(List<Pair<String, String>> mExtraQueryStringParameters) {
         this.mExtraQueryStringParameters = mExtraQueryStringParameters;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALOperationParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALOperationParameters.java
@@ -24,8 +24,8 @@ package com.microsoft.identity.client.internal.controllers;
 
 import android.content.Context;
 
-import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.dto.IAccount;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 
 import java.util.List;

--- a/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
+++ b/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
@@ -26,6 +26,7 @@ package com.microsoft.identity.client.sample;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Pair;
 
 import com.microsoft.identity.client.AuthenticationCallback;
 import com.microsoft.identity.client.AuthenticationResult;
@@ -102,7 +103,7 @@ final class AuthUtil {
                 SCOPES,
                 "",
                 UiBehavior.CONSENT,
-                "", // Extra query parameters
+                new ArrayList<Pair<String, String>>(), // Extra query parameters
                 EXTRA_SCOPES,
                 null,
                 new AuthenticationCallback() {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -56,7 +56,6 @@ import com.microsoft.identity.client.Telemetry;
 import com.microsoft.identity.client.UiBehavior;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -312,25 +311,12 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         try {
-//            mApplication.acquireToken(
-//                    this,
-//                    scopes,
-//                    loginHint,
-//                    uiBehavior,
-//                    extraQueryParam,
-//                    extraScope,
-//                    null,
-//                    getAuthenticationCallback()
-//            );
-
             mApplication.acquireToken(
                     this,
                     scopes,
-                    mSelectedAccount,
+                    loginHint,
                     uiBehavior,
-                    new ArrayList<Pair<String, String>>() {{
-                        add(new Pair<>("foo", "bar"));
-                    }},
+                    extraQueryParam,
                     extraScope,
                     null,
                     getAuthenticationCallback()

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -36,6 +36,7 @@ import android.support.v7.app.ActionBarDrawerToggle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
+import android.util.Pair;
 import android.view.MenuItem;
 import android.widget.RelativeLayout;
 import android.widget.Toast;
@@ -55,6 +56,7 @@ import com.microsoft.identity.client.Telemetry;
 import com.microsoft.identity.client.UiBehavior;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -91,7 +93,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     private String[] mScopes;
     private UiBehavior mUiBehavior;
     private String mLoginHint;
-    private String mExtraQp;
+    private List<Pair<String, String>> mExtraQp;
     private String[] mExtraScopesToConsent;
     private boolean mEnablePiiLogging;
     private boolean mForceRefresh;
@@ -296,8 +298,11 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         mSelectedAccount = user;
     }
 
-    private void callAcquireToken(final String[] scopes, final UiBehavior uiBehavior, final String loginHint,
-                                  final String extraQueryParam, final String[] extraScope) {
+    private void callAcquireToken(final String[] scopes,
+                                  final UiBehavior uiBehavior,
+                                  final String loginHint,
+                                  final List<Pair<String, String>> extraQueryParam,
+                                  final String[] extraScope) {
         // The sample app is having the PII enable setting on the MainActivity. Ideally, app should decide to enable Pii or not,
         // if it's enabled, it should be  the setting when the application is onCreate.
         if (mEnablePiiLogging) {
@@ -307,8 +312,29 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         try {
-            mApplication.acquireToken(this, scopes, loginHint, uiBehavior, extraQueryParam, extraScope,
-                    null, getAuthenticationCallback());
+//            mApplication.acquireToken(
+//                    this,
+//                    scopes,
+//                    loginHint,
+//                    uiBehavior,
+//                    extraQueryParam,
+//                    extraScope,
+//                    null,
+//                    getAuthenticationCallback()
+//            );
+
+            mApplication.acquireToken(
+                    this,
+                    scopes,
+                    mSelectedAccount,
+                    uiBehavior,
+                    new ArrayList<Pair<String, String>>() {{
+                        add(new Pair<>("foo", "bar"));
+                    }},
+                    extraScope,
+                    null,
+                    getAuthenticationCallback()
+            );
         } catch (IllegalArgumentException e) {
             showMessage("Scope cannot be blank.");
         }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -61,7 +61,7 @@ public class UsersFragment extends Fragment {
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
         final View view = inflater.inflate(R.layout.fragment_user, container, false);
 
-        mUserList = (ListView) view.findViewById(R.id.user_list);
+        mUserList = view.findViewById(R.id.user_list);
 
         final List<IAccount> accounts = ((MainActivity) this.getActivity()).getAccounts();
         mGson = new GsonBuilder().setPrettyPrinting().create();


### PR DESCRIPTION
Cleans up formatting in MSAL to _better fit*_ display in a 100-char term. Adds `// TODOs` for unused parameters on public methods.



* Still doesn't fit some method declarations