### PR TITLE
Updating buildToolsVersion to 28.0.3 (minimum supported by Gradle Plugin 3.2.1)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ android:
     # https://github.com/travis-ci/travis-ci/issues/6059
     - tools
     - platform-tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-25
     - android-27
     - extra

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -4,10 +4,10 @@ ext {
     minSdkVersion = 16
     targetSdkVersion = 27
     compileSdkVersion = 27
-    buildToolsVersion = "27.0.3"
+    buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '3.1.3'
+    gradleVersion = '3.2.1'
     androidMavenGradlePluginVersion = "1.4.1"
 
     // Libraries


### PR DESCRIPTION
Expands: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/327
Relates: https://github.com/AzureAD/ad-accounts-for-android/pull/766