### PR TITLE
Introduce PublicClientApplication.Create and related interfaces

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -116,46 +116,6 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
     }
 
     /**
-     * Verify correct exception is thrown if activity is not provided.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testActivityNull() {
-        new PublicClientApplication(null);
-    }
-
-    /**
-     * Verify correct exception is thrown if client id is not set in the manifest.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testClientIdNotInManifest() throws PackageManager.NameNotFoundException {
-        final ApplicationInfo applicationInfo = Mockito.mock(ApplicationInfo.class);
-        // meta data is empty, no client id there.
-        applicationInfo.metaData = new Bundle();
-
-        final Context context = new MockContext(mAppContext);
-        final PackageManager mockedPackageManager = context.getPackageManager();
-        Mockito.when(mockedPackageManager.getApplicationInfo(
-                Mockito.refEq(mAppContext.getPackageName()), Mockito.eq(
-                        PackageManager.GET_META_DATA))).thenReturn(applicationInfo);
-
-        new PublicClientApplication(context);
-    }
-
-    /**
-     * Verify correct exception is thrown if cannot retrieve package info.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testApplicationInfoIsNull() throws PackageManager.NameNotFoundException {
-        final Context context = new MockContext(mAppContext);
-        final PackageManager mockedPackageManager = context.getPackageManager();
-        Mockito.when(mockedPackageManager.getApplicationInfo(
-                Mockito.refEq(mAppContext.getPackageName()), Mockito.eq(
-                        PackageManager.GET_META_DATA))).thenReturn(null);
-
-        new PublicClientApplication(context);
-    }
-
-    /**
      * Verify correct exception is thrown if {@link BrowserTabActivity} does not have the correct intent-filer.
      */
     @Test(expected = IllegalStateException.class)
@@ -163,38 +123,19 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
         final Context context = new MockContext(mAppContext);
         mockPackageManagerWithClientId(context, null, CLIENT_ID);
 
-        new PublicClientApplication(context);
-    }
-
-    /**
-     * Verify correct exception is thrown if meta-data is null.
-     */
-    @Test(expected = IllegalArgumentException.class)
-    public void testMetaDataIsNull() throws PackageManager.NameNotFoundException {
-        final ApplicationInfo applicationInfo = Mockito.mock(ApplicationInfo.class);
-        // null metadata
-        applicationInfo.metaData = null;
-
-        final Context context = new MockContext(mAppContext);
-        final PackageManager mockedPackageManager = context.getPackageManager();
-        Mockito.when(mockedPackageManager.getApplicationInfo(
-                Mockito.refEq(mAppContext.getPackageName()), Mockito.eq(
-                        PackageManager.GET_META_DATA))).thenReturn(applicationInfo);
-
-        new PublicClientApplication(context);
+        new PublicClientApplication(context, CLIENT_ID);
     }
 
     /**
      * Verify correct exception is thrown if callback is not provided.
      */
     @Test(expected = IllegalArgumentException.class)
-    @Ignore
     public void testCallBackEmpty() throws PackageManager.NameNotFoundException {
         final Context context = new MockContext(mAppContext);
         mockPackageManagerWithClientId(context, null, CLIENT_ID);
         mockHasCustomTabRedirect(context);
 
-        final PublicClientApplication application = new PublicClientApplication(context);
+        final PublicClientApplication application = new PublicClientApplication(context, CLIENT_ID);
         application.acquireToken(getActivity(context), SCOPE, null);
     }
 
@@ -207,7 +148,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
         Mockito.when(packageManager.checkPermission(Mockito.refEq("android.permission.INTERNET"),
                 Mockito.refEq(mAppContext.getPackageName()))).thenReturn(PackageManager.PERMISSION_DENIED);
 
-        new PublicClientApplication(context);
+        new PublicClientApplication(context, CLIENT_ID);
     }
 
     @Test
@@ -597,7 +538,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
 
     @Test
     public void testSecretKeysAreSet() throws NoSuchAlgorithmException, InvalidKeySpecException {
-        final PublicClientApplication pca = new PublicClientApplication(mAppContext);
+        final PublicClientApplication pca = new PublicClientApplication(mAppContext, CLIENT_ID);
         final PublicClientApplicationConfiguration appConfig = pca.getConfiguration();
 
         SecretKeyFactory keyFactory = SecretKeyFactory
@@ -774,7 +715,7 @@ public final class PublicClientApplicationTest extends AndroidTestCase {
             final CountDownLatch resultLock = new CountDownLatch(1);
             final Activity testActivity = getActivity(context);
 
-            final PublicClientApplication application = new PublicClientApplication(context);
+            final PublicClientApplication application = new PublicClientApplication(context, CLIENT_ID);
             makeAcquireTokenCall(application, testActivity, resultLock);
 
 

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -1,0 +1,100 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+
+import java.util.List;
+
+/**
+ * An interface that contains list of operations that are available when MSAL is in 'multiple account' mode.
+ * - This mode allows an application to make API calls with more than one accounts.
+ * - The application will only be able to retrieve/remove accounts that have been used to acquire token interactively in this application
+ * - API calls' scope is limited to 'the calling app'. (i.e. removeAccount() will not remove credentials of the same account in other apps).
+ *
+ * This is MSAL's default mode.
+ * */
+public interface IMultipleAccountPublicClientApplication extends IPublicClientApplication{
+    /**
+     * Asynchronously returns a List of {@link IAccount} objects for which this application has RefreshTokens.
+     *
+     * @param callback The callback to notify once this action has finished.
+     */
+    void getAccounts(@NonNull final AccountsLoadedCallback callback);
+
+    /**
+     * Returns the IAccount object matching the supplied home_account_id.
+     *
+     * @param homeAccountIdentifier The home_account_id of the sought IAccount.
+     * @param authority             The authority of the sought IAccount.
+     * @return The IAccount stored in the cache or null, if no such matching entry exists.
+     */
+    IAccount getAccount(@NonNull final String homeAccountIdentifier, @Nullable final String authority);
+
+    /**
+     * Removes the Account and Credentials (tokens) for the supplied IAccount.
+     *
+     * @param account The IAccount whose entry and associated tokens should be removed.
+     * @return True, if the account was removed. False otherwise.
+     */
+    void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback);
+
+    /**
+     * Listener callback for asynchronous loading of msal IAccount accounts.
+     */
+    interface AccountsLoadedCallback {
+        /**
+         * Called once Accounts have been loaded from the cache.
+         *
+         * @param accounts The accounts in the cache.
+         */
+        void onAccountsLoaded(List<IAccount> accounts);
+    }
+
+    /**
+     * Listener callback for asynchronous loading of broker AccountRecord accounts.
+     */
+    interface BrokerAccountsLoadedCallback {
+        /**
+         * Called once Accounts have been loaded from the broker.
+         * @param accountRecords The accountRecords in broker.
+         */
+        void onAccountsLoaded(List<AccountRecord> accountRecords);
+    }
+
+    /**
+     * Listener callback for asynchronous loading of msal IAccount accounts.
+     */
+    interface AccountsRemovedCallback {
+        /**
+         * Called once Accounts have been removed from the cache.
+         *
+         * @param isSuccess true if the account is successfully removed.
+         */
+        void onAccountsRemoved(Boolean isSuccess);
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -61,7 +61,7 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * @param account The IAccount whose entry and associated tokens should be removed.
      * @return True, if the account was removed. False otherwise.
      */
-    void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback);
+    void removeAccount(@Nullable final IAccount account, final AccountRemovedListener callback);
 
     /**
      * Listener callback for asynchronous loading of msal IAccount accounts.
@@ -84,17 +84,5 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
          * @param accountRecords The accountRecords in broker.
          */
         void onAccountsLoaded(List<AccountRecord> accountRecords);
-    }
-
-    /**
-     * Listener callback for asynchronous loading of msal IAccount accounts.
-     */
-    interface AccountsRemovedCallback {
-        /**
-         * Called once Accounts have been removed from the cache.
-         *
-         * @param isSuccess true if the account is successfully removed.
-         */
-        void onAccountsRemoved(Boolean isSuccess);
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -273,4 +273,16 @@ public interface IPublicClientApplication {
      * @param acquireTokenSilentParameters
      */
     void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
+
+    /**
+     * Listener callback for asynchronous removal of msal IAccount account.
+     */
+    interface AccountRemovedListener {
+        /**
+         * Called once Accounts have been removed.
+         *
+         * @param isSuccess true if the account is successfully removed.
+         */
+        void onAccountRemoved(Boolean isSuccess);
+    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -1,0 +1,276 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Pair;
+
+import com.microsoft.identity.client.exception.MsalException;
+
+import java.util.List;
+
+public interface IPublicClientApplication {
+    /**
+     * MSAL requires the calling app to pass an {@link Activity} which <b> MUST </b> call this method to get the auth
+     * code passed back correctly.
+     *
+     * @param requestCode The request code for interactive request.
+     * @param resultCode  The result code for the request to get auth code.
+     * @param data        {@link Intent} either contains the url with auth code as query string or the errors.
+     */
+    void handleInteractiveRequestRedirect(final int requestCode,
+                                          final int resultCode,
+                                          @NonNull final Intent data);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                 All apps doing an interactive request are required to call the
+     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes   The non-null array of scopes to be requested for the access token.
+     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param callback The {@link AuthenticationCallback} to receive the result back.
+     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                 back via {@link AuthenticationCallback#onCancel()}.
+     *                 2) If the sdk successfully receives the token back, result will be sent back via
+     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                 3) All the other errors will be sent back via
+     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                  All the apps doing interactive request are required to call the
+     *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                  activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                  back via {@link AuthenticationCallback#onCancel()}.
+     *                  2) If the sdk successfully receives the token back, result will be sent back via
+     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                  3) All the other errors will be sent back via
+     *                  {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final String loginHint,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameters sent to authorize endpoint.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final String loginHint,
+                      @NonNull final UiBehavior uiBehavior,
+                      @Nullable final List<Pair<String, String>> extraQueryParameters,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
+     *                             error will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final IAccount account,
+                      @NonNull final UiBehavior uiBehavior,
+                      @Nullable final List<Pair<String, String>> extraQueryParameters,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraScopesToConsent Optional. The extra scopes to request consent.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final String loginHint,
+                      @Nullable final UiBehavior uiBehavior,
+                      @Nullable final List<Pair<String, String>> extraQueryParameters,
+                      @Nullable final String[] extraScopesToConsent,
+                      @Nullable final String authority,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param scopes               The non-null array of scopes to be requested for the access token.
+     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
+     *                             will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraScopesToConsent Optional. The extra scopes to request consent.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final IAccount account,
+                      @NonNull final UiBehavior uiBehavior,
+                      @Nullable final List<Pair<String, String>> extraQueryParameters,
+                      @Nullable final String[] extraScopesToConsent,
+                      @Nullable final String authority,
+                      @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     * <p>
+     * Convey parameters via the AquireTokenParameters object
+     *
+     * @param acquireTokenParameters
+     */
+    void acquireTokenAsync(@NonNull final AcquireTokenParameters acquireTokenParameters);
+
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param scopes   The non-null array of scopes to be requested for the access token.
+     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account  {@link IAccount} represents the account to silently request tokens.
+     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                 sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                 Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireTokenSilentAsync(@NonNull final String[] scopes,
+                                 @NonNull final IAccount account,
+                                 @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param scopes       The non-null array of scopes to be requested for the access token.
+     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account      {@link IAccount} represents the account to silently request tokens.
+     * @param authority    Optional. Can be passed to override the configured authority.
+     * @param forceRefresh True if the request is forced to refresh, false otherwise.
+     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                     sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                     Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireTokenSilentAsync(@NonNull final String[] scopes,
+                                 @NonNull final IAccount account,
+                                 @Nullable final String authority,
+                                 final boolean forceRefresh,
+                                 @NonNull final AuthenticationCallback callback);
+
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param acquireTokenSilentParameters
+     */
+    void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
+}

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -50,7 +50,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * @param callback a callback to be invoked when the operation finishes.
      * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
      */
-    void globalSignOut(final PublicClientApplication.AccountsRemovedCallback callback) throws MsalClientException;
+    void globalSignOut(final AccountRemovedListener callback) throws MsalClientException;
 
     /**
      * Listener callback for asynchronous loading of the signed-in IAccount account.
@@ -72,5 +72,6 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
          * @param currentAccount the current signed-in account. This could be nil.
          * */
         void onAccountChanged(final IAccount priorAccount, final IAccount currentAccount);
+
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -1,0 +1,76 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client;
+
+import com.microsoft.identity.client.exception.MsalClientException;
+
+/**
+ * An interface that contains list of operations that are available when MSAL is in 'single account' mode.
+ * - In this mode, the user can 'sign-in' an account to the device.
+ * - Once an account is 'signed-in', every app on the device will be able to retrieve this account, and use them to silently perform API calls.
+ * - If the user wants to acquire a token for another account, the previous account must be removed from the device first through globalSignOut().
+ *   Otherwise, the operation will fail.
+ *
+ * Currently, this mode is only set when the device is registered as 'shared'.
+ * */
+public interface ISingleAccountPublicClientApplication extends IPublicClientApplication {
+    /**
+     * Gets the current account and notify if the current account changes.
+     * This method must be called whenever the application is resumed or prior to running a scheduled background operation.
+     *
+     * @param listener a callback to be invoked when the operation finishes.
+     * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
+     */
+    void getCurrentAccount(final CurrentAccountListener listener) throws MsalClientException;
+
+    /**
+     * Removes the Account and Credentials (tokens) of the account that is currently signed into the device.
+     *
+     * @param callback a callback to be invoked when the operation finishes.
+     * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
+     */
+    void globalSignOut(final PublicClientApplication.AccountsRemovedCallback callback) throws MsalClientException;
+
+    /**
+     * Listener callback for asynchronous loading of the signed-in IAccount account.
+     */
+    interface CurrentAccountListener {
+        /**
+         * Invoked when the account is loaded.
+         * The calling app is responsible for keeping track of this account and cleaning its states if the account changes.
+         *
+         * @param activeAccount the signed-in account. This could be nil.
+         */
+        void onAccountLoaded(final IAccount activeAccount);
+
+        /**
+         * Invoked when signed-in account is changed after the application resumes, or prior to running a scheduled background operation.
+         * The calling app is responsible for keeping track of this account and cleaning its states if the account changes.
+         *
+         * @param priorAccount the previous signed-in account. This could be nil.
+         * @param currentAccount the current signed-in account. This could be nil.
+         * */
+        void onAccountChanged(final IAccount priorAccount, final IAccount currentAccount);
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -605,7 +605,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
     }
 
     @Override
-    public void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback) {
+    public void removeAccount(@Nullable final IAccount account, final AccountRemovedListener callback) {
         ApiDispatcher.initializeDiagnosticContext();
         if (null == account
                 || null == account.getHomeAccountIdentifier()
@@ -615,7 +615,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
                     "Requisite IAccount or IAccount fields were null. Insufficient criteria to remove IAccount."
             );
 
-            callback.onAccountsRemoved(false);
+            callback.onAccountRemoved(false);
         }
 
         // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
@@ -644,7 +644,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
                     callback
             );
         } else {
-            callback.onAccountsRemoved(localRemoveAccountSuccess);
+            callback.onAccountRemoved(localRemoveAccountSuccess);
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -232,11 +232,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         if (MsalUtils.isEmpty(clientId)) {
             throw new IllegalArgumentException("client id is empty or null");
         }
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
-        {
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
             @Override
-            public void onGetMode(String mode)
-            {
+            public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
                     // TODO: return SingleAccountPublicClientApplication
                     listener.onCreated(new PublicClientApplication(context, clientId));
@@ -279,11 +277,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
             throw new IllegalArgumentException("authority is null");
         }
 
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
-        {
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
             @Override
-            public void onGetMode(String mode)
-            {
+            public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
                     // TODO: return SingleAccountPublicClientApplication
                     listener.onCreated(new PublicClientApplication(context, clientId, authority));
@@ -298,11 +294,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
     private static void create(@NonNull final Context context,
                                final PublicClientApplicationConfiguration developerConfig,
                                @NonNull final ApplicationCreatedListener listener){
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
-        {
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
             @Override
-            public void onGetMode(String mode)
-            {
+            public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
                     // TODO: return SingleAccountPublicClientApplication
                     listener.onCreated(new PublicClientApplication(context, developerConfig));
@@ -403,6 +397,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return mPublicClientConfiguration;
     }
 
+    @Override
     public void getAccounts(@NonNull final AccountsLoadedCallback callback) {
         ApiDispatcher.initializeDiagnosticContext();
         final String methodName = ":getAccounts";
@@ -567,6 +562,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return accountsInCache;
     }
 
+    @Override
     @Nullable
     public IAccount getAccount(@NonNull final String homeAccountIdentifier,
                                @Nullable final String authority) {
@@ -608,6 +604,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
     }
 
+    @Override
     public void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback) {
         ApiDispatcher.initializeDiagnosticContext();
         if (null == account
@@ -664,12 +661,14 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return realm;
     }
 
+    @Override
     public void handleInteractiveRequestRedirect(final int requestCode,
                                                  final int resultCode,
                                                  @NonNull final Intent data) {
         ApiDispatcher.completeInteractive(requestCode, resultCode, data);
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
@@ -687,6 +686,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -705,6 +705,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -725,6 +726,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final IAccount account,
@@ -745,6 +747,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -767,6 +770,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final IAccount account,
@@ -834,6 +838,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         }
     }
 
+    @Override
     public void acquireTokenAsync(@NonNull final AcquireTokenParameters acquireTokenParameters) {
         acquireTokenParameters.setAccountRecord(
                 getAccountRecord(acquireTokenParameters.getAccount())
@@ -875,6 +880,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return null;
     }
 
+    @Override
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
                                         @NonNull final AuthenticationCallback callback) {
@@ -888,6 +894,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         );
     }
 
+    @Override
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
                                         @Nullable final String authority,
@@ -925,6 +932,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         acquireTokenSilentAsync(acquireTokenSilentParameters);
     }
 
+    @Override
     public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
         acquireTokenSilentParameters.setAccountRecord(
                 getAccountRecord(

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -309,7 +309,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
     }
 
     protected PublicClientApplication(@NonNull final Context context,
-                                      @NonNull final PublicClientApplicationConfiguration developerConfig) {
+                                      @Nullable final PublicClientApplicationConfiguration developerConfig) {
         setupConfiguration(context, developerConfig);
         AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
@@ -317,10 +317,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
 
     protected PublicClientApplication(@NonNull final Context context,
                                       @NonNull final String clientId) {
-        setupConfiguration(context, null);
+        this(context, (PublicClientApplicationConfiguration)null);
         mPublicClientConfiguration.mClientId = clientId;
         initializeApplication();
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
     }
 
     protected PublicClientApplication(@NonNull final Context context,
@@ -393,7 +392,7 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
      *
      * @return
      */
-    public PublicClientApplicationConfiguration getConfiguration() {
+    PublicClientApplicationConfiguration getConfiguration() {
         return mPublicClientConfiguration;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -26,7 +26,6 @@ package com.microsoft.identity.client;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageManager;
 import android.os.Handler;
 import android.os.Looper;
@@ -47,6 +46,7 @@ import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
 import com.microsoft.identity.client.internal.telemetry.DefaultEvent;
 import com.microsoft.identity.client.internal.telemetry.Defaults;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.exception.BaseException;
@@ -145,53 +145,16 @@ import static com.microsoft.identity.common.internal.cache.SharedPreferencesAcco
  * </p>
  * </p>
  */
-public final class PublicClientApplication {
+public class PublicClientApplication implements IPublicClientApplication, IMultipleAccountPublicClientApplication {
     private static final String TAG = PublicClientApplication.class.getSimpleName();
 
-    private static final String CLIENT_ID_META_DATA = "com.microsoft.identity.client.ClientId";
-    private static final String AUTHORITY_META_DATA = "com.microsoft.identity.client.AuthorityMetadata";
     private static final String INTERNET_PERMISSION = "android.permission.INTERNET";
     private static final String ACCESS_NETWORK_STATE_PERMISSION = "android.permission.ACCESS_NETWORK_STATE";
 
     private PublicClientApplicationConfiguration mPublicClientConfiguration;
 
     /**
-     * @param context Application's {@link Context}. The sdk requires the application context to be passed in
-     *                {@link PublicClientApplication}. Cannot be null.
-     *                <p>
-     *                Note: The {@link Context} should be the application context instead of the running activity's context, which could potentially make the sdk hold a
-     *                strong reference to the activity, thus preventing correct garbage collection and causing bugs.
-     *                </p>
-     * @deprecated This constructor has been replaced with one that leverages a configuration file.
-     * <p> Use {@link PublicClientApplication#PublicClientApplication(Context, int)}</p> instead.
-     * <p>
-     * <p>
-     * {@link PublicClientApplication#PublicClientApplication(Context)} will read the client id (which must be set) from manifest, and if authority
-     * is not set, default authority(https://login.microsoftonline.com/common) will be used.
-     * <p>
-     * Client id <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
-     * if client id is not provided), name for client id in the metadata is: "com.microsoft.identity.client.ClientId".
-     * <p>
-     * Redirect uri <b>MUST</b> be set in the manifest as the meta data({@link IllegalArgumentException} will be thrown
-     * if client id is not provided), name for redirect uri in metadata is: "com.microsoft.identity.client.RedirectUri".
-     * <p>
-     * AuthorityMetadata can be set in the meta data, if not provided, the sdk will use the default authority https://login.microsoftonline.com/common.
-     * </p>
-     */
-    @Deprecated
-    public PublicClientApplication(@NonNull final Context context) {
-        if (context == null) {
-            throw new IllegalArgumentException("context is null.");
-        }
-
-        setupConfiguration(context);
-        loadMetaDataFromManifest();
-        initializeApplication();
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
-    }
-
-    /**
-     * {@link PublicClientApplication#PublicClientApplication(Context, int)} will read the client id and other configuration settings from the
+     * {@link PublicClientApplication#create(Context, int, ApplicationCreatedListener)} will read the client id and other configuration settings from the
      * file included in your applications resources.
      * <p>
      * For more information on adding configuration files to your applications resources please
@@ -207,20 +170,22 @@ public final class PublicClientApplication {
      * <p>
      * For more information on the schema of the MSAL config json please
      * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki">MSAL Github Wiki</a>
+     * @param listener a callback to be invoked when the object is successfully created.
      */
-    public PublicClientApplication(@NonNull final Context context, final int configFileResourceId) {
+    public static void create(@NonNull final Context context,
+                              final int configFileResourceId,
+                              @NonNull final ApplicationCreatedListener listener){
         if (context == null) {
             throw new IllegalArgumentException("context is null.");
         }
 
-        final PublicClientApplicationConfiguration developerConfig = loadConfiguration(context, configFileResourceId);
-        setupConfiguration(context, developerConfig);
-        AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+        create(context,
+            loadConfiguration(context, configFileResourceId),
+            listener);
     }
 
     /**
-     * {@link PublicClientApplication#PublicClientApplication(Context, File)} will read the client id and other configuration settings from the
+     * {@link PublicClientApplication#create(Context, File, ApplicationCreatedListener)} will read the client id and other configuration settings from the
      * specified file.
      *
      * @param context    Application's {@link Context}. The sdk requires the application context to be passed in
@@ -234,20 +199,18 @@ public final class PublicClientApplication {
      * <p>
      * For more information on the schema of the MSAL config json please
      * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki">MSAL Github Wiki</a>
+     * @param listener a callback to be invoked when the object is successfully created.
      */
-    public PublicClientApplication(@NonNull final Context context, final File configFile) {
-        if (context == null) {
-            throw new IllegalArgumentException("context is null.");
-        }
-
-        final PublicClientApplicationConfiguration developerConfig = loadConfiguration(configFile);
-        setupConfiguration(context, developerConfig);
-        AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+    public static void create(@NonNull final Context context,
+                              final File configFile,
+                              @NonNull final ApplicationCreatedListener listener){
+        create(context,
+            loadConfiguration(configFile),
+            listener);
     }
 
     /**
-     * {@link PublicClientApplication#PublicClientApplication(Context, String)} allows the client id to be passed instead of
+     * {@link PublicClientApplication#create(Context, String, ApplicationCreatedListener)} allows the client id to be passed instead of
      * providing through the AndroidManifest metadata. If this constructor is called, the default authority https://login.microsoftonline.com/common will be used.
      *
      * @param context  Application's {@link Context}. The sdk requires the application context to be passed in
@@ -257,24 +220,36 @@ public final class PublicClientApplication {
      *                 strong reference to the activity, thus preventing correct garbage collection and causing bugs.
      *                 </p>
      * @param clientId The application's client id.
+     * @param listener a callback to be invoked when the object is successfully created.
      */
-    public PublicClientApplication(@NonNull final Context context, @NonNull final String clientId) {
+    public static void create(@NonNull final Context context,
+                              @NonNull final String clientId,
+                              @NonNull final ApplicationCreatedListener listener) {
         if (context == null) {
-            throw new IllegalArgumentException("Context is null");
+            throw new IllegalArgumentException("Context is null.");
         }
 
         if (MsalUtils.isEmpty(clientId)) {
             throw new IllegalArgumentException("client id is empty or null");
         }
-
-        setupConfiguration(context);
-        mPublicClientConfiguration.mClientId = clientId;
-        initializeApplication();
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
+        {
+            @Override
+            public void onGetMode(String mode)
+            {
+                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+                    // TODO: return SingleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context, clientId));
+                } else {
+                    // TODO: return MultipleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context, clientId));
+                }
+            }
+        });
     }
 
     /**
-     * {@link PublicClientApplication#PublicClientApplication(Context, String, String)} allows the client id and authority to be passed instead of
+     * {@link PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)} allows the client id and authority to be passed instead of
      * providing them through metadata.
      *
      * @param context   Application's {@link Context}. The sdk requires the application context to be passed in
@@ -285,17 +260,83 @@ public final class PublicClientApplication {
      *                  </p>
      * @param clientId  The application client id.
      * @param authority The default authority to be used for the authority.
+     * @param listener  a callback to be invoked when the object is successfully created.
      */
-    public PublicClientApplication(@NonNull final Context context,
-                                   @NonNull final String clientId,
-                                   @NonNull final String authority) {
-        this(context, clientId);
+    public static void create(@NonNull final Context context,
+                              @NonNull final String clientId,
+                              @NonNull final String authority,
+                              @NonNull final ApplicationCreatedListener listener) {
 
-        if (MsalUtils.isEmpty(authority)) {
-            throw new IllegalArgumentException("authority is empty or null");
+        if (context == null) {
+            throw new IllegalArgumentException("Context is null.");
         }
 
+        if (MsalUtils.isEmpty(clientId)) {
+            throw new IllegalArgumentException("client id is empty or null");
+        }
+
+        if (authority == null) {
+            throw new IllegalArgumentException("authority is null");
+        }
+
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
+        {
+            @Override
+            public void onGetMode(String mode)
+            {
+                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+                    // TODO: return SingleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context, clientId, authority));
+                } else {
+                    // TODO: return MultipleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context, clientId, authority));
+                }
+            }
+        });
+    }
+
+    private static void create(@NonNull final Context context,
+                               final PublicClientApplicationConfiguration developerConfig,
+                               @NonNull final ApplicationCreatedListener listener){
+        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback()
+        {
+            @Override
+            public void onGetMode(String mode)
+            {
+                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+                    // TODO: return SingleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context, developerConfig));
+                } else {
+                    // TODO: return MultipleAccountPublicClientApplication
+                    listener.onCreated(new PublicClientApplication(context,  developerConfig));
+                }
+            }
+        });
+    }
+
+    protected PublicClientApplication(@NonNull final Context context,
+                                      @NonNull final PublicClientApplicationConfiguration developerConfig) {
+        setupConfiguration(context, developerConfig);
+        AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
+        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+    }
+
+    protected PublicClientApplication(@NonNull final Context context,
+                                      @NonNull final String clientId) {
+        setupConfiguration(context, null);
+        mPublicClientConfiguration.mClientId = clientId;
+        initializeApplication();
+        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+    }
+
+    protected PublicClientApplication(@NonNull final Context context,
+                                      @NonNull final String clientId,
+                                      @NonNull final String authority) {
+
+        this(context, clientId);
+
         mPublicClientConfiguration.getAuthorities().clear();
+
         if (authority != null) {
             Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
             authorityObject.setDefault(true);
@@ -324,6 +365,27 @@ public final class PublicClientApplication {
     }
 
     /**
+     * Listener callback for asynchronous initialization of IPublicClientApplication object.
+     */
+    public interface ApplicationCreatedListener {
+        /**
+         * Called once an IPublicClientApplication is successfully created.
+         */
+        void onCreated(final IPublicClientApplication application);
+    }
+
+    /**
+     * Listener callback for asynchronous loading of MSAL mode retrieval.
+     */
+    public interface BrokerAccountModeCallback {
+        /**
+         * Called once MSAL mode is retrieved from Broker.
+         * If the value can't be retrieved, this will fall back to the BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT mode.
+         */
+        void onGetMode(String mode);
+    }
+
+    /**
      * @return The current version for the sdk.
      */
     public static String getSdkVersion() {
@@ -333,7 +395,7 @@ public final class PublicClientApplication {
     /**
      * Returns the PublicClientConfiguration for this instance of PublicClientApplication
      * Configuration is based on the defaults established for MSAl and can be overridden by creating the
-     * PublicClientApplication using {@link PublicClientApplication#PublicClientApplication(Context, int)}
+     * PublicClientApplication using {@link PublicClientApplication#create(Context, int, ApplicationCreatedListener)}
      *
      * @return
      */
@@ -341,48 +403,6 @@ public final class PublicClientApplication {
         return mPublicClientConfiguration;
     }
 
-    /**
-     * Listener callback for asynchronous loading of msal IAccount accounts.
-     */
-    public interface AccountsLoadedCallback {
-
-        /**
-         * Called once Accounts have been loaded from the cache.
-         *
-         * @param accounts The accounts in the cache.
-         */
-        void onAccountsLoaded(List<IAccount> accounts);
-    }
-
-    /**
-     * Listener callback for asynchronous loading of msal IAccount accounts.
-     */
-    public interface AccountsRemovedCallback {
-
-        /**
-         * Called once Accounts have been removed from the cache.
-         *
-         * @param isSuccess true if the account is successfully removed.
-         */
-        void onAccountsRemoved(Boolean isSuccess);
-    }
-
-    /**
-     * Listener callback for asynchronous loading of broker AccountRecord accounts.
-     */
-    public interface BrokerAccountsLoadedCallback {
-        /**
-         * Called once Accounts have been loaded from the broker.
-         * @param accountRecords The accountRecords in broker.
-         */
-        void onAccountsLoaded(List<AccountRecord> accountRecords);
-    }
-
-    /**
-     * Asynchronously returns a List of {@link IAccount} objects for which this application has RefreshTokens.
-     *
-     * @param callback The callback to notify once this action has finished.
-     */
     public void getAccounts(@NonNull final AccountsLoadedCallback callback) {
         ApiDispatcher.initializeDiagnosticContext();
         final String methodName = ":getAccounts";
@@ -547,13 +567,6 @@ public final class PublicClientApplication {
         return accountsInCache;
     }
 
-    /**
-     * Returns the IAccount object matching the supplied home_account_id.
-     *
-     * @param homeAccountIdentifier The home_account_id of the sought IAccount.
-     * @param authority             The authority of the sought IAccount.
-     * @return The IAccount stored in the cache or null, if no such matching entry exists.
-     */
     @Nullable
     public IAccount getAccount(@NonNull final String homeAccountIdentifier,
                                @Nullable final String authority) {
@@ -595,12 +608,6 @@ public final class PublicClientApplication {
         return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
     }
 
-    /**
-     * Removes the Account and Credentials (tokens) for the supplied IAccount.
-     *
-     * @param account The IAccount whose entry and associated tokens should be removed.
-     * @return True, if the account was removed. False otherwise.
-     */
     public void removeAccount(@Nullable final IAccount account, final AccountsRemovedCallback callback) {
         ApiDispatcher.initializeDiagnosticContext();
         if (null == account
@@ -657,38 +664,12 @@ public final class PublicClientApplication {
         return realm;
     }
 
-    /**
-     * MSAL requires the calling app to pass an {@link Activity} which <b> MUST </b> call this method to get the auth
-     * code passed back correctly.
-     *
-     * @param requestCode The request code for interactive request.
-     * @param resultCode  The result code for the request to get auth code.
-     * @param data        {@link Intent} either contains the url with auth code as query string or the errors.
-     */
     public void handleInteractiveRequestRedirect(final int requestCode,
                                                  final int resultCode,
                                                  @NonNull final Intent data) {
         ApiDispatcher.completeInteractive(requestCode, resultCode, data);
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                 All apps doing an interactive request are required to call the
-     *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes   The non-null array of scopes to be requested for the access token.
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param callback The {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
@@ -706,26 +687,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                  All the apps doing interactive request are required to call the
-     *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                  activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes    The non-null array of scopes to be requested for the access token.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                  back via {@link AuthenticationCallback#onCancel()}.
-     *                  2) If the sdk successfully receives the token back, result will be sent back via
-     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                  3) All the other errors will be sent back via
-     *                  {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -744,28 +705,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes               The non-null array of scopes to be requested for the access token.
-     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                             which will have the UPN pre-populated.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameters sent to authorize endpoint.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -786,28 +725,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes               The non-null array of scopes to be requested for the access token.
-     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
-     *                             error will be returned.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final IAccount account,
@@ -828,30 +745,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes               The non-null array of scopes to be requested for the access token.
-     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                             which will have the UPN pre-populated.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority            Optional. Can be passed to override the configured authority.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
@@ -874,30 +767,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param scopes               The non-null array of scopes to be requested for the access token.
-     *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
-     *                             will be returned.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority            Optional. Can be passed to override the configured authority.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final IAccount account,
@@ -965,14 +834,6 @@ public final class PublicClientApplication {
         }
     }
 
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     * <p>
-     * Convey parameters via the AquireTokenParameters object
-     *
-     * @param acquireTokenParameters
-     */
     public void acquireTokenAsync(@NonNull final AcquireTokenParameters acquireTokenParameters) {
         acquireTokenParameters.setAccountRecord(
                 getAccountRecord(acquireTokenParameters.getAccount())
@@ -1014,19 +875,6 @@ public final class PublicClientApplication {
         return null;
     }
 
-    /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
-     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
-     * or it fails the refresh, exception will be sent back via callback.
-     *
-     * @param scopes   The non-null array of scopes to be requested for the access token.
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account  {@link IAccount} represents the account to silently request tokens.
-     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                 sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                 Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
                                         @NonNull final AuthenticationCallback callback) {
@@ -1040,21 +888,6 @@ public final class PublicClientApplication {
         );
     }
 
-    /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
-     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
-     * or it fails the refresh, exception will be sent back via callback.
-     *
-     * @param scopes       The non-null array of scopes to be requested for the access token.
-     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account      {@link IAccount} represents the account to silently request tokens.
-     * @param authority    Optional. Can be passed to override the configured authority.
-     * @param forceRefresh True if the request is forced to refresh, false otherwise.
-     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                     sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                     Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
-     */
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
                                         @Nullable final String authority,
@@ -1092,13 +925,6 @@ public final class PublicClientApplication {
         acquireTokenSilentAsync(acquireTokenSilentParameters);
     }
 
-    /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
-     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
-     * or it fails the refresh, exception will be sent back via callback.
-     *
-     * @param acquireTokenSilentParameters
-     */
     public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
         acquireTokenSilentParameters.setAccountRecord(
                 getAccountRecord(
@@ -1127,35 +953,6 @@ public final class PublicClientApplication {
         ApiDispatcher.submitSilent(silentTokenCommand);
     }
 
-    private void loadMetaDataFromManifest() {
-        final String methodName = ":loadMetaDataFromManifest";
-        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                TAG + methodName,
-                "Loading metadata from manifest..."
-        );
-        final ApplicationInfo applicationInfo = MsalUtils.getApplicationInfo(mPublicClientConfiguration.getAppContext());
-        if (applicationInfo == null || applicationInfo.metaData == null) {
-            throw new IllegalArgumentException("No meta-data exists");
-        }
-
-        // read authority from manifest.
-        final String authority = applicationInfo.metaData.getString(AUTHORITY_META_DATA);
-
-        if (!MsalUtils.isEmpty(authority)) {
-            mPublicClientConfiguration.getAuthorities().clear();
-            mPublicClientConfiguration.getAuthorities().add(Authority.getAuthorityFromAuthorityUrl(authority));
-        }
-
-        // read client id from manifest
-        final String clientId = applicationInfo.metaData.getString(CLIENT_ID_META_DATA);
-
-        if (MsalUtils.isEmpty(clientId)) {
-            throw new IllegalArgumentException("client id missing from manifest");
-        }
-
-        mPublicClientConfiguration.mClientId = clientId;
-    }
-
     @VisibleForTesting
     static PublicClientApplicationConfiguration loadConfiguration(@NonNull final Context context,
                                                                   final int configResourceId) {
@@ -1171,12 +968,6 @@ public final class PublicClientApplication {
         } catch (FileNotFoundException e) {
             throw new IllegalArgumentException("Provided configuration file path=" + configFile.getPath() + " not found.");
         }
-    }
-
-    private void setupConfiguration(Context context) {
-        mPublicClientConfiguration = loadDefaultConfiguration(context);
-        mPublicClientConfiguration.setAppContext(context);
-        mPublicClientConfiguration.setOAuth2TokenCache(getOAuth2TokenCache());
     }
 
     private static PublicClientApplicationConfiguration loadConfiguration(InputStream configStream, boolean isDefaultConfiguration) {
@@ -1215,9 +1006,13 @@ public final class PublicClientApplication {
         return gson.fromJson(config, PublicClientApplicationConfiguration.class);
     }
 
-    private void setupConfiguration(@NonNull Context context, PublicClientApplicationConfiguration developerConfig) {
+    private void setupConfiguration(@NonNull Context context,
+                                    @Nullable PublicClientApplicationConfiguration developerConfig) {
         final PublicClientApplicationConfiguration defaultConfig = loadDefaultConfiguration(context);
-        defaultConfig.mergeConfiguration(developerConfig);
+        if (developerConfig != null) {
+            defaultConfig.mergeConfiguration(developerConfig);
+        }
+
         mPublicClientConfiguration = defaultConfig;
         mPublicClientConfiguration.setAppContext(context);
         mPublicClientConfiguration.setOAuth2TokenCache(getOAuth2TokenCache());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.internal.controllers;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
@@ -33,6 +34,8 @@ import android.support.annotation.Nullable;
 import com.google.gson.Gson;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
+import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
@@ -199,6 +202,57 @@ public class BrokerMsalController extends BaseController {
         }
     }
 
+    /**
+     * Get MSAL PublicClientApplication mode from Broker.
+     * */
+    public void getBrokerAccountMode(final Context appContext,
+                                     final PublicClientApplication.BrokerAccountModeCallback callback) {
+
+        final String methodName = ":getBrokerAccountMode";
+        final Handler handler = new Handler(Looper.getMainLooper());
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                IMicrosoftAuthService service;
+                final MicrosoftAuthClient client = new MicrosoftAuthClient(appContext);
+                try {
+                    final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+
+                    service = authServiceFuture.get();
+
+                    final String mode =
+                        MsalBrokerResultAdapter
+                            .accountModeFromBundle(
+                                service.getAccountMode()
+                            );
+
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onGetMode(mode);
+                        }
+                    });
+                } catch (final ClientException | InterruptedException | ExecutionException | RemoteException e) {
+                    com.microsoft.identity.common.internal.logging.Logger.error(
+                        TAG + methodName,
+                        "Exception is thrown when trying to get current account from Broker, returning default mode."
+                            + e.getMessage(),
+                        ErrorStrings.IO_ERROR,
+                        e);
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onGetMode(AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT);
+                        }
+                    });
+                } finally {
+                    client.disconnect();
+                }
+            }
+        }).start();
+    }
+
     private AcquireTokenResult getAcquireTokenResult(final Bundle resultBundle) throws BaseException {
 
         final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
@@ -224,7 +278,7 @@ public class BrokerMsalController extends BaseController {
      * this needs to be called on background thread.
      */
     public void getBrokerAccounts(final PublicClientApplicationConfiguration configuration,
-                                  final PublicClientApplication.BrokerAccountsLoadedCallback callback) {
+                                  final IMultipleAccountPublicClientApplication.BrokerAccountsLoadedCallback callback) {
 
         final String methodName = ":getBrokerAccounts";
         final Handler handler = new Handler(Looper.getMainLooper());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -337,7 +337,7 @@ public class BrokerMsalController extends BaseController {
 
     public void removeBrokerAccount(@Nullable final IAccount account,
                                     @NonNull final PublicClientApplicationConfiguration configuration,
-                                    @NonNull final PublicClientApplication.AccountsRemovedCallback callback) {
+                                    @NonNull final IPublicClientApplication.AccountRemovedListener callback) {
         sBackgroundExecutor.submit(new Runnable() {
             @Override
             public void run() {
@@ -355,7 +355,7 @@ public class BrokerMsalController extends BaseController {
                     handler.post(new Runnable() {
                         @Override
                         public void run() {
-                            callback.onAccountsRemoved(true);
+                            callback.onAccountRemoved(true);
                         }
                     });
                 } catch (final BaseException | InterruptedException | ExecutionException | RemoteException e) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -211,7 +211,7 @@ public class BrokerMsalController extends BaseController {
         final String methodName = ":getBrokerAccountMode";
         final Handler handler = new Handler(Looper.getMainLooper());
 
-        new Thread(new Runnable() {
+        sBackgroundExecutor.submit(new Runnable() {
             @Override
             public void run() {
                 IMicrosoftAuthService service;
@@ -250,7 +250,7 @@ public class BrokerMsalController extends BaseController {
                     client.disconnect();
                 }
             }
-        }).start();
+        });
     }
 
     private AcquireTokenResult getAcquireTokenResult(final Bundle resultBundle) throws BaseException {
@@ -283,7 +283,7 @@ public class BrokerMsalController extends BaseController {
         final String methodName = ":getBrokerAccounts";
         final Handler handler = new Handler(Looper.getMainLooper());
 
-        new Thread(new Runnable() {
+        sBackgroundExecutor.submit(new Runnable() {
             @Override
             public void run() {
                 IMicrosoftAuthService service;
@@ -299,7 +299,6 @@ public class BrokerMsalController extends BaseController {
                                     .getAccountRecordListFromBundle(
                                             service.getAccounts(requestBundle)
                                     );
-
 
                     handler.post(new Runnable() {
                         @Override
@@ -324,7 +323,7 @@ public class BrokerMsalController extends BaseController {
                     client.disconnect();
                 }
             }
-        }).start();
+        });
 
     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -273,8 +273,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                     }
                 }
             });
-        }
-        else if (mApplication instanceof ISingleAccountPublicClientApplication) {
+        } else if (mApplication instanceof ISingleAccountPublicClientApplication) {
             final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
 
             try {
@@ -288,8 +287,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         }
                     }
                 });
-            }
-            catch (MsalClientException e) {
+            } catch (MsalClientException e) {
                 showMessage(e.getMessage());
             }
 
@@ -327,9 +325,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                     }
                 }
             });
-        }
-
-        else if (mApplication instanceof ISingleAccountPublicClientApplication) {
+        } else if (mApplication instanceof ISingleAccountPublicClientApplication) {
             final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
 
             try {
@@ -348,8 +344,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         // No op.
                     }
                 });
-            }
-            catch (MsalClientException e) {
+            } catch (MsalClientException e) {
                 showMessage(e.getMessage());
             }
         }
@@ -386,8 +381,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         // No op.
                     }
                 });
-            }
-            catch (MsalClientException e) {
+            } catch (MsalClientException e) {
                 showMessage(e.getMessage());
             }
         }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -48,8 +48,13 @@ import com.microsoft.identity.client.AuthenticationResult;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.ILoggerCallback;
+import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
+import com.microsoft.identity.client.IPublicClientApplication;
+import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.Logger;
+import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.UiBehavior;
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -78,7 +83,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     private static final String TAG = MainActivity.class.getSimpleName();
 
-    private PublicClientApplication mApplication;
+    private IPublicClientApplication mApplication;
     private IAccount mSelectedAccount;
     private Handler mHandler;
 
@@ -169,9 +174,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         if (mApplication == null) {
-            mApplication = new PublicClientApplication(this.getApplicationContext(), R.raw.msal_arlington_config);
+            PublicClientApplication.create(this.getApplicationContext(),
+                R.raw.msal_config,
+                new PublicClientApplication.ApplicationCreatedListener() {
+                    @Override
+                    public void onCreated(IPublicClientApplication application) {
+                        mApplication = application;
+                    }
+                });
         }
-
     }
 
     @Override
@@ -238,12 +249,15 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     public void onRemoveUserClicked(final String username) {
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
-            @Override
-            public void onAccountsLoaded(List<IAccount> accountsToRemove) {
-                for (final IAccount accountToRemove : accountsToRemove) {
-                    if (TextUtils.isEmpty(username) || accountToRemove.getUsername().equalsIgnoreCase(username.trim())) {
-                        mApplication.removeAccount(
+        if (mApplication instanceof IMultipleAccountPublicClientApplication){
+            final IMultipleAccountPublicClientApplication application = (IMultipleAccountPublicClientApplication)(mApplication);
+
+            application.getAccounts(new IMultipleAccountPublicClientApplication.AccountsLoadedCallback() {
+                @Override
+                public void onAccountsLoaded(List<IAccount> accountsToRemove) {
+                    for (final IAccount accountToRemove : accountsToRemove) {
+                        if (TextUtils.isEmpty(username) || accountToRemove.getUsername().equalsIgnoreCase(username.trim())) {
+                            application.removeAccount(
                                 accountToRemove,
                                 new PublicClientApplication.AccountsRemovedCallback() {
                                     @Override
@@ -255,13 +269,34 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                                         }
                                     }
                                 });
+                        }
                     }
                 }
+            });
+        }
+        else if (mApplication instanceof ISingleAccountPublicClientApplication) {
+            final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
+
+            try {
+                application.globalSignOut(new PublicClientApplication.AccountsRemovedCallback() {
+                    @Override
+                    public void onAccountsRemoved(Boolean isSuccess) {
+                        if (isSuccess) {
+                            showMessage("The account is successfully removed.");
+                        } else {
+                            showMessage("Account is not removed.");
+                        }
+                    }
+                });
             }
-        });
+            catch (MsalClientException e) {
+                showMessage(e.getMessage());
+            }
+
+        }
     }
 
-    public PublicClientApplication getPublicClientApplication() {
+    public IPublicClientApplication getPublicClientApplication() {
         return mApplication;
     }
 
@@ -269,44 +304,106 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     public void onAcquireTokenSilentClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
         prepareRequestParameters(requestOptions);
 
-        //final IAccount requestAccount = getAccount();
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
-            @Override
-            public void onAccountsLoaded(final List<IAccount> accounts) {
-                IAccount requestAccount = null;
+        if (mApplication instanceof IMultipleAccountPublicClientApplication){
+            final IMultipleAccountPublicClientApplication application = (IMultipleAccountPublicClientApplication)(mApplication);
 
-                for (final IAccount account : accounts) {
-                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
-                        requestAccount = account;
-                        break;
+            //final IAccount requestAccount = getAccount();
+            application.getAccounts(new IMultipleAccountPublicClientApplication.AccountsLoadedCallback() {
+                @Override
+                public void onAccountsLoaded(final List<IAccount> accounts) {
+                    IAccount requestAccount = null;
+
+                    for (final IAccount account : accounts) {
+                        if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
+                            requestAccount = account;
+                            break;
+                        }
+                    }
+
+                    if (null != requestAccount) {
+                        callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
+                    } else {
+                        showMessage("No account found matching loginHint");
                     }
                 }
+            });
+        }
 
-                if (null != requestAccount) {
-                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
-                } else {
-                    showMessage("No account found matching loginHint");
-                }
+        else if (mApplication instanceof ISingleAccountPublicClientApplication) {
+            final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
+
+            try {
+                application.getCurrentAccount(new ISingleAccountPublicClientApplication.CurrentAccountListener() {
+                    @Override
+                    public void onAccountLoaded(IAccount activeAccount) {
+                        if (activeAccount != null){
+                            callAcquireTokenSilent(mScopes, activeAccount, mForceRefresh);
+                        } else {
+                            showMessage("No account is being signed in.");
+                        }
+                    }
+
+                    @Override
+                    public void onAccountChanged(IAccount priorAccount, IAccount currentAccount) {
+                        // No op.
+                    }
+                });
             }
-        });
+            catch (MsalClientException e) {
+                showMessage(e.getMessage());
+            }
+        }
     }
 
     @Override
     public void bindSelectAccountSpinner(final Spinner selectUser) {
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
-            @Override
-            public void onAccountsLoaded(final List<IAccount> accounts) {
-                final ArrayAdapter<String> userAdapter = new ArrayAdapter<>(
-                        getApplicationContext(), android.R.layout.simple_spinner_item,
-                        new ArrayList<String>() {{
-                            for (IAccount account : accounts)
-                                add(account.getUsername());
-                        }}
-                );
-                userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-                selectUser.setAdapter(userAdapter);
+
+        if (mApplication instanceof IMultipleAccountPublicClientApplication){
+            final IMultipleAccountPublicClientApplication application = (IMultipleAccountPublicClientApplication)(mApplication);
+
+            application.getAccounts(new IMultipleAccountPublicClientApplication.AccountsLoadedCallback() {
+                @Override
+                public void onAccountsLoaded(final List<IAccount> accounts) {
+                    bindSelectAccountSpinnerForAccountList(selectUser, accounts);
+                }
+            });
+        } else if (mApplication instanceof ISingleAccountPublicClientApplication) {
+            final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
+
+            try {
+                application.getCurrentAccount(new ISingleAccountPublicClientApplication.CurrentAccountListener() {
+                    @Override
+                    public void onAccountLoaded(final IAccount activeAccount) {
+                        ArrayList<IAccount> accountList = new ArrayList<>();
+                        if (activeAccount != null){
+                            accountList.add(activeAccount);
+                        }
+                        bindSelectAccountSpinnerForAccountList(selectUser, accountList);
+                    }
+
+                    @Override
+                    public void onAccountChanged(IAccount priorAccount, IAccount currentAccount) {
+                        // No op.
+                    }
+                });
             }
-        });
+            catch (MsalClientException e) {
+                showMessage(e.getMessage());
+            }
+        }
+    }
+
+    private void bindSelectAccountSpinnerForAccountList(final Spinner selectUser,
+                                                        final List<IAccount> accounts) {
+        final ArrayAdapter<String> userAdapter = new ArrayAdapter<>(
+            getApplicationContext(), android.R.layout.simple_spinner_item,
+            new ArrayList<String>() {{
+                for (IAccount account : accounts)
+                    add(account.getUsername());
+            }}
+        );
+        userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+        selectUser.setAdapter(userAdapter);
     }
 
     void prepareRequestParameters(final AcquireTokenFragment.RequestOptions requestOptions) {
@@ -328,17 +425,26 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         mScopes = scopes.toLowerCase().split(" ");
         mExtraScopesToConsent = requestOptions.getExtraScopesToConsent() == null ? null : requestOptions.getExtraScopesToConsent().toLowerCase().split(" ");
 
+        int configFileResourceId = R.raw.msal_config;
+
         if (userAgent.name().equalsIgnoreCase("BROWSER")) {
-            mApplication = new PublicClientApplication(this.getApplicationContext(), R.raw.msal_config_browser);
+            configFileResourceId = R.raw.msal_config_browser;
         } else if (userAgent.name().equalsIgnoreCase("WEBVIEW")) {
-            mApplication = new PublicClientApplication(this.getApplicationContext(), R.raw.msal_config_webview);
-        } else {
-            mApplication = new PublicClientApplication(this.getApplicationContext(), R.raw.msal_arlington_config);
+            configFileResourceId = R.raw.msal_config_webview;
         }
 
         if(environment == Constants.AzureActiveDirectoryEnvironment.PREPRODUCTION){
-            mApplication = new PublicClientApplication(this.getApplicationContext(), R.raw.msal_ppe_config);
+            configFileResourceId = R.raw.msal_ppe_config;
         }
+
+        PublicClientApplication.create(this.getApplicationContext(),
+            configFileResourceId,
+            new PublicClientApplication.ApplicationCreatedListener() {
+                @Override
+                public void onCreated(IPublicClientApplication application) {
+                    mApplication = application;
+                }
+            });
     }
 
     final String getAuthority(Constants.AuthorityType authorityTypeType) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -52,9 +52,7 @@ import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.Logger;
-import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
-import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.UiBehavior;
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -259,9 +257,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         if (TextUtils.isEmpty(username) || accountToRemove.getUsername().equalsIgnoreCase(username.trim())) {
                             application.removeAccount(
                                 accountToRemove,
-                                new PublicClientApplication.AccountsRemovedCallback() {
+                                new IPublicClientApplication.AccountRemovedListener() {
                                     @Override
-                                    public void onAccountsRemoved(Boolean isSuccess) {
+                                    public void onAccountRemoved(Boolean isSuccess) {
                                         if (isSuccess) {
                                             showMessage("The account is successfully removed.");
                                         } else {
@@ -277,9 +275,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
             final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
 
             try {
-                application.globalSignOut(new PublicClientApplication.AccountsRemovedCallback() {
+                application.globalSignOut(new IPublicClientApplication.AccountRemovedListener() {
                     @Override
-                    public void onAccountsRemoved(Boolean isSuccess) {
+                    public void onAccountRemoved(Boolean isSuccess) {
                         if (isSuccess) {
                             showMessage("The account is successfully removed.");
                         } else {


### PR DESCRIPTION
This is part of the End-my-Shift functionality. 

- Replace PublicClientApplication's public constructor with PublicClientApplication.Create()

- Introduce IPublicClientApplication, ISingleAccountPublicClientApplication and IMultipleAccountPublicClientApplication
    - Also move all of the API descriptions to these interfaces.

- Update test app to accompany the new interface.