### PR TITLE
Targeting Common 0.0.10 for snapshot builds

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -127,7 +127,7 @@ dependencies {
 
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.10-SNAPSHOT', changing: true)
 
-    distApi("com.microsoft.identity:common:0.0.10") {
+    distApi("com.microsoft.identity:common:0.0.8") {
         transitive = false
     }
 }

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -125,9 +125,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.8-SNAPSHOT', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.10-SNAPSHOT', changing: true)
 
-    distApi("com.microsoft.identity:common:0.0.8") {
+    distApi("com.microsoft.identity:common:0.0.10") {
         transitive = false
     }
 }


### PR DESCRIPTION
assembleSnapshot works, assembleDist does not.