### PR TITLE
Don't delete tokens for invalid_grant: keep them and replace when new tokens are acquired in subsequent requests

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALController.java
@@ -26,6 +26,7 @@ import android.content.Intent;
 
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.exception.ClientException;
 
 import java.io.IOException;
@@ -37,6 +38,6 @@ public abstract class MSALController {
 
     public abstract void completeAcquireToken(int requestCode, int resultCode, final Intent data);
 
-    public abstract AcquireTokenResult acquireTokenSilent(MSALAcquireTokenSilentOperationParameters request) throws MsalClientException, IOException, ClientException, MsalArgumentException;
+    public abstract AcquireTokenResult acquireTokenSilent(MSALAcquireTokenSilentOperationParameters request) throws MsalClientException, IOException, ClientException, MsalArgumentException, MsalUiRequiredException;
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALTokenCommand.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALTokenCommand.java
@@ -29,6 +29,7 @@ import android.support.annotation.NonNull;
 import com.microsoft.identity.client.AuthenticationCallback;
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.exception.ClientException;
 
 import java.io.IOException;
@@ -60,7 +61,7 @@ public class MSALTokenCommand implements MSALTokenOperation {
     }
 
     @Override
-    public AcquireTokenResult execute() throws InterruptedException, ExecutionException, IOException, ClientException, MsalClientException, MsalArgumentException {
+    public AcquireTokenResult execute() throws InterruptedException, ExecutionException, IOException, ClientException, MsalClientException, MsalArgumentException, MsalUiRequiredException {
         return getController().acquireTokenSilent((MSALAcquireTokenSilentOperationParameters) getParameters());
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALTokenOperation.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALTokenOperation.java
@@ -26,13 +26,14 @@ import android.content.Intent;
 
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.exception.ClientException;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 
 public interface MSALTokenOperation {
-    public AcquireTokenResult execute() throws InterruptedException, ExecutionException, IOException, ClientException, MsalClientException, MsalArgumentException;
+    public AcquireTokenResult execute() throws InterruptedException, ExecutionException, IOException, ClientException, MsalClientException, MsalArgumentException, MsalUiRequiredException;
 
     public void notify(int requestCode, int resultCode, final Intent data);
 }


### PR DESCRIPTION
If AAD serves up `invalid_grant` we now throw the following `MsalUiRequiredException`, including the error description if present.

>Note: Tokens will not be deleted. Instead, this Exception is thrown and the implicit assumption is that they will be replaced with a new AT/RT pair on a subsequent `acquireToken()` call

```java
if (INVALID_GRANT.equalsIgnoreCase(tokenResult.getErrorResponse().getError())) {
    throw new MsalUiRequiredException(
        INVALID_GRANT,
        null != tokenResult.getErrorResponse().getErrorDescription()
                ? tokenResult.getErrorResponse().getErrorDescription()
                : "Failed to renew access token"
    );
}
```