### PR TITLE
Fix nightly builds for MSAL

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -125,7 +125,7 @@ dependencies {
         transitive = false
     }
 
-    //snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.3-SNAPSHOT', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.3-SNAPSHOT', changing: true)
 
     distApi("com.microsoft.identity:common:0.0.3") {
         transitive = false


### PR DESCRIPTION
This was commented out in this PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/366/files#diff-c5d37f2c9047944b7a74d469ff6e24c7L128

Spoke to @heidijinxujia offline, it was an unintentional 