### PR TITLE
[AppConfig Validation] Closes #584

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -33,6 +33,7 @@ import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
 import android.util.Pair;
 
 import com.google.gson.Gson;
@@ -216,6 +217,7 @@ public final class PublicClientApplication {
 
         final PublicClientApplicationConfiguration developerConfig = loadConfiguration(context, configFileResourceId);
         setupConfiguration(context, developerConfig);
+        initializeApplication();
         AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
     }
@@ -236,13 +238,19 @@ public final class PublicClientApplication {
      * For more information on the schema of the MSAL config json please
      * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki">MSAL Github Wiki</a>
      */
-    public PublicClientApplication(@NonNull final Context context, final File configFile) {
-        if (context == null) {
+    public PublicClientApplication(@NonNull final Context context,
+                                   @NonNull final File configFile) {
+        if (null == context) {
             throw new IllegalArgumentException("context is null.");
+        }
+
+        if (null == configFile) {
+            throw new IllegalArgumentException("config is null.");
         }
 
         final PublicClientApplicationConfiguration developerConfig = loadConfiguration(configFile);
         setupConfiguration(context, developerConfig);
+        initializeApplication();
         AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
     }
@@ -292,18 +300,16 @@ public final class PublicClientApplication {
                                    @NonNull final String authority) {
         this(context, clientId);
 
-        if (MsalUtils.isEmpty(authority)) {
+        if (TextUtils.isEmpty(authority)) {
             throw new IllegalArgumentException("authority is empty or null");
         }
 
         mPublicClientConfiguration.getAuthorities().clear();
-        if (authority != null) {
-            Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
-            authorityObject.setDefault(true);
-            mPublicClientConfiguration.getAuthorities().add(authorityObject);
-        }
-
+        Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
+        authorityObject.setDefault(true);
+        mPublicClientConfiguration.getAuthorities().add(authorityObject);
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+        initializeApplication();
     }
 
     private void initializeApplication() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1117,6 +1117,7 @@ public final class PublicClientApplication {
     private void setupConfiguration(@NonNull Context context, PublicClientApplicationConfiguration developerConfig) {
         final PublicClientApplicationConfiguration defaultConfig = loadDefaultConfiguration(context);
         defaultConfig.mergeConfiguration(developerConfig);
+        defaultConfig.validateConfiguration();
         mPublicClientConfiguration = defaultConfig;
         mPublicClientConfiguration.setAppContext(context);
         mPublicClientConfiguration.setOAuth2TokenCache(getOAuth2TokenCache());


### PR DESCRIPTION
See #584 

Summary of changes:
- Updates submodule
- Validates the `PublicClientApplicationConfiguration` post-merge
- Adds `@NonNull` annotation to `PublicClientApplication` `File` parameter
- Adds in additional calls to `initalizeApplication()` such that the following actions happen for _every_ constructor call
    * `DefaultEvents` are initialized (inactive, telemetry related)
    * Sets the `redirect_uri` on the config from configured `client_id` if not already set
    * Verifies `IntentFilters` registered in `AndroidManfest` for `BrowserTabActivity`
    * Asserts `android.permission.INTERNET` is declared