### PR TITLE
Refactor for removeLocalAccount()

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -140,7 +140,7 @@ public class AccountAdapter {
     }
 
     @Nullable
-    public static String getRealm(@NonNull IAccount account) {
+    static String getRealm(@NonNull IAccount account) {
         String realm = null;
 
         if (null != account.getAccountIdentifier() // This is an AAD account w/ tenant info

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -138,4 +138,17 @@ public class AccountAdapter {
 
         return accountToReturn;
     }
+
+    @Nullable
+    public static String getRealm(@NonNull IAccount account) {
+        String realm = null;
+
+        if (null != account.getAccountIdentifier() // This is an AAD account w/ tenant info
+                && account.getAccountIdentifier() instanceof AzureActiveDirectoryAccountIdentifier) {
+            final AzureActiveDirectoryAccountIdentifier identifier = (AzureActiveDirectoryAccountIdentifier) account.getAccountIdentifier();
+            realm = identifier.getTenantIdentifier();
+        }
+
+        return realm;
+    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.client.internal.configuration.LogLevelDeserializer;
 import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.client.internal.controllers.LocalMSALController;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
 import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
@@ -620,20 +621,6 @@ public final class PublicClientApplication {
             callback.onAccountsRemoved(false);
         }
 
-        // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
-        final boolean deleteAccountsInAllTenants = true;
-
-        final String realm = deleteAccountsInAllTenants ? null : getRealm(account);
-
-        final boolean localRemoveAccountSuccess = !mPublicClientConfiguration
-                .getOAuth2TokenCache()
-                .removeAccount(
-                        account.getEnvironment(),
-                        mPublicClientConfiguration.getClientId(),
-                        account.getHomeAccountIdentifier().getIdentifier(),
-                        realm
-                ).isEmpty();
-
         if (MSALControllerFactory.brokerEligible(
                 mPublicClientConfiguration.getAppContext(),
                 mPublicClientConfiguration.getDefaultAuthority(),
@@ -646,21 +633,12 @@ public final class PublicClientApplication {
                     callback
             );
         } else {
-            callback.onAccountsRemoved(localRemoveAccountSuccess);
+            new LocalMSALController().removeLocalAccount(
+                    account,
+                    mPublicClientConfiguration,
+                    callback
+            );
         }
-    }
-
-    @Nullable
-    private static String getRealm(@NonNull IAccount account) {
-        String realm = null;
-
-        if (null != account.getAccountIdentifier() // This is an AAD account w/ tenant info
-                && account.getAccountIdentifier() instanceof AzureActiveDirectoryAccountIdentifier) {
-            final AzureActiveDirectoryAccountIdentifier identifier = (AzureActiveDirectoryAccountIdentifier) account.getAccountIdentifier();
-            realm = identifier.getTenantIdentifier();
-        }
-
-        return realm;
     }
 
     /**
@@ -1013,7 +991,7 @@ public final class PublicClientApplication {
                     mPublicClientConfiguration.getClientId(),
                     mPublicClientConfiguration.getOAuth2TokenCache(),
                     account.getHomeAccountIdentifier().getIdentifier(),
-                    getRealm(account)
+                    AccountAdapter.getRealm(account)
             );
         }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -27,7 +27,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
-import com.microsoft.identity.client.AccountAdapter;
+import com.microsoft.identity.client.AzureActiveDirectoryAccountIdentifier;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
@@ -258,15 +258,23 @@ public class LocalMSALController extends BaseController {
                                    @NonNull final PublicClientApplication.AccountsRemovedCallback callback) {
         // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
         final boolean deleteHomeAndGuestAccounts = true;
+        String realm = null;
 
-        final String realm = deleteHomeAndGuestAccounts ? null : AccountAdapter.getRealm(account);
+        if (deleteHomeAndGuestAccounts) {
+            if (account!= null
+                    && null != account.getAccountIdentifier() // This is an AAD account w/ tenant info
+                    && account.getAccountIdentifier() instanceof AzureActiveDirectoryAccountIdentifier) {
+                final AzureActiveDirectoryAccountIdentifier identifier = (AzureActiveDirectoryAccountIdentifier) account.getAccountIdentifier();
+                realm = identifier.getTenantIdentifier();
+            }
+        }
 
         final boolean localRemoveAccountSuccess = !configuration
                 .getOAuth2TokenCache()
                 .removeAccount(
-                        account.getEnvironment(),
+                        account == null? null : account.getEnvironment(),
                         configuration.getClientId(),
-                        account.getHomeAccountIdentifier().getIdentifier(),
+                        account == null? null : account.getHomeAccountIdentifier().getIdentifier(),
                         realm
                 ).isEmpty();
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -281,7 +281,6 @@ public class LocalMSALController extends BaseController {
 
         final String realm = deleteAccountsInAllTenants ? null : AccountAdapter.getRealm(account);
 
-        // Step 1. clear msal local cache
         final boolean localRemoveAccountSuccess = !configuration
                 .getOAuth2TokenCache()
                 .removeAccount(
@@ -290,20 +289,6 @@ public class LocalMSALController extends BaseController {
                         account.getHomeAccountIdentifier().getIdentifier(),
                         realm
                 ).isEmpty();
-
-        // Step 2.
-        // Clear cookies from embedded webView.
-        final CookieManager cookieManager = CookieManager.getInstance();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP){
-            cookieManager.removeAllCookies(null);
-            cookieManager.flush();
-        } else {
-            final CookieSyncManager syncManager = CookieSyncManager.createInstance(configuration.getAppContext());
-            syncManager.startSync();
-            cookieManager.removeAllCookie();
-            syncManager.stopSync();
-            syncManager.sync();
-        }
 
         callback.onAccountsRemoved(localRemoveAccountSuccess);
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -261,9 +261,9 @@ public class LocalMSALController extends BaseController {
                                    @NonNull final PublicClientApplicationConfiguration configuration,
                                    @NonNull final PublicClientApplication.AccountsRemovedCallback callback) {
         // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
-        final boolean deleteAccountsInAllTenants = true;
+        final boolean deleteHomeAndGuestAccounts = true;
 
-        final String realm = deleteAccountsInAllTenants ? null : AccountAdapter.getRealm(account);
+        final String realm = deleteHomeAndGuestAccounts ? null : AccountAdapter.getRealm(account);
 
         final boolean localRemoveAccountSuccess = !configuration
                 .getOAuth2TokenCache()

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -23,15 +23,11 @@
 package com.microsoft.identity.client.internal.controllers;
 
 import android.content.Intent;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.webkit.CookieManager;
-import android.webkit.CookieSyncManager;
 
 import com.microsoft.identity.client.AccountAdapter;
-import com.microsoft.identity.client.BrowserTabActivity;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;


### PR DESCRIPTION
**Problem**
When configuring the app with ```"authorization_user_agent": "WEBVIEW"```
Although the user calling -
```public void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback)```

Ref: #590 

and getting onAccountsRemoved = true, when the user tries to resign in, MSAL automatically signs me in, without prompting for password.

**Diagnose**
This is because the app embedded webview's cookie is still valid and not cleaned even the local MSAL cache is removed.

**Repro steps**
1. acquireToken with user agent as WEBVIEW
2. entering the username and credentials
3. get the token back 
4. type in the login hint used in Step 2 in the test app
5. Click "remove account"
6. Toast msg shows "the account is deleted successfully"
7. acquireToken with user agent as WEBVIEW with loginhint
8. [not expected] get the token back without entering credentials.

**Work items**
1. Add the cache clean up for embedded webview when calling removeLocalAccount()
2. Refactor the removeAccounts()
