### PR TITLE
Dereferencing constant from CustomTabService, no reimplementing

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -35,7 +35,6 @@ import android.net.Uri;
 import android.util.Base64;
 
 import com.microsoft.identity.client.BrowserTabActivity;
-import com.microsoft.identity.client.Logger;
 
 import org.json.JSONException;
 import org.json.JSONObject;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -32,6 +32,7 @@ import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.content.pm.ServiceInfo;
 import android.net.Uri;
+import android.support.customtabs.CustomTabsService;
 import android.util.Base64;
 
 import com.microsoft.identity.client.BrowserTabActivity;
@@ -75,9 +76,6 @@ public final class MsalUtils {
     public static final int DEFAULT_EXPIRATION_TIME_SEC = 3600;
 
     private static final String TAG = MsalUtils.class.getSimpleName();
-
-    private static final String CUSTOM_TABS_SERVICE_ACTION =
-            "android.support.customtabs.action.CustomTabsService";
 
     private static final String TOKEN_HASH_ALGORITHM = "SHA256";
 
@@ -244,7 +242,7 @@ public final class MsalUtils {
             return null;
         }
 
-        final Intent customTabServiceIntent = new Intent(CUSTOM_TABS_SERVICE_ACTION);
+        final Intent customTabServiceIntent = new Intent(CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION);
         final List<ResolveInfo> resolveInfoList = context.getPackageManager().queryIntentServices(
                 customTabServiceIntent, 0);
 
@@ -252,7 +250,7 @@ public final class MsalUtils {
         if (resolveInfoList == null || resolveInfoList.isEmpty()) {
             com.microsoft.identity.common.internal.logging.Logger.warn(
                     TAG,
-                    "No Service responded to Intent: " + CUSTOM_TABS_SERVICE_ACTION
+                    "No Service responded to Intent: " + CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION
             );
             return null;
         }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMSALController.java
@@ -30,7 +30,7 @@ import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
 import com.microsoft.identity.common.internal.broker.BrokerResult;
 import com.microsoft.identity.common.internal.broker.BrokerResultFuture;
-import com.microsoft.identity.common.internal.broker.BrokerTokenResult;
+import com.microsoft.identity.common.internal.broker.BrokerTokenResponse;
 import com.microsoft.identity.common.internal.broker.IMicrosoftAuthService;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthServiceFuture;
@@ -114,7 +114,7 @@ public class BrokerMSALController extends MSALController {
     public void completeAcquireToken(int requestCode, int resultCode, Intent data) {
 
         //TODO: Map data into broker result and signal future
-        mBrokerResultFuture.setBrokerResult(new BrokerResult(new BrokerTokenResult()));
+        mBrokerResultFuture.setBrokerResult(new BrokerResult(new BrokerTokenResponse()));
 
 
     }
@@ -136,7 +136,10 @@ public class BrokerMSALController extends MSALController {
         }
 
         try {
-            result = service.acquireTokenSilently(getSilentParameters(request));
+            //result = service.acquireTokenSilently(getSilentParameters(request));
+
+            // Path is broken by common/#303 - @kreedula & @shoatman to resolve
+            BrokerResult brokerResult = service.acquireTokenSilently(new BrokerRequest());
         } catch (RemoteException e) {
             throw new RuntimeException("Exception occurred while attempting to invoke remote service", e);
         }


### PR DESCRIPTION
Expansion of https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/304

Replaces hard coded `android.support.customtabs.action.CustomTabsService` value with [`CustomTabsService.ACTION_CUSTOM_TABS_CONNECTION`](https://developer.android.com/reference/android/support/customtabs/CustomTabsService.html#ACTION_CUSTOM_TABS_CONNECTION)

Organizes imports, updates submodule