### PR TITLE
Resolves common/#554 (Adds public API for setting MSAL SecretKey byte data)

### DIFF
--- a/msal/src/androidTest/AndroidManifest.xml
+++ b/msal/src/androidTest/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
-        android:label="@string/app_name"
+        android:label="MSAL Test App"
         android:allowBackup="false">
         <uses-library android:name="android.test.runner" />
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -188,7 +188,6 @@ public final class PublicClientApplication {
         loadMetaDataFromManifest();
         initializeApplication();
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
-
     }
 
     /**
@@ -218,7 +217,6 @@ public final class PublicClientApplication {
         setupConfiguration(context, developerConfig);
 
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
-
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -264,7 +264,7 @@ public class PublicClientApplicationConfiguration {
         }
     }
 
-    void nullConfigurationCheck(String configKey, String configValue) {
+    private void nullConfigurationCheck(String configKey, String configValue) {
         if (configValue == null) {
             throw new IllegalArgumentException(configKey + " cannot be null.  Invalid configuration.");
         }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -28,6 +28,7 @@ import android.support.annotation.NonNull;
 import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
+import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.internal.authorities.UnknownAudience;
@@ -36,6 +37,8 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 
 import java.util.List;
+
+import javax.crypto.SecretKey;
 
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORITIES;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_USER_AGENT;
@@ -86,6 +89,17 @@ public class PublicClientApplicationConfiguration {
     transient OAuth2TokenCache mOAuth2TokenCache;
 
     transient Context mAppContext;
+
+    /**
+     * Sets the secret key bytes to use when encrypting/decrypting cache entries.
+     * {@link java.security.spec.KeySpec} algorithm is AES.
+     *
+     * @param rawKey The SecretKey to use in its primary encoding format.
+     * @see SecretKey#getEncoded()
+     */
+    public void setTokenCacheSecretKeys(@NonNull final byte[] rawKey) {
+        AuthenticationSettings.INSTANCE.setSecretKey(rawKey);
+    }
 
     /**
      * Gets the currently configured client id for the PublicClientApplication.


### PR DESCRIPTION
See:
- https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/554

Expands:
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/449

### Not Covered in this PR
- Error handling/recovery related to misconfigured or mismatched keys
    * API proposal for behavior to follow...