### PR TITLE
Prepare for release 0.2.2

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,13 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 
+Version 0.2.2
+----------------------------
+- Picks up common@0.0.8
+	* Bugfix: Resolves MSAL/#517
+		- Fix the bug caused by fragment parameter when extracting the redirect url
+	* Bugfix: Resolves COMMON/#343
+		- Fix the discrepancy on "mIdentityProvider" of Account object between ADAL v1.14.1 and ADAL v1.15.1
+
 Version 0.2.1
 ----------------------------
 - Picks up common@0.0.7

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.7', changing: true)
 
-    distApi("com.microsoft.identity:common:0.0.7") {
+    distApi("com.microsoft.identity:common:0.0.8-rc2") {
         transitive = false
     }
 }


### PR DESCRIPTION
* Update changelog and version number
* Update submodule

Version 0.2.2
----------------------------
- Picks up common@0.0.8
	* Bugfix: Resolves MSAL/#517
		- Fix the bug caused by fragment parameter when extracting the redirect url
	* Bugfix: Resolves COMMON/#343
		- Fix the discrepancy on "mIdentityProvider" of Account object between ADAL v1.14.1 and ADAL v1.15.1