### PR TITLE
Load VSTS PAT via same constant project-wide

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Load credentials for VSTS Maven
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsADALAndroidInternalGradleAccessToken")
+project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")


### PR DESCRIPTION
The root `build.gradle` is loading maven artifacts using `vstsADALAndroidInternalGradleAccessToken` to dereference the PAT whereas [`msal/build.gradle`](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/build.gradle#L250) and [`common/build.gradle`](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/a6580be4a066863aef66c8b992845c4ded58451e/common/build.gradle#L13) use `vstsMavenAccessToken`.

This change makes all of these values use the same `vstsMavenAccessToken` key