### PR TITLE
Update 0.2.0-RC1 -> 0.2.0-RC2

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.3-SNAPSHOT', changing: true)
 
-    distApi("com.microsoft.identity:common:0.0.5-RC2") {
+    distApi("com.microsoft.identity:common:0.0.5-RC3") {
         transitive = false
     }
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=0.2.0-RC1
+versionName=0.2.0-RC2
 versionCode=0


### PR DESCRIPTION
Picking up fixes in #380 - this branch will need to update the submodule pointer once https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/246 merges