### PR TITLE
Close resources after reading the config file.

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1066,6 +1066,23 @@ public final class PublicClientApplication {
                 throw new IllegalArgumentException("Unable to open provided configuration file.", e);
             }
         }
+        finally {
+            try {
+                configStream.close();
+            } catch (IOException e) {
+                if (isDefaultConfiguration) {
+                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + "loadConfiguration",
+                        "Unable to close default configuration file. This can cause memory leak."
+                    );
+                } else {
+                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                            TAG + "loadConfiguration",
+                            "Unable to close provided configuration file. This can cause memory leak."
+                    );
+                }
+            }
+        }
 
         final String config = new String(buffer);
         final Gson gson = getGsonForLoadingConfiguration();

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1071,12 +1071,12 @@ public final class PublicClientApplication {
                 configStream.close();
             } catch (IOException e) {
                 if (isDefaultConfiguration) {
-                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    com.microsoft.identity.common.internal.logging.Logger.warn(
                         TAG + "loadConfiguration",
                         "Unable to close default configuration file. This can cause memory leak."
                     );
                 } else {
-                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    com.microsoft.identity.common.internal.logging.Logger.warn(
                             TAG + "loadConfiguration",
                             "Unable to close provided configuration file. This can cause memory leak."
                     );


### PR DESCRIPTION
Fixes the #510 issue.
Need to close the resources after reading the config file to prevent memory leaks.