### PR TITLE
[Blocked] Add PCA.getAccount(oid) API to retrieve account by object id

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -351,27 +351,14 @@ public final class PublicClientApplication {
     /**
      * Listener callback for asynchronous loading of msal IAccount accounts.
      */
-    public interface AccountsLoadedCallback {
+    public interface AccountsLoadedCallback<T> {
 
         /**
          * Called once Accounts have been loaded from the cache.
          *
          * @param accounts The accounts in the cache.
          */
-        void onAccountsLoaded(List<IAccount> accounts);
-    }
-
-    /**
-     * Listener callback for asynchronous finding of IAccount matching the given oid.
-     */
-    public interface AccountLoadedCallback {
-
-        /**
-         * Called once Account have been found from the cache.
-         *
-         * @param account The account in the cache.
-         */
-        void onAccountLoaded(IAccount account);
+        void onAccountsLoaded(T accounts);
     }
 
     /**
@@ -574,7 +561,7 @@ public final class PublicClientApplication {
      * @param callback AccountLoadedCallback
      */
     public void getAccount(@NonNull final String oid,
-                           @NonNull final AccountLoadedCallback callback) {
+                           @NonNull final AccountsLoadedCallback<IAccount> callback) {
         final String methodName = ":getAccount";
 
         ApiDispatcher.initializeDiagnosticContext();
@@ -603,7 +590,7 @@ public final class PublicClientApplication {
     }
 
     private void getBrokerAndLocalAccount(@NonNull final String oid,
-                                          @NonNull final AccountLoadedCallback callback) {
+                                          @NonNull final AccountsLoadedCallback callback) {
         final String methodName = ":getBrokerAndLocalAccount";
 
         final Handler handler;
@@ -632,7 +619,7 @@ public final class PublicClientApplication {
                                 @Override
                                 public void run() {
                                     //Return null if no account found.
-                                    callback.onAccountLoaded(null);
+                                    callback.onAccountsLoaded(null);
                                 }
                             });
                         }
@@ -648,7 +635,7 @@ public final class PublicClientApplication {
                                 handler.post(new Runnable() {
                                     @Override
                                     public void run() {
-                                        callback.onAccountLoaded(AccountAdapter.adapt(accountRecord));
+                                        callback.onAccountsLoaded(AccountAdapter.adapt(accountRecord));
                                     }
                                 });
                             }
@@ -659,7 +646,7 @@ public final class PublicClientApplication {
 
 
     private void getLocalAccount(@NonNull final String oid,
-                                 @NonNull final AccountLoadedCallback callback) {
+                                 @NonNull final AccountsLoadedCallback callback) {
         final String methodName = ":getLocalAccount";
         List<AccountRecord> localAccountList = getLocalAccounts();
         if (localAccountList == null || localAccountList.isEmpty()) {
@@ -668,7 +655,8 @@ public final class PublicClientApplication {
                     "No account stored in the local cache."
             );
 
-            callback.onAccountLoaded(null);
+            callback.onAccountsLoaded(null);
+            return;
         }
 
         for (AccountRecord accountRecord : getLocalAccounts()) {
@@ -679,7 +667,8 @@ public final class PublicClientApplication {
                         "Found the matched account."
                 );
 
-                callback.onAccountLoaded(AccountAdapter.adapt(accountRecord));
+                callback.onAccountsLoaded(AccountAdapter.adapt(accountRecord));
+                return;
             }
         }
 
@@ -687,7 +676,7 @@ public final class PublicClientApplication {
                 TAG + methodName,
                 "No account found in the local cache."
         );
-        callback.onAccountLoaded(null);
+        callback.onAccountsLoaded(null);
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -238,8 +238,9 @@ public class BrokerMsalController extends BaseController {
                                        @NonNull final MsalOAuth2TokenCache msalOAuth2TokenCache) throws ClientException {
         final String methodName = ":saveMsaAccountToCache";
 
-        final BrokerResult brokerResult = (BrokerResult) resultBundle.getSerializable(
-                AuthenticationConstants.Broker.BROKER_RESULT_V2
+        final BrokerResult brokerResult = new Gson().fromJson(
+                resultBundle.getString(AuthenticationConstants.Broker.BROKER_RESULT_V2),
+                BrokerResult.class
         );
 
         if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)

--- a/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
+++ b/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
@@ -85,7 +85,12 @@ final class AuthUtil {
     void doSignout() {
         final int userCount = getUserCount();
         for (int i = 0; i < userCount; i++) {
-            mApplication.removeAccount(mAccounts.get(i));
+            mApplication.removeAccount(mAccounts.get(i), new PublicClientApplication.AccountsRemovedCallback() {
+                @Override
+                public void onAccountsRemoved(Boolean isSuccess) {
+                    //TODO
+                }
+            });
         }
     }
 

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
 
         <meta-data
             android:name="com.microsoft.identity.client.ClientId"
-            android:value="b92e0ba5-f86e-4411-8e18-6b5f928d968a"/>
+            android:value="4b0db8c2-9f26-4417-8bde-3f0e3656f8e0a"/>
     </application>
 
 </manifest>

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -55,14 +55,15 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- To Test PPE:  msal7cc2dd84-bb0f-4711-8fca-4c7d01249f56 -->
                 <!-- To Test Sovereign: msalcb7faed4-b8c0-49ee-b421-f5ed16894c83 -->
-                <data android:scheme="msal9851987a-55e5-46e2-8d70-75f8dc060f21"
-                    android:host="auth" />
+                <data android:scheme="msauth"
+                    android:host= "com.microsoft.identity.client.sample.local"
+                    android:path= "/QK0hWtPIQviyU3IX8AhunaS0IY4=" />
             </intent-filter>
         </activity>
 
         <meta-data
             android:name="com.microsoft.identity.client.ClientId"
-            android:value="9851987a-55e5-46e2-8d70-75f8dc060f21"/>
+            android:value="b92e0ba5-f86e-4411-8e18-6b5f928d968a"/>
     </application>
 
 </manifest>

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -37,9 +37,6 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TextView;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.UiBehavior;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.ui.browser.Browser;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -37,6 +37,9 @@ import android.widget.Spinner;
 import android.widget.Switch;
 import android.widget.TextView;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.UiBehavior;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.ui.browser.Browser;
@@ -106,9 +109,10 @@ public class AcquireTokenFragment extends Fragment {
         mAcquireTokenSilent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                if (mSelectAccount.getSelectedItem() != null) {
-                    mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
-                }
+//                if (mSelectAccount.getSelectedItem() != null) {
+//                    IAccount account = new Gson().fromJson(mSelectAccount.getSelectedItem().toString(), IAccount.class);
+//                    mLoginhint.setText(account.getAccountIdentifier().getIdentifier());
+//                }
                 mOnFragmentInteractionListener.onAcquireTokenSilentClicked(getCurrentRequestOptions());
             }
         });

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -109,10 +109,9 @@ public class AcquireTokenFragment extends Fragment {
         mAcquireTokenSilent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-//                if (mSelectAccount.getSelectedItem() != null) {
-//                    IAccount account = new Gson().fromJson(mSelectAccount.getSelectedItem().toString(), IAccount.class);
-//                    mLoginhint.setText(account.getAccountIdentifier().getIdentifier());
-//                }
+                if (mSelectAccount.getSelectedItem() != null) {
+                    mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
+                }
                 mOnFragmentInteractionListener.onAcquireTokenSilentClicked(getCurrentRequestOptions());
             }
         });

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -238,7 +238,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     public void onRemoveUserClicked(final String username) {
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback<List<IAccount>>() {
             @Override
             public void onAccountsLoaded(List<IAccount> accountsToRemove) {
                 for (final IAccount accountToRemove : accountsToRemove) {
@@ -269,9 +269,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     public void onAcquireTokenSilentClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
         prepareRequestParameters(requestOptions);
 
-        mApplication.getAccount(requestOptions.getLoginHint().trim(), new PublicClientApplication.AccountLoadedCallback() {
+        mApplication.getAccount(requestOptions.getLoginHint().trim(), new PublicClientApplication.AccountsLoadedCallback<IAccount>() {
             @Override
-            public void onAccountLoaded(IAccount account) {
+            public void onAccountsLoaded(IAccount account) {
                 if (null != account) {
                     callAcquireTokenSilent(mScopes, account, mForceRefresh);
                 } else {
@@ -283,7 +283,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     @Override
     public void bindSelectAccountSpinner(final Spinner selectUser) {
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback<List<IAccount>>() {
             @Override
             public void onAccountsLoaded(final List<IAccount> accounts) {
                 final ArrayAdapter<String> userAdapter = new ArrayAdapter<>(

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -269,7 +269,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     public void onAcquireTokenSilentClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
         prepareRequestParameters(requestOptions);
 
-        //final IAccount requestAccount = getAccount();
         mApplication.getAccount(requestOptions.getLoginHint().trim(), new PublicClientApplication.AccountLoadedCallback() {
             @Override
             public void onAccountLoaded(IAccount account) {
@@ -280,25 +279,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 }
             }
         });
-//        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
-//            @Override
-//            public void onAccountsLoaded(final List<IAccount> accounts) {
-//                IAccount requestAccount = null;
-//
-//                for (final IAccount account : accounts) {
-//                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
-//                        requestAccount = account;
-//                        break;
-//                    }
-//                }
-//
-//                if (null != requestAccount) {
-//                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
-//                } else {
-//                    showMessage("No account found matching loginHint");
-//                }
-//            }
-//        });
     }
 
     @Override
@@ -310,7 +290,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                         getApplicationContext(), android.R.layout.simple_spinner_item,
                         new ArrayList<String>() {{
                             for (IAccount account : accounts)
-                                add(account.getUsername());
+                                add(account.getAccountIdentifier().getIdentifier());
                         }}
                 );
                 userAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -270,25 +270,35 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         prepareRequestParameters(requestOptions);
 
         //final IAccount requestAccount = getAccount();
-        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+        mApplication.getAccount(requestOptions.getLoginHint().trim(), new PublicClientApplication.AccountLoadedCallback() {
             @Override
-            public void onAccountsLoaded(final List<IAccount> accounts) {
-                IAccount requestAccount = null;
-
-                for (final IAccount account : accounts) {
-                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
-                        requestAccount = account;
-                        break;
-                    }
-                }
-
-                if (null != requestAccount) {
-                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
+            public void onAccountLoaded(IAccount account) {
+                if (null != account) {
+                    callAcquireTokenSilent(mScopes, account, mForceRefresh);
                 } else {
                     showMessage("No account found matching loginHint");
                 }
             }
         });
+//        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+//            @Override
+//            public void onAccountsLoaded(final List<IAccount> accounts) {
+//                IAccount requestAccount = null;
+//
+//                for (final IAccount account : accounts) {
+//                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
+//                        requestAccount = account;
+//                        break;
+//                    }
+//                }
+//
+//                if (null != requestAccount) {
+//                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
+//                } else {
+//                    showMessage("No account found matching loginHint");
+//                }
+//            }
+//        });
     }
 
     @Override

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -65,7 +65,7 @@ public class UsersFragment extends Fragment {
         mUserList = view.findViewById(R.id.user_list);
 
         final PublicClientApplication pca = ((MainActivity) this.getActivity()).getPublicClientApplication();
-        pca.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+        pca.getAccounts(new PublicClientApplication.AccountsLoadedCallback<List<IAccount>>() {
             @Override
             public void onAccountsLoaded(final List<IAccount> accounts) {
                 mGson = new GsonBuilder().setPrettyPrinting().create();

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -1,7 +1,7 @@
 {
-  "client_id" : "9851987a-55e5-46e2-8d70-75f8dc060f21",
+  "client_id" : "b92e0ba5-f86e-4411-8e18-6b5f928d968a",
   "authorization_user_agent" : "DEFAULT",
-  "redirect_uri" : "msal9851987a-55e5-46e2-8d70-75f8dc060f21://auth",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
   "authorities" : [

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -1,5 +1,5 @@
 {
-  "client_id" : "b92e0ba5-f86e-4411-8e18-6b5f928d968a",
+  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
   "multiple_clouds_supported":true,

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -1,7 +1,7 @@
 {
-  "client_id" : "9851987a-55e5-46e2-8d70-75f8dc060f21",
+  "client_id" : "2523b71d-3ac3-4aea-833d-7096286ec643",
   "authorization_user_agent" : "WEBVIEW",
-  "redirect_uri" : "msal9851987a-55e5-46e2-8d70-75f8dc060f21://auth",
+  "redirect_uri" : "msauth://com.azuresamples.msalandroidapp/IcB5PxIyvbLkbFVtBI%2FitkW%2Fejk%3D",
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -1,5 +1,5 @@
 {
-  "client_id" : "2523b71d-3ac3-4aea-833d-7096286ec643",
+  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.azuresamples.msalandroidapp/IcB5PxIyvbLkbFVtBI%2FitkW%2Fejk%3D",
   "authorities" : [


### PR DESCRIPTION
**Problem**
Currently MSAL getAccount expects a homeAccountIdentifier.  I think we should just an identifier.  This will allow for a simpler migration for customers who've already persisted the object id of the user in their system.

The oid is the obejct id, which should be the same value of local account id. For the accounts with same home accout id, the local account ids differ with tenants. 

**Solution**
Add the API to retrieve the account with oid
Remove the API to getAccount() with homeAccountId, because the aim here is to restrict the retrieving with oid only.

Also fixed the redirect uri bug founding during the E2E testing
- Update the redirectUri generation with the new format