### PR TITLE
Removes duplicated method in MSAL, points references to common implementation

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestUtil.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestUtil.java
@@ -31,6 +31,7 @@ import android.net.NetworkInfo;
 import android.util.Base64;
 
 import com.microsoft.identity.client.internal.MsalUtils;
+import com.microsoft.identity.common.internal.util.StringUtil;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -238,7 +239,7 @@ public final class AndroidTestUtil {
 
     static String encodeProtocolState(final String authority, final Set<String> scopes) throws UnsupportedEncodingException {
         String state = String.format("a=%s&r=%s", MsalUtils.urlFormEncode(authority),
-                MsalUtils.urlFormEncode(MsalUtils.convertSetToString(scopes, " ")));
+                MsalUtils.urlFormEncode(StringUtil.convertSetToString(scopes, " ")));
         return Base64.encodeToString(state.getBytes(Charset.forName("UTF-8")), Base64.NO_PADDING | Base64.URL_SAFE);
     }
 

--- a/msal/src/androidTest/java/com/microsoft/identity/client/MsalUtilTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/MsalUtilTest.java
@@ -36,6 +36,7 @@ import android.test.suitebuilder.annotation.SmallTest;
 import android.util.Base64;
 
 import com.microsoft.identity.client.internal.MsalUtils;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
 import org.json.JSONException;
 import org.junit.Assert;
@@ -305,12 +306,12 @@ public final class MsalUtilTest {
 
     @Test
     public void testConvertSetToStringEmptyOrNullSetOrDelimiter() {
-        Assert.assertTrue(MsalUtils.convertSetToString(null, " ").equals(""));
-        Assert.assertTrue(MsalUtils.convertSetToString(Collections.EMPTY_SET, " ").equals(""));
+        Assert.assertTrue(StringUtil.convertSetToString(null, " ").equals(""));
+        Assert.assertTrue(StringUtil.convertSetToString(Collections.EMPTY_SET, " ").equals(""));
 
         final Set<String> set = new HashSet<>();
         set.add("some string");
-        Assert.assertTrue(MsalUtils.convertSetToString(set, null).equals(""));
+        Assert.assertTrue(StringUtil.convertSetToString(set, null).equals(""));
     }
 
     @Test
@@ -318,7 +319,7 @@ public final class MsalUtilTest {
         final List<String> input = new ArrayList<>();
         input.add("scope1");
         input.add("scope2");
-        final String result = MsalUtils.convertSetToString(new HashSet<>(input), " ");
+        final String result = StringUtil.convertSetToString(new HashSet<>(input), " ");
 
         Assert.assertTrue(result.equals("scope1 scope2"));
     }

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -46,6 +46,7 @@ import com.microsoft.identity.client.internal.controllers.RequestCodes;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.internal.controllers.ApiDispatcher;
 import com.microsoft.identity.common.internal.net.HttpUrlConnectionFactory;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
 import org.junit.After;
 import org.junit.Assert;
@@ -694,7 +695,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
 
     private String convertScopesArrayToString(final String[] scopes) {
         final Set<String> scopesInSet = new HashSet<>(Arrays.asList(scopes));
-        return MsalUtils.convertSetToString(scopesInSet, " ");
+        return StringUtil.convertSetToString(scopesInSet, " ");
     }
 
     private Context getMockedContext(final String clientId) throws PackageManager.NameNotFoundException {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -62,6 +62,8 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.TimeUnit;
 
+import static com.microsoft.identity.common.internal.util.StringUtil.convertSetToString;
+
 /**
  * Internal Util class for MSAL.
  */
@@ -344,30 +346,6 @@ public final class MsalUtils {
         }
 
         return decodedUrlMap;
-    }
-
-    /**
-     * Convert the given set of scopes into the string with the provided delimiter.
-     *
-     * @param inputSet  The Set of scopes to convert.
-     * @param delimiter The delimiter used to construct the scopes in the format of String.
-     * @return The converted scopes in the format of String.
-     */
-    public static String convertSetToString(final Set<String> inputSet, final String delimiter) {
-        if (inputSet == null || inputSet.isEmpty() || delimiter == null) {
-            return "";
-        }
-
-        final StringBuilder stringBuilder = new StringBuilder();
-        final Iterator<String> iterator = inputSet.iterator();
-        stringBuilder.append(iterator.next());
-
-        while (iterator.hasNext()) {
-            stringBuilder.append(delimiter);
-            stringBuilder.append(iterator.next());
-        }
-
-        return stringBuilder.toString();
     }
 
     /**


### PR DESCRIPTION
Implementations of `convertSetToString` are identical in common & MSAL