### PR TITLE
Delete the RT when invalid_grant is received and the requested scopes match the cached RT target

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IAccount.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IAccount.java
@@ -22,10 +22,12 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import java.io.Serializable;
+
 /**
  * Interface describing MSAL's externally-exposed Account representation.
  */
-public interface IAccount {
+public interface IAccount extends Serializable {
 
     /**
      * Gets the {@link IAccountIdentifier} for this Account -- this value is authority-specific.

--- a/msal/src/main/java/com/microsoft/identity/client/IAccountIdentifier.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IAccountIdentifier.java
@@ -22,10 +22,12 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import java.io.Serializable;
+
 /**
  * Interface describing an identifier with a {@link String} representation.
  */
-public interface IAccountIdentifier {
+public interface IAccountIdentifier extends Serializable {
 
     /**
      * Gets the identifier.

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
@@ -45,6 +45,10 @@ public final class MsalUiRequiredException extends MsalException {
      */
     public static final String NO_TOKENS_FOUND = "no_tokens_found";
 
+    /**
+     * The supplied Account cannot be found in the cache.
+     */
+    public static final String NO_ACCOUNT_FOUND = "no_account_found";
 
     public MsalUiRequiredException(final String errorCode) {
         super(errorCode);

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -222,6 +222,22 @@ public class LocalMSALController extends MSALController {
                 homeAccountId
         );
 
+        if (null == targetAccount) {
+            Logger.errorPII(
+                    TAG,
+                    "No accounts found for clientId, homeAccountId: ["
+                            + clientId
+                            + ", "
+                            + homeAccountId
+                            + "]",
+                    null
+            );
+            throw new MsalClientException(
+                    MsalUiRequiredException.NO_ACCOUNT_FOUND,
+                    "No cached accounts found for the supplied homeAccountId"
+            );
+        }
+
         final OAuth2Strategy strategy = parameters.getAuthority().createOAuth2Strategy();
         final ICacheRecord cacheRecord = tokenCache.load(
                 clientId,


### PR DESCRIPTION
If we attempt to renew an AT using the RT and `invalid_grant` is returned, then we inspect the contents of the cached RT and, if the scopes match the request, it is deleted (we can assume it's expired).

In the case where `invalid_grant` is returned and the cached RT scopes do NOT match the request, the RT is preserved -- this allows us to receive `invalid_grant` for admin-consent scenarios and not delete what is otherwise a valid RT until a new one is attained in a subsequent acquireToken call.

Other changes in this PR:
- Make `IAccount` and `IAccountIdentifier` interfaces implement `Serializable`
    * This supports apps who need to save these values between restarts, whatever
- `LocalMsalController` will now throw an `Exception` if the `IAccount` supplied to `acquireTokenSilent` doesn't exist in the cache
    * If an app saves an `IAccount` and calls `removeAccount()` and then passes that `IAccount` to `acquireTokenSilent()` this may happen