### PR TITLE
Add APIs for acquireToken with resource id

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -716,40 +716,6 @@ public final class PublicClientApplication {
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
      *
-     * @param activity    Non-null {@link Activity} that is used as the parent activity for launching the {@link AuthenticationActivity}.
-     *      *                 All apps doing an interactive request are required to call the
-     *      *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *      *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource    The non-null string of resource identifier.
-     * @param callback    The {@link AuthenticationCallback} to receive the result back.
-     *      *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *      *                 back via {@link AuthenticationCallback#onCancel()}.
-     *      *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *      *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *      *                 3) All the other errors will be sent back via
-     *      *                 {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                null, // uiBehavior
-                null, // extraQueryParams
-                null, // extraScopes
-                null, // authority
-                callback,
-                null, // loginHint
-                null // claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
      * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
      *                  All the apps doing interactive request are required to call the
      *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
@@ -788,43 +754,6 @@ public final class PublicClientApplication {
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
      *
-     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                  All the apps doing interactive request are required to call the
-     *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                  activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource  The non-null string of resource identifier.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                  back via {@link AuthenticationCallback#onCancel()}.
-     *                  2) If the sdk successfully receives the token back, result will be sent back via
-     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                  3) All the other errors will be sent back via
-     *                  {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                null, // uiBehavior
-                null, // extraQueryParams
-                null, // extraScopes
-                null, // authority
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
      * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
      *                             All the apps doing interactive request are required to call the
      *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
@@ -871,47 +800,6 @@ public final class PublicClientApplication {
      *                             All the apps doing interactive request are required to call the
      *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
      *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource             The non-null string of resource identifier.
-     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                             which will have the UPN pre-populated.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameters sent to authorize endpoint.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                uiBehavior,
-                extraQueryParameters,
-                null, // extraScopes
-                null, // authority
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
      * @param scopes               The non-null array of scopes to be requested for the access token.
      *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
@@ -935,47 +823,6 @@ public final class PublicClientApplication {
         acquireToken(
                 activity,
                 scopes,
-                account,
-                uiBehavior,
-                extraQueryParameters,
-                null, // extraScopes
-                null, // authority
-                callback,
-                null, // loginHint
-                null // claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource             The non-null string of resource identifier.
-     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
-     *                             error will be returned.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final IAccount account,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
                 account,
                 uiBehavior,
                 extraQueryParameters,
@@ -1041,51 +888,6 @@ public final class PublicClientApplication {
      *                             All the apps doing interactive request are required to call the
      *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
      *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource             The non-null string of resource identifier.
-     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                             which will have the UPN pre-populated.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority            Optional. Can be passed to override the configured authority.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @Nullable final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @Nullable final String[] extraScopesToConsent,
-                             @Nullable final String authority,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                uiBehavior,
-                extraQueryParameters,
-                extraScopesToConsent,
-                authority,
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
      * @param scopes               The non-null array of scopes to be requested for the access token.
      *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
@@ -1113,51 +915,6 @@ public final class PublicClientApplication {
         acquireToken(
                 activity,
                 scopes,
-                account,
-                uiBehavior,
-                extraQueryParameters,
-                extraScopesToConsent,
-                authority,
-                callback,
-                null, // loginHint
-                null //claimsRequest
-        );
-    }
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     *                             All the apps doing interactive request are required to call the
-     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
-     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
-     * @param resource             The non-null string of resource identifier.
-     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
-     *                             will be returned.
-     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
-     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
-     * @param extraScopesToConsent Optional. The extra scopes to request consent.
-     * @param authority            Optional. Can be passed to override the configured authority.
-     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                             back via {@link AuthenticationCallback#onCancel()}.
-     *                             2) If the sdk successfully receives the token back, result will be sent back via
-     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                             3) All the other errors will be sent back via
-     *                             {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final IAccount account,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @Nullable final String[] extraScopesToConsent,
-                             @Nullable final String authority,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
                 account,
                 uiBehavior,
                 extraQueryParameters,
@@ -1294,31 +1051,6 @@ public final class PublicClientApplication {
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param resource The non-null string of resource identifier.
-     * @param account  {@link IAccount} represents the account to silently request tokens.
-     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                 sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                 Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireTokenSilentAsync(@NonNull final String resource,
-                                        @NonNull final IAccount account,
-                                        @NonNull final AuthenticationCallback callback) {
-        acquireTokenSilent(
-                mapResourceToDefaultScope(resource),
-                account,
-                null, // authority
-                false, // forceRefresh
-                null, // claimsRequest
-                callback
-        );
-    }
-
-    /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
-     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
-     * or it fails the refresh, exception will be sent back via callback.
-     *
      * @param scopes       The non-null array of scopes to be requested for the access token.
      *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account      {@link IAccount} represents the account to silently request tokens.
@@ -1336,35 +1068,6 @@ public final class PublicClientApplication {
                                         @NonNull final AuthenticationCallback callback) {
         acquireTokenSilent(
                 scopes,
-                account,
-                authority,
-                forceRefresh,
-                null, // claimsRequest
-                callback
-        );
-    }
-
-    /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token;
-     * If no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token.
-     * If refresh token does not exist or it fails the refresh, exception will be sent back via callback.
-     *
-     * @param resource     The non-null string of resource identifier.
-     * @param account      {@link IAccount} represents the account to silently request tokens.
-     * @param authority    Optional. Can be passed to override the configured authority.
-     * @param forceRefresh True if the request is forced to refresh, false otherwise.
-     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                     sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                     Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
-     */
-    public void acquireTokenSilentAsync(@NonNull final String resource,
-                                        @NonNull final IAccount account,
-                                        @Nullable final String authority,
-                                        final boolean forceRefresh,
-                                        @NonNull final AuthenticationCallback callback) {
-        acquireTokenSilent(
-                mapResourceToDefaultScope(resource),
                 account,
                 authority,
                 forceRefresh,
@@ -1648,14 +1351,5 @@ public final class PublicClientApplication {
 
     private OAuth2TokenCache<?, ?, ?> getOAuth2TokenCache() {
         return initCommonCache(mPublicClientConfiguration.getAppContext());
-    }
-
-    @VisibleForTesting
-    static String[] mapResourceToDefaultScope(@NonNull String resource) {
-        if (!StringUtil.isEmpty(resource)) {
-            return new String[]{resource.toLowerCase().trim() + "/.default"};
-        } else {
-            return new String[]{""};
-        }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1650,9 +1650,10 @@ public final class PublicClientApplication {
         return initCommonCache(mPublicClientConfiguration.getAppContext());
     }
 
-    private static String[] mapResourceToDefaultScope(@NonNull String resource) {
+    @VisibleForTesting
+    static String[] mapResourceToDefaultScope(@NonNull String resource) {
         if (!StringUtil.isEmpty(resource)) {
-            return new String[]{resource + "/.default"};
+            return new String[]{resource.toLowerCase().trim() + "/.default"};
         } else {
             return new String[]{""};
         }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -712,6 +712,133 @@ public final class PublicClientApplication {
         );
     }
 
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                null, // uiBehavior
+                null, // extraQueryParams
+                null, // extraScopes
+                null, // authority
+                callback,
+                null, // loginHint
+                null // claimsRequest
+        );
+    }
+
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                null, // uiBehavior
+                null, // extraQueryParams
+                null, // extraScopes
+                null, // authority
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                uiBehavior,
+                extraQueryParameters,
+                null, // extraScopes
+                null, // authority
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                account,
+                uiBehavior,
+                extraQueryParameters,
+                null, // extraScopes
+                null, // authority
+                callback,
+                null, // loginHint
+                null // claimsRequest
+        );
+    }
+
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @Nullable final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @Nullable final String[] extraScopesToConsent,
+                             @Nullable final String authority,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                uiBehavior,
+                extraQueryParameters,
+                extraScopesToConsent,
+                authority,
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @Nullable final String[] extraScopesToConsent,
+                             @Nullable final String authority,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                account,
+                uiBehavior,
+                extraQueryParameters,
+                extraScopesToConsent,
+                authority,
+                callback,
+                null, // loginHint
+                null //claimsRequest
+        );
+    }
+
+    private static String[] mapResourceToDefaultScope(@NonNull String resource) {
+        if (!StringUtil.isEmpty(resource)) {
+            return new String[]{resource + "/.default"};
+        } else {
+            return new String[]{""};
+        }
+    }
+
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -712,6 +712,23 @@ public final class PublicClientApplication {
         );
     }
 
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity    Non-null {@link Activity} that is used as the parent activity for launching the {@link AuthenticationActivity}.
+     *      *                 All apps doing an interactive request are required to call the
+     *      *                 {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *      *                 activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource    The non-null string of resource identifier.
+     * @param callback    The {@link AuthenticationCallback} to receive the result back.
+     *      *                 1) If user cancels the flow by pressing the device back button, the result will be sent
+     *      *                 back via {@link AuthenticationCallback#onCancel()}.
+     *      *                 2) If the sdk successfully receives the token back, result will be sent back via
+     *      *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *      *                 3) All the other errors will be sent back via
+     *      *                 {@link AuthenticationCallback#onError(MsalException)}.
+     */
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String resource,
                              @NonNull final AuthenticationCallback callback) {
@@ -727,116 +744,6 @@ public final class PublicClientApplication {
                 null, // loginHint
                 null // claimsRequest
         );
-    }
-
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                null, // uiBehavior
-                null, // extraQueryParams
-                null, // extraScopes
-                null, // authority
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                uiBehavior,
-                extraQueryParameters,
-                null, // extraScopes
-                null, // authority
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final IAccount account,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                account,
-                uiBehavior,
-                extraQueryParameters,
-                null, // extraScopes
-                null, // authority
-                callback,
-                null, // loginHint
-                null // claimsRequest
-        );
-    }
-
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final String loginHint,
-                             @Nullable final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @Nullable final String[] extraScopesToConsent,
-                             @Nullable final String authority,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                null, // account
-                uiBehavior,
-                extraQueryParameters,
-                extraScopesToConsent,
-                authority,
-                callback,
-                loginHint,
-                null // claimsRequest
-        );
-    }
-
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String resource,
-                             @Nullable final IAccount account,
-                             @NonNull final UiBehavior uiBehavior,
-                             @Nullable final List<Pair<String, String>> extraQueryParameters,
-                             @Nullable final String[] extraScopesToConsent,
-                             @Nullable final String authority,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                mapResourceToDefaultScope(resource),
-                account,
-                uiBehavior,
-                extraQueryParameters,
-                extraScopesToConsent,
-                authority,
-                callback,
-                null, // loginHint
-                null //claimsRequest
-        );
-    }
-
-    private static String[] mapResourceToDefaultScope(@NonNull String resource) {
-        if (!StringUtil.isEmpty(resource)) {
-            return new String[]{resource + "/.default"};
-        } else {
-            return new String[]{""};
-        }
     }
 
     /**
@@ -866,6 +773,43 @@ public final class PublicClientApplication {
         acquireToken(
                 activity,
                 scopes,
+                null, // account
+                null, // uiBehavior
+                null, // extraQueryParams
+                null, // extraScopes
+                null, // authority
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                  All the apps doing interactive request are required to call the
+     *                  {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                  activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource  The non-null string of resource identifier.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                  back via {@link AuthenticationCallback#onCancel()}.
+     *                  2) If the sdk successfully receives the token back, result will be sent back via
+     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                  3) All the other errors will be sent back via
+     *                  {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
                 null, // account
                 null, // uiBehavior
                 null, // extraQueryParams
@@ -927,6 +871,47 @@ public final class PublicClientApplication {
      *                             All the apps doing interactive request are required to call the
      *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
      *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource             The non-null string of resource identifier.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameters sent to authorize endpoint.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                uiBehavior,
+                extraQueryParameters,
+                null, // extraScopes
+                null, // authority
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
      * @param scopes               The non-null array of scopes to be requested for the access token.
      *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
@@ -950,6 +935,47 @@ public final class PublicClientApplication {
         acquireToken(
                 activity,
                 scopes,
+                account,
+                uiBehavior,
+                extraQueryParameters,
+                null, // extraScopes
+                null, // authority
+                callback,
+                null, // loginHint
+                null // claimsRequest
+        );
+    }
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource             The non-null string of resource identifier.
+     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user,
+     *                             error will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
                 account,
                 uiBehavior,
                 extraQueryParameters,
@@ -1015,6 +1041,51 @@ public final class PublicClientApplication {
      *                             All the apps doing interactive request are required to call the
      *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
      *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource             The non-null string of resource identifier.
+     * @param loginHint            Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                             which will have the UPN pre-populated.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraScopesToConsent Optional. The extra scopes to request consent.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final String loginHint,
+                             @Nullable final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @Nullable final String[] extraScopesToConsent,
+                             @Nullable final String authority,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
+                null, // account
+                uiBehavior,
+                extraQueryParameters,
+                extraScopesToConsent,
+                authority,
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
+    }
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
      * @param scopes               The non-null array of scopes to be requested for the access token.
      *                             MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
@@ -1042,6 +1113,51 @@ public final class PublicClientApplication {
         acquireToken(
                 activity,
                 scopes,
+                account,
+                uiBehavior,
+                extraQueryParameters,
+                extraScopesToConsent,
+                authority,
+                callback,
+                null, // loginHint
+                null //claimsRequest
+        );
+    }
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity             Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     *                             All the apps doing interactive request are required to call the
+     *                             {@link PublicClientApplication#handleInteractiveRequestRedirect(int, int, Intent)} within the calling
+     *                             activity {@link Activity#onActivityResult(int, int, Intent)}.
+     * @param resource             The non-null string of resource identifier.
+     * @param account              Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different user, error
+     *                             will be returned.
+     * @param uiBehavior           The {@link UiBehavior} for prompting behavior. By default, the sdk use {@link UiBehavior#SELECT_ACCOUNT}.
+     * @param extraQueryParameters Optional. The extra query parameter sent to authorize endpoint.
+     * @param extraScopesToConsent Optional. The extra scopes to request consent.
+     * @param authority            Optional. Can be passed to override the configured authority.
+     * @param callback             The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                             1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                             back via {@link AuthenticationCallback#onCancel()}.
+     *                             2) If the sdk successfully receives the token back, result will be sent back via
+     *                             {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                             3) All the other errors will be sent back via
+     *                             {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String resource,
+                             @Nullable final IAccount account,
+                             @NonNull final UiBehavior uiBehavior,
+                             @Nullable final List<Pair<String, String>> extraQueryParameters,
+                             @Nullable final String[] extraScopesToConsent,
+                             @Nullable final String authority,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                mapResourceToDefaultScope(resource),
                 account,
                 uiBehavior,
                 extraQueryParameters,
@@ -1178,6 +1294,31 @@ public final class PublicClientApplication {
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
+     * @param resource The non-null string of resource identifier.
+     * @param account  {@link IAccount} represents the account to silently request tokens.
+     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                 sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                 Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireTokenSilentAsync(@NonNull final String resource,
+                                        @NonNull final IAccount account,
+                                        @NonNull final AuthenticationCallback callback) {
+        acquireTokenSilent(
+                mapResourceToDefaultScope(resource),
+                account,
+                null, // authority
+                false, // forceRefresh
+                null, // claimsRequest
+                callback
+        );
+    }
+
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
      * @param scopes       The non-null array of scopes to be requested for the access token.
      *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account      {@link IAccount} represents the account to silently request tokens.
@@ -1195,6 +1336,35 @@ public final class PublicClientApplication {
                                         @NonNull final AuthenticationCallback callback) {
         acquireTokenSilent(
                 scopes,
+                account,
+                authority,
+                forceRefresh,
+                null, // claimsRequest
+                callback
+        );
+    }
+
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token;
+     * If no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token.
+     * If refresh token does not exist or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param resource     The non-null string of resource identifier.
+     * @param account      {@link IAccount} represents the account to silently request tokens.
+     * @param authority    Optional. Can be passed to override the configured authority.
+     * @param forceRefresh True if the request is forced to refresh, false otherwise.
+     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                     sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                     Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
+     */
+    public void acquireTokenSilentAsync(@NonNull final String resource,
+                                        @NonNull final IAccount account,
+                                        @Nullable final String authority,
+                                        final boolean forceRefresh,
+                                        @NonNull final AuthenticationCallback callback) {
+        acquireTokenSilent(
+                mapResourceToDefaultScope(resource),
                 account,
                 authority,
                 forceRefresh,
@@ -1478,5 +1648,13 @@ public final class PublicClientApplication {
 
     private OAuth2TokenCache<?, ?, ?> getOAuth2TokenCache() {
         return initCommonCache(mPublicClientConfiguration.getAppContext());
+    }
+
+    private static String[] mapResourceToDefaultScope(@NonNull String resource) {
+        if (!StringUtil.isEmpty(resource)) {
+            return new String[]{resource + "/.default"};
+        } else {
+            return new String[]{""};
+        }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -181,6 +181,8 @@ abstract class TokenParameters {
         public B withScopes(List<String> scopes) {
             if (null != mScopes) {
                 throw new IllegalArgumentException("Scopes is already set.");
+            } else if (null == scopes || scopes.isEmpty()) {
+                throw new IllegalArgumentException("Empty scopes list.");
             } else {
                 mScopes = scopes;
             }
@@ -214,12 +216,14 @@ abstract class TokenParameters {
                 throw new IllegalArgumentException(
                         "Scopes is already set. Scopes and resources cannot be combined in a single request."
                 );
-            } else if (!StringUtil.isEmpty(resource)) {
+            } else if (StringUtil.isEmpty(resource)) {
+                throw new IllegalArgumentException(
+                        "Empty resource string."
+                );
+            } else {
                 mScopes = new ArrayList<String>() {{
                     add(resource.toLowerCase().trim() + "/.default");
                 }};
-            } else {
-                mScopes = new ArrayList<>();
             }
 
             return self();

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -25,7 +25,9 @@ package com.microsoft.identity.client;
 
 import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.util.StringUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -199,6 +201,18 @@ abstract class TokenParameters {
 
         public B callback(AuthenticationCallback callback) {
             mCallback = callback;
+            return self();
+        }
+
+        public B withResource(final String resource) {
+            if (!StringUtil.isEmpty(resource)) {
+                mScopes = new ArrayList<String>() {{
+                    add(resource.toLowerCase().trim() + "/.default");
+                }};
+            } else {
+                mScopes = new ArrayList<>();
+            }
+
             return self();
         }
 

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -179,7 +179,12 @@ abstract class TokenParameters {
         private AuthenticationCallback mCallback;
 
         public B withScopes(List<String> scopes) {
-            mScopes = scopes;
+            if (null != mScopes) {
+                throw new IllegalArgumentException("Scopes is already set.");
+            } else {
+                mScopes = scopes;
+            }
+
             return self();
         }
 
@@ -205,7 +210,11 @@ abstract class TokenParameters {
         }
 
         public B withResource(final String resource) {
-            if (!StringUtil.isEmpty(resource)) {
+            if (null != mScopes) {
+                throw new IllegalArgumentException(
+                        "Scopes is already set. Scopes and resources cannot be combined in a single request."
+                );
+            } else if (!StringUtil.isEmpty(resource)) {
                 mScopes = new ArrayList<String>() {{
                     add(resource.toLowerCase().trim() + "/.default");
                 }};

--- a/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
+++ b/testapps/sample/src/main/java/com/microsoft/identity/client/sample/AuthUtil.java
@@ -85,7 +85,12 @@ final class AuthUtil {
     void doSignout() {
         final int userCount = getUserCount();
         for (int i = 0; i < userCount; i++) {
-            mApplication.removeAccount(mAccounts.get(i));
+            mApplication.removeAccount(mAccounts.get(i), new PublicClientApplication.AccountsRemovedCallback() {
+                @Override
+                public void onAccountsRemoved(Boolean isSuccess) {
+                    //TODO
+                }
+            });
         }
     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -63,6 +63,8 @@ public class AcquireTokenFragment extends Fragment {
     private Button mClearCache;
     private Button mAcquireToken;
     private Button mAcquireTokenSilent;
+    private Button mAcquireTokenWithResource;
+    private Button mAcquireTokenSilentWithResource;
     private Spinner mSelectAccount;
     private Spinner mAADEnvironments;
 
@@ -89,6 +91,8 @@ public class AcquireTokenFragment extends Fragment {
         mClearCache = view.findViewById(R.id.btn_clearCache);
         mAcquireToken = view.findViewById(R.id.btn_acquiretoken);
         mAcquireTokenSilent = view.findViewById(R.id.btn_acquiretokensilent);
+        mAcquireTokenWithResource = view.findViewById(R.id.btn_acquiretokenWithResource);
+        mAcquireTokenSilentWithResource = view.findViewById(R.id.btn_acquiretokensilentWithResource);
         mAADEnvironments = view.findViewById(R.id.environment);
 
         bindSpinnerChoice(mAuthority, Constants.AuthorityType.class);
@@ -100,6 +104,23 @@ public class AcquireTokenFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 mOnFragmentInteractionListener.onAcquireTokenClicked(getCurrentRequestOptions());
+            }
+        });
+
+        mAcquireTokenSilent.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                if (mSelectAccount.getSelectedItem() != null) {
+                    mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
+                }
+                mOnFragmentInteractionListener.onAcquireTokenSilentClicked(getCurrentRequestOptions());
+            }
+        });
+
+        mAcquireTokenWithResource.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mOnFragmentInteractionListener.onAcquireTokenWithResourceClicked(getCurrentRequestOptions());
             }
         });
 
@@ -279,6 +300,10 @@ public class AcquireTokenFragment extends Fragment {
         void onAcquireTokenClicked(final RequestOptions requestOptions);
 
         void onAcquireTokenSilentClicked(final RequestOptions requestOptions);
+
+        void onAcquireTokenWithResourceClicked(final RequestOptions requestOptions);
+
+        void onAcquireTokenSilentWithResourceClicked(final RequestOptions requestOptions);
 
         void bindSelectAccountSpinner(Spinner selectAccount);
     }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -124,13 +124,13 @@ public class AcquireTokenFragment extends Fragment {
             }
         });
 
-        mAcquireTokenSilent.setOnClickListener(new View.OnClickListener() {
+        mAcquireTokenSilentWithResource.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 if (mSelectAccount.getSelectedItem() != null) {
                     mLoginhint.setText(mSelectAccount.getSelectedItem().toString());
                 }
-                mOnFragmentInteractionListener.onAcquireTokenSilentClicked(getCurrentRequestOptions());
+                mOnFragmentInteractionListener.onAcquireTokenSilentWithResourceClicked(getCurrentRequestOptions());
             }
         });
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -289,8 +289,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
                 }
 
                 if (null != requestAccount) {
-                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
-
                     AcquireTokenSilentParameters.Builder builder = new AcquireTokenSilentParameters.Builder();
                     AcquireTokenSilentParameters acquireTokenSilentParameters =
                             builder.withResource(mResource)

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -43,6 +43,8 @@ import android.widget.RelativeLayout;
 import android.widget.Spinner;
 import android.widget.Toast;
 
+import com.microsoft.identity.client.AcquireTokenParameters;
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AuthenticationCallback;
 import com.microsoft.identity.client.AuthenticationResult;
 import com.microsoft.identity.client.IAccount;
@@ -63,6 +65,7 @@ import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import javax.crypto.SecretKey;
@@ -84,6 +87,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     private String mAuthority;
     private String[] mScopes;
+    private String mResource;
     private UiBehavior mUiBehavior;
     private String mLoginHint;
     private List<Pair<String, String>> mExtraQp;
@@ -237,6 +241,72 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         callAcquireToken(mScopes, mUiBehavior, mLoginHint, mExtraQp, mExtraScopesToConsent);
     }
 
+    @Override
+    public void  onAcquireTokenWithResourceClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
+        prepareRequestParameters(requestOptions);
+
+        if (mEnablePiiLogging) {
+            Logger.getInstance().setEnableLogcatLog(mEnablePiiLogging);
+        }
+
+        if (mEnablePiiLogging) {
+            Logger.getInstance().setEnablePII(true);
+        } else {
+            Logger.getInstance().setEnablePII(false);
+        }
+
+        try {
+            AcquireTokenParameters.Builder builder = new AcquireTokenParameters.Builder();
+            AcquireTokenParameters acquireTokenParameters = builder.startAuthorizationFromActivity(this)
+                    .withResource(mResource)
+                    .withUiBehavior(mUiBehavior)
+                    .withAuthorizationQueryStringParameters(mExtraQp)
+                    .callback(getAuthenticationCallback())
+                    .withLoginHint(mLoginHint)
+                    .build();
+
+            mApplication.acquireTokenAsync(acquireTokenParameters);
+        } catch (IllegalArgumentException e) {
+            showMessage(e.getMessage());
+        }
+    }
+
+    @Override
+    public void onAcquireTokenSilentWithResourceClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
+        prepareRequestParameters(requestOptions);
+
+        //final IAccount requestAccount = getAccount();
+        mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+            @Override
+            public void onAccountsLoaded(final List<IAccount> accounts) {
+                IAccount requestAccount = null;
+
+                for (final IAccount account : accounts) {
+                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
+                        requestAccount = account;
+                        break;
+                    }
+                }
+
+                if (null != requestAccount) {
+                    callAcquireTokenSilent(mScopes, requestAccount, mForceRefresh);
+
+                    AcquireTokenSilentParameters.Builder builder = new AcquireTokenSilentParameters.Builder();
+                    AcquireTokenSilentParameters acquireTokenSilentParameters =
+                            builder.withResource(mResource)
+                                    .forAccount(requestAccount)
+                                    .forceRefresh(mForceRefresh)
+                                    .callback(getAuthenticationCallback())
+                                    .build();
+
+                    mApplication.acquireTokenSilentAsync(acquireTokenSilentParameters);
+                } else {
+                    showMessage("No account found matching loginHint");
+                }
+            }
+        });
+    }
+
     public void onRemoveUserClicked(final String username) {
         mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
             @Override
@@ -326,6 +396,7 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         }
 
         mScopes = scopes.toLowerCase().split(" ");
+        mResource = scopes.toLowerCase();
         mExtraScopesToConsent = requestOptions.getExtraScopesToConsent() == null ? null : requestOptions.getExtraScopesToConsent().toLowerCase().split(" ");
 
         if (userAgent.name().equalsIgnoreCase("BROWSER")) {

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -24,6 +24,7 @@
   ~ //  THE SOFTWARE.
   -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
     <LinearLayout
@@ -346,6 +347,51 @@
                 android:id="@+id/txt_output"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent" />
+
+            <TextView
+                android:id="@+id/txt_output2"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:paddingTop="5dp"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_alignParentBottom="true"
+                android:gravity="center"
+                android:orientation="horizontal">
+
+                <Button
+                    android:id="@+id/btn_acquiretokenWithResource"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/acquire_token_with_resource_button" />
+
+                <Button
+                    android:id="@+id/btn_acquiretokensilentWithResource"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/acquire_token_silent_with_resource_button" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/txt_output3"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <TextView
+                android:id="@+id/txt_output4"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
         </RelativeLayout>
 
     </LinearLayout>

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="auth_user_agent">User Agent</string>
     <string name="acquire_token_button">AcquireToken</string>
     <string name="acquire_token_silent_button">AcquireTokenSilent</string>
+    <string name="acquire_token_with_resource_button">AT w/ Resource</string>
+    <string name="acquire_token_silent_with_resource_button">ATS w/ Resource</string>
     <string name="result_hint_text">Acquire token interactive/silent flow result data goes here...</string>
     <string name="log_hint_text">Log data goes here...</string>
     <string name="clear_log_button">clear logs</string>


### PR DESCRIPTION
Add the builder method for `withResource(String resource)` into TokenParameters.java, which adapts the resource string into scope string array.

The developer can only use either resource string or scope string array when creating the acquireTokenParameter and acquireTokenSilentParameter, not both at the same time. If the dev sets the scope after setting the resource string, the scope array will be overwritten.

To acquireToken interactively
```java
 AcquireTokenParameters.Builder builder = new AcquireTokenParameters.Builder();
 AcquireTokenParameters acquireTokenParameters = builder.startAuthorizationFromActivity(this)
                    .withResource(mResource)
                    .withUiBehavior(mUiBehavior)
                    .withAuthorizationQueryStringParameters(mExtraQp)
                    .callback(getAuthenticationCallback())
                    .withLoginHint(mLoginHint)
                    .build();

 mApplication.acquireTokenAsync(acquireTokenParameters);
```

To aquireToken silently
```java
mApplication.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
            @Override
            public void onAccountsLoaded(final List<IAccount> accounts) {
                IAccount requestAccount = null;

                for (final IAccount account : accounts) {
                    if (account.getUsername().equalsIgnoreCase(requestOptions.getLoginHint().trim())) {
                        requestAccount = account;
                        break;
                    }
                }

                if (null != requestAccount) {
                    AcquireTokenSilentParameters.Builder builder = new AcquireTokenSilentParameters.Builder();
                    AcquireTokenSilentParameters acquireTokenSilentParameters =
                            builder.withResource(mResource)
                                    .forAccount(requestAccount)
                                    .forceRefresh(mForceRefresh)
                                    .callback(getAuthenticationCallback())
                                    .build();

                    mApplication.acquireTokenSilentAsync(acquireTokenSilentParameters);
                } else {
                    showMessage("No account found matching loginHint");
                }
            }
        });
```