### PR TITLE
Revert changes from previous PR w.r.t MicrosoftStsResult

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMSALController.java
@@ -48,7 +48,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
-import com.microsoft.identity.common.internal.result.MicrosoftStsAuthenticationResult;
+import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.internal.util.QueryParamsAdapter;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.msal.BuildConfig;
@@ -201,7 +201,7 @@ public class BrokerMSALController extends BaseController {
         AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
         acquireTokenResult.setTokenResult(brokerResult);
         if (brokerResult.isSuccessful() && brokerResult.getTokenResponse() != null) {
-            MicrosoftStsAuthenticationResult result = getAuthenticationResult(brokerResult.getTokenResponse());
+            LocalAuthenticationResult result = getAuthenticationResult(brokerResult.getTokenResponse());
             if (result != null) {
                 acquireTokenResult.setLocalAuthenticationResult(result);
             }
@@ -209,7 +209,7 @@ public class BrokerMSALController extends BaseController {
         return acquireTokenResult;
     }
 
-    private static MicrosoftStsAuthenticationResult getAuthenticationResult(BrokerTokenResponse brokerTokenResponse){
+    private static LocalAuthenticationResult getAuthenticationResult(BrokerTokenResponse brokerTokenResponse){
         final String methodName = "getLocalAuthenticationResult";
         try {
             ClientInfo clientInfo = new ClientInfo(brokerTokenResponse.getClientInfo());
@@ -230,7 +230,7 @@ public class BrokerMSALController extends BaseController {
 
             MicrosoftStsAccount microsoftStsAccount = new MicrosoftStsAccount(new IDToken(idToken), clientInfo);
             Logger.info(TAG, methodName + " AuthenticationResult successfully returned ");
-            return new MicrosoftStsAuthenticationResult(accessTokenRecord, idToken, microsoftStsAccount);
+            return new LocalAuthenticationResult(accessTokenRecord, idToken, microsoftStsAccount);
 
         } catch (ServiceException e) {
             Logger.error(TAG, "Unable to construct Authentication result from BrokerTokenResponse ", e);

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.logging.DiagnosticContext;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationResult;
@@ -47,8 +48,9 @@ import com.microsoft.identity.common.internal.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.internal.providers.oauth2.TokenResult;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
+import com.microsoft.identity.common.internal.request.OperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
-import com.microsoft.identity.common.internal.result.MicrosoftStsAuthenticationResult;
+import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
 import com.microsoft.identity.common.internal.ui.AuthorizationStrategyFactory;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
@@ -56,6 +58,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
@@ -116,7 +119,7 @@ public class LocalMSALController extends BaseController {
                 );
 
                 acquireTokenResult.setLocalAuthenticationResult(
-                        new MicrosoftStsAuthenticationResult(cacheRecord)
+                        new LocalAuthenticationResult(cacheRecord)
                 );
             }
         }
@@ -149,6 +152,53 @@ public class LocalMSALController extends BaseController {
 
         return result;
     }
+
+    private AuthorizationRequest getAuthorizationRequest(final OAuth2Strategy strategy,
+                                                         final OperationParameters parameters) {
+        AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
+
+        List<String> msalScopes = new ArrayList<>();
+        msalScopes.add("openid");
+        msalScopes.add("profile");
+        msalScopes.add("offline_access");
+        msalScopes.addAll(parameters.getScopes());
+
+        //TODO: Not sure why diagnostic context is using AuthenticationConstants....
+
+        UUID correlationId = null;
+
+        try {
+            correlationId = UUID.fromString(DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
+        } catch (IllegalArgumentException ex) {
+            Logger.error("LocalMsalController", "correlation id from diagnostic context is not a UUID", ex);
+        }
+
+        AuthorizationRequest.Builder request = builder
+                .setClientId(parameters.getClientId())
+                .setRedirectUri(parameters.getRedirectUri())
+                .setCorrelationId(correlationId);
+
+        if (parameters instanceof AcquireTokenOperationParameters) {
+            AcquireTokenOperationParameters acquireTokenOperationParameters = (AcquireTokenOperationParameters) parameters;
+            msalScopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
+
+            // Add additional fields to the AuthorizationRequest.Builder to support interactive
+            request.setLoginHint(
+                    acquireTokenOperationParameters.getLoginHint()
+            ).setExtraQueryParams(
+                    acquireTokenOperationParameters.getExtraQueryStringParameters()
+            ).setPrompt(
+                    acquireTokenOperationParameters.getOpenIdConnectPromptParameter().toString()
+            );
+        }
+
+        //Remove empty strings and null values
+        msalScopes.removeAll(Arrays.asList("", null));
+        request.setScope(StringUtil.join(' ', msalScopes));
+
+        return request.build();
+    }
+
 
 
     @Override
@@ -275,7 +325,7 @@ public class LocalMSALController extends BaseController {
             );
             // the result checks out, return that....
             acquireTokenSilentResult.setLocalAuthenticationResult(
-                    new MicrosoftStsAuthenticationResult(cacheRecord)
+                    new LocalAuthenticationResult(cacheRecord)
             );
         }
 
@@ -310,7 +360,7 @@ public class LocalMSALController extends BaseController {
             );
 
             // Create a new AuthenticationResult to hold the saved record
-            final MicrosoftStsAuthenticationResult authenticationResult = new MicrosoftStsAuthenticationResult(savedRecord);
+            final LocalAuthenticationResult authenticationResult = new LocalAuthenticationResult(savedRecord);
 
             // Set the AuthenticationResult on the final result object
             acquireTokenSilentResult.setLocalAuthenticationResult(authenticationResult);

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -153,54 +153,6 @@ public class LocalMSALController extends BaseController {
         return result;
     }
 
-    private AuthorizationRequest getAuthorizationRequest(final OAuth2Strategy strategy,
-                                                         final OperationParameters parameters) {
-        AuthorizationRequest.Builder builder = strategy.createAuthorizationRequestBuilder(parameters.getAccount());
-
-        List<String> msalScopes = new ArrayList<>();
-        msalScopes.add("openid");
-        msalScopes.add("profile");
-        msalScopes.add("offline_access");
-        msalScopes.addAll(parameters.getScopes());
-
-        //TODO: Not sure why diagnostic context is using AuthenticationConstants....
-
-        UUID correlationId = null;
-
-        try {
-            correlationId = UUID.fromString(DiagnosticContext.getRequestContext().get(DiagnosticContext.CORRELATION_ID));
-        } catch (IllegalArgumentException ex) {
-            Logger.error("LocalMsalController", "correlation id from diagnostic context is not a UUID", ex);
-        }
-
-        AuthorizationRequest.Builder request = builder
-                .setClientId(parameters.getClientId())
-                .setRedirectUri(parameters.getRedirectUri())
-                .setCorrelationId(correlationId);
-
-        if (parameters instanceof AcquireTokenOperationParameters) {
-            AcquireTokenOperationParameters acquireTokenOperationParameters = (AcquireTokenOperationParameters) parameters;
-            msalScopes.addAll(acquireTokenOperationParameters.getExtraScopesToConsent());
-
-            // Add additional fields to the AuthorizationRequest.Builder to support interactive
-            request.setLoginHint(
-                    acquireTokenOperationParameters.getLoginHint()
-            ).setExtraQueryParams(
-                    acquireTokenOperationParameters.getExtraQueryStringParameters()
-            ).setPrompt(
-                    acquireTokenOperationParameters.getOpenIdConnectPromptParameter().toString()
-            );
-        }
-
-        //Remove empty strings and null values
-        msalScopes.removeAll(Arrays.asList("", null));
-        request.setScope(StringUtil.join(' ', msalScopes));
-
-        return request.build();
-    }
-
-
-
     @Override
     public void completeAcquireToken(final int requestCode,
                                      final int resultCode,


### PR DESCRIPTION
PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/485
Corresponding PR in `common` : https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/329
Using existing `AdalUserInfo` class in `ad-accounts` instead of `MicrosoftStsAccount`