### PR TITLE
Do not fail with exit code if javadoc cannot document all files

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -91,12 +91,6 @@ task javadoc(type: Javadoc) {
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
 }
 
-afterEvaluate {
-    javadoc.classpath += files(android.libraryVariants.collect { variant ->
-        variant.javaCompile.classpath.files
-    })
-}
-
 // Task to generate javadoc.jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -78,6 +78,7 @@ android {
 
 // Task to generate javadoc
 task javadoc(type: Javadoc) {
+    failOnError false
     source = android.sourceSets.main.java.srcDirs
     classpath += configurations.compile
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
@@ -87,8 +88,13 @@ task javadoc(type: Javadoc) {
 
     exclude '**/BuildConfig.Java'
     exclude '**/R.java'
-    classpath = configurations.compile
     destinationDir = reporting.file("$project.buildDir/outputs/jar/javadoc/")
+}
+
+afterEvaluate {
+    javadoc.classpath += files(android.libraryVariants.collect { variant ->
+        variant.javaCompile.classpath.files
+    })
 }
 
 // Task to generate javadoc.jar


### PR DESCRIPTION
This change is to fix the` MSAL Nightly VSTS Release`

The `javadoc` task is failing on project dependency files.

Implications of this change:
- If `javadoc` cannot find the proper file (as it will not for project dependencies), the javadocs will still be generated, but no source link will be provided to the absent file (only the name will be present)
- If the dependency can be resolved (such as from maven or a snapshot) the file should be generated normally