### PR TITLE
Safelist support for browser auth flow

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -288,7 +288,10 @@ public class PublicClientApplicationConfiguration {
         nullConfigurationCheck(CLIENT_ID, mClientId);
         checkDefaultAuthoritySpecified();
 
-        if (mBrowserSafeList == null) {
+        // Only validate the browser safe list configuration
+        // when the authorization agent is set either DEFAULT or BROWSER.
+        if ( !mAuthorizationAgent.equals(AuthorizationAgent.WEBVIEW)
+                && (mBrowserSafeList == null || mBrowserSafeList.isEmpty())) {
             throw new IllegalArgumentException(
                     "Null browser safe list configured."
             );

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.common.internal.authorities.UnknownAudience;
 import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
+import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 
 import java.util.List;
 
@@ -92,6 +93,9 @@ public class PublicClientApplicationConfiguration {
     @SerializedName(ENVIRONMENT)
     Environment mEnvironment;
 
+    @SerializedName("browser_safelist")
+    List<BrowserDescriptor> mBrowserSafeList;
+
     transient OAuth2TokenCache mOAuth2TokenCache;
 
     transient Context mAppContext;
@@ -105,6 +109,14 @@ public class PublicClientApplicationConfiguration {
      */
     public void setTokenCacheSecretKeys(@NonNull final byte[] rawKey) {
         AuthenticationSettings.INSTANCE.setSecretKey(rawKey);
+    }
+
+    /**
+     * Gets the list of browser safe list.
+     * @return The list of browser which are allowed to use for auth flow.
+     */
+    public List<BrowserDescriptor> getBrowserSafeList() {
+        return mBrowserSafeList;
     }
 
     /**
@@ -264,12 +276,23 @@ public class PublicClientApplicationConfiguration {
         this.mHttpConfiguration = config.mHttpConfiguration == null ? this.mHttpConfiguration : config.mHttpConfiguration;
         this.mMultipleCloudsSupported = config.mMultipleCloudsSupported == null ? this.mMultipleCloudsSupported : config.mMultipleCloudsSupported;
         this.mUseBroker = config.mUseBroker == null ? this.mUseBroker : config.mUseBroker;
+        if (this.mBrowserSafeList == null) {
+            this.mBrowserSafeList = config.mBrowserSafeList;
+        } else if (config.mBrowserSafeList != null){
+            this.mBrowserSafeList.addAll(config.mBrowserSafeList);
+        }
     }
 
     void validateConfiguration() {
         nullConfigurationCheck(REDIRECT_URI, mRedirectUri);
         nullConfigurationCheck(CLIENT_ID, mClientId);
         checkDefaultAuthoritySpecified();
+
+        if (mBrowserSafeList == null) {
+            throw new IllegalArgumentException(
+                    "Null browser safe list configured."
+            );
+        }
 
         for (final Authority authority : mAuthorities) {
             if (authority instanceof UnknownAuthority) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -140,8 +140,7 @@ public class LocalMSALController extends BaseController {
         mAuthorizationStrategy = AuthorizationStrategyFactory
                 .getInstance()
                 .getAuthorizationStrategy(
-                        parameters.getActivity(),
-                        parameters.getAuthorizationAgent(),
+                        parameters,
                         resultIntent
                 );
         mAuthorizationRequest = getAuthorizationRequest(strategy, parameters);

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -27,7 +27,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.support.annotation.NonNull;
 
-import com.microsoft.identity.client.AccountAdapter;
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AzureActiveDirectoryAccountIdentifier;
@@ -81,6 +80,10 @@ public class OperationParametersAdapter {
                     )
             );
         }
+
+        acquireTokenOperationParameters.setBrowserSafeList(
+                publicClientApplicationConfiguration.getBrowserSafeList()
+        );
 
         if (acquireTokenOperationParameters.getAuthority() instanceof AzureActiveDirectoryAuthority) {
             AzureActiveDirectoryAuthority aadAuthority =

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -15,5 +15,121 @@
   "http": {
     "connect_timeout": 10000,
     "read_timeout": 30000
-  }
+  },
+  "browser_safelist": [
+    {
+      "browser_package_name": "com.android.chrome",
+      "browser_signature_hashes": [
+        "7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg=="
+      ],
+      "browser_use_customTab" : true,
+      "browser_version_lower_bound": "45"
+    },
+    {
+      "browser_package_name": "com.android.chrome",
+      "browser_signature_hashes": [
+        "7fmduHKTdHHrlMvldlEqAIlSfii1tl35bxj1OXN5Ve8c4lU6URVu4xtSHc3BVZxS6WWJnxMDhIfQN0N0K2NDJg=="
+      ],
+      "browser_use_customTab" : false
+    },
+    {
+      "browser_package_name": "org.mozilla.firefox",
+      "browser_signature_hashes": [
+        "2gCe6pR_AO_Q2Vu8Iep-4AsiKNnUHQxu0FaDHO_qa178GByKybdT_BuE8_dYk99G5Uvx_gdONXAOO2EaXidpVQ=="
+      ],
+      "browser_use_customTab" : false
+    },
+    {
+      "browser_package_name": "org.mozilla.firefox",
+      "browser_signature_hashes": [
+        "2gCe6pR_AO_Q2Vu8Iep-4AsiKNnUHQxu0FaDHO_qa178GByKybdT_BuE8_dYk99G5Uvx_gdONXAOO2EaXidpVQ=="
+      ],
+      "browser_use_customTab" : true,
+      "browser_version_lower_bound": "57"
+    },
+    {
+      "browser_package_name": "com.sec.android.app.sbrowser",
+      "browser_signature_hashes": [
+        "ABi2fbt8vkzj7SJ8aD5jc4xJFTDFntdkMrYXL3itsvqY1QIw-dZozdop5rgKNxjbrQAd5nntAGpgh9w84O1Xgg=="
+      ],
+      "browser_use_customTab" : true,
+      "browser_version_lower_bound": "4.0"
+    },
+    {
+      "browser_package_name": "com.sec.android.app.sbrowser",
+      "browser_signature_hashes": [
+        "ABi2fbt8vkzj7SJ8aD5jc4xJFTDFntdkMrYXL3itsvqY1QIw-dZozdop5rgKNxjbrQAd5nntAGpgh9w84O1Xgg=="
+      ],
+      "browser_use_customTab" : false
+    },
+    {
+      "browser_package_name": "com.cloudmosa.puffinFree",
+      "browser_signature_hashes": [
+        "1WqG8SoK2WvE4NTYgr2550TRhjhxT-7DWxu6C_o6GrOLK6xzG67Hq7GCGDjkAFRCOChlo2XUUglLRAYu3Mn8Ag=="
+      ],
+      "browser_use_customTab" : false
+    },
+    {
+      "browser_package_name": "com.duckduckgo.mobile.android",
+      "browser_signature_hashes": [
+        "S5Av4cfEycCvIvKPpKGjyCuAE5gZ8y60-knFfGkAEIZWPr9lU5kA7iOAlSZxaJei08s0ruDvuEzFYlmH-jAi4Q=="
+      ],
+      "browser_use_customTab" : false
+    },
+    {
+      "browser_package_name": "com.explore.web.browser",
+      "browser_signature_hashes": [
+        "BzDzBVSAwah8f_A0MYJCPOkt0eb7WcIEw6Udn7VLcizjoU3wxAzVisCm6bW7uTs4WpMfBEJYf0nDgzTYvYHCag=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "com.ksmobile.cb",
+      "browser_signature_hashes": [
+        "lFDYx1Rwc7_XUn4KlfQk2klXLufRyuGHLa3a7rNjqQMkMaxZueQfxukVTvA7yKKp3Md3XUeeDSWGIZcRy7nouw=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "com.microsoft.emmx",
+      "browser_signature_hashes": [
+        "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "com.opera.browser",
+      "browser_signature_hashes": [
+        "FIJ3IIeqB7V0qHpRNEpYNkhEGA_eJaf7ntca-Oa_6Feev3UkgnpguTNV31JdAmpEFPGNPo0RHqdlU0k-3jWJWw=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "com.opera.mini.native",
+      "browser_signature_hashes": [
+        "TOTyHs086iGIEdxrX_24aAewTZxV7Wbi6niS2ZrpPhLkjuZPAh1c3NQ_U4Lx1KdgyhQE4BiS36MIfP6LbmmUYQ=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "mobi.mgeek.TunnyBrowser",
+      "browser_signature_hashes": [
+        "RMVoXuK1sfJZuGZ8onG1yhMc-sKiAV2NiB_GZfdNlN8XJ78XEE2wPM6LnQiyltF25GkHiPN2iKQiGwaO2bkyyQ=="
+      ],
+      "browser_use_customTab" : false
+    },
+
+    {
+      "browser_package_name": "org.mozilla.focus",
+      "browser_signature_hashes": [
+        "L72dT-stFqomSY7sYySrgBJ3VYKbipMZapmUXfTZNqOzN_dekT5wdBACJkpz0C6P0yx5EmZ5IciI93Q0hq0oYA=="
+      ],
+      "browser_use_customTab" : false
+    }
+  ]
 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -63,7 +63,6 @@ public class AcquireTokenFragment extends Fragment {
     private Button mClearCache;
     private Button mAcquireToken;
     private Button mAcquireTokenSilent;
-    private TextView mDefaultBrowser;
     private Spinner mSelectAccount;
     private Spinner mAADEnvironments;
 
@@ -85,7 +84,6 @@ public class AcquireTokenFragment extends Fragment {
         mExtraScope = view.findViewById(R.id.extraScope);
         mEnablePII = view.findViewById(enablePII);
         mForceRefresh = view.findViewById(R.id.forceRefresh);
-        mDefaultBrowser = view.findViewById(R.id.default_browser);
         mSelectAccount = view.findViewById(R.id.select_user);
         mGetUsers = view.findViewById(R.id.btn_getUsers);
         mClearCache = view.findViewById(R.id.btn_clearCache);
@@ -151,17 +149,6 @@ public class AcquireTokenFragment extends Fragment {
         return view;
     }
 
-//    private void setCurrentDefaultBrowserValue() {
-//        try {
-//            if (getActivity() != null) {
-//                Browser browser = BrowserSelector.select(getActivity().getApplicationContext(), );
-//                mDefaultBrowser.setText(browser.getPackageName());
-//            }
-//        } catch (ClientException e) {
-//            e.printStackTrace();
-//        }
-//    }
-
     @Override
     public void onResume() {
         super.onResume();
@@ -171,7 +158,6 @@ public class AcquireTokenFragment extends Fragment {
         if (mSelectAccount.getSelectedItem() != null) {
             mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
         }
-        //setCurrentDefaultBrowserValue();
     }
 
     @Override

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -151,16 +151,16 @@ public class AcquireTokenFragment extends Fragment {
         return view;
     }
 
-    private void setCurrentDefaultBrowserValue() {
-        try {
-            if (getActivity() != null) {
-                Browser browser = BrowserSelector.select(getActivity().getApplicationContext());
-                mDefaultBrowser.setText(browser.getPackageName());
-            }
-        } catch (ClientException e) {
-            e.printStackTrace();
-        }
-    }
+//    private void setCurrentDefaultBrowserValue() {
+//        try {
+//            if (getActivity() != null) {
+//                Browser browser = BrowserSelector.select(getActivity().getApplicationContext(), );
+//                mDefaultBrowser.setText(browser.getPackageName());
+//            }
+//        } catch (ClientException e) {
+//            e.printStackTrace();
+//        }
+//    }
 
     @Override
     public void onResume() {
@@ -171,7 +171,7 @@ public class AcquireTokenFragment extends Fragment {
         if (mSelectAccount.getSelectedItem() != null) {
             mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
         }
-        setCurrentDefaultBrowserValue();
+        //setCurrentDefaultBrowserValue();
     }
 
     @Override


### PR DESCRIPTION
- Add the configuration support for the browser safe list
- E2E tested all the following popular browsers in the PlayStore

 -- | Browser | CustomTabs
-- | -- | --
com.android.chrome | pass | pass
com.sec.android.app.sbrowser | pass | pass
org.mozilla.firefox | pass | pass
com.UCMobile.intl | not redirect back | not supported
com.cloudmosa.puffinFree | pass | not supported
com.duckduckgo.mobile.android | pass | not supported
com.explore.web.browser | pass | not supported
com.ksmobile.cb | pass | not supported
com.microsoft.emmx | pass | not redirect back
com.opera.browser | pass | not supported
com.opera.mini.native | pass | not supported
com.uc.browser.en | not redirect back | not supported
mobi.mgeek.TunnyBrowser | pass | not supported
org.mozilla.focus | pass | not supported
quick.browser.secure | App self crashed because of too much ads prompt | not supported

- Update all the "pass" browsers' attributes into the default configuration file