### PR TITLE
Implements SingleAccount and MultipleAccountPublicCilentApplication

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -64,7 +64,7 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
     void removeAccount(@Nullable final IAccount account, final AccountRemovedListener callback);
 
     /**
-     * Listener callback for asynchronous loading of msal IAccount accounts.
+     * Callback for asynchronous loading of msal IAccount accounts.
      */
     interface AccountsLoadedCallback {
         /**
@@ -76,7 +76,7 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
     }
 
     /**
-     * Listener callback for asynchronous loading of broker AccountRecord accounts.
+     * Callback for asynchronous loading of broker AccountRecord accounts (in Multiple account mode).
      */
     interface BrokerAccountsLoadedCallback {
         /**

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -74,15 +74,4 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
          */
         void onAccountsLoaded(List<IAccount> accounts);
     }
-
-    /**
-     * Callback for asynchronous loading of broker AccountRecord accounts (in Multiple account mode).
-     */
-    interface BrokerAccountsLoadedCallback {
-        /**
-         * Called once Accounts have been loaded from the broker.
-         * @param accountRecords The accountRecords in broker.
-         */
-        void onAccountsLoaded(List<AccountRecord> accountRecords);
-    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -53,7 +53,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * @param callback a callback to be invoked when the operation finishes.
      * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
      */
-    void globalSignOut(final AccountRemovedListener callback) throws MsalClientException;
+    void removeCurrentAccount(final AccountRemovedListener callback) throws MsalClientException;
 
     /**
      * Callback for asynchronous loading of the msal IAccount account.

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -76,17 +76,4 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
          * */
         void onAccountChanged(final IAccount priorAccount, final IAccount currentAccount);
     }
-
-    /**
-     * Callback for asynchronous loading of broker AccountRecord account (in Single account mode).
-     */
-    interface SingleAccountLoadedCallback {
-
-        /**
-         * Called once the signed-in account (if there is any), has been loaded from the broker.
-         * @param accountRecord The accountRecord in broker. This could be null.
-         */
-        void onAccountLoaded(@Nullable final AccountRecord accountRecord);
-    }
-
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -23,7 +23,10 @@
 
 package com.microsoft.identity.client;
 
+import android.support.annotation.Nullable;
+
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
 
 /**
  * An interface that contains list of operations that are available when MSAL is in 'single account' mode.
@@ -53,7 +56,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     void globalSignOut(final AccountRemovedListener callback) throws MsalClientException;
 
     /**
-     * Listener callback for asynchronous loading of the signed-in IAccount account.
+     * Callback for asynchronous loading of the msal IAccount account.
      */
     interface CurrentAccountListener {
         /**
@@ -72,6 +75,18 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
          * @param currentAccount the current signed-in account. This could be nil.
          * */
         void onAccountChanged(final IAccount priorAccount, final IAccount currentAccount);
-
     }
+
+    /**
+     * Callback for asynchronous loading of broker AccountRecord account (in Single account mode).
+     */
+    interface SingleAccountLoadedCallback {
+
+        /**
+         * Called once the signed-in account (if there is any), has been loaded from the broker.
+         * @param accountRecord The accountRecord in broker. This could be null.
+         */
+        void onAccountLoaded(@Nullable final AccountRecord accountRecord);
+    }
+
 }

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -1,0 +1,303 @@
+package com.microsoft.identity.client;
+
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
+import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
+import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
+import com.microsoft.identity.common.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
+import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
+import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
+import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.ApiDispatcher;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.migration.AdalMigrationAdapter;
+import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
+import com.microsoft.identity.common.internal.migration.TokenMigrationUtility;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
+import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
+import com.microsoft.identity.common.internal.util.StringUtil;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MultipleAccountPublicClientApplication extends PublicClientApplication
+    implements IMultipleAccountPublicClientApplication {
+    private static final String TAG = MultipleAccountPublicClientApplication.class.getSimpleName();
+
+    protected MultipleAccountPublicClientApplication(@NonNull final Context context,
+                                                     @NonNull final PublicClientApplicationConfiguration developerConfig) {
+        super(context, developerConfig);
+    }
+
+    protected MultipleAccountPublicClientApplication(@NonNull final Context context,
+                                                     @NonNull final String clientId) {
+        super(context, clientId);
+    }
+
+    protected MultipleAccountPublicClientApplication(@NonNull final Context context,
+                                                     @NonNull final String clientId,
+                                                     @NonNull final String authority) {
+        super(context, clientId, authority);
+    }
+
+    @Override
+    public void getAccounts(@NonNull final AccountsLoadedCallback callback) {
+        ApiDispatcher.initializeDiagnosticContext();
+        final String methodName = ":getAccounts";
+        final List<AccountRecord> accounts = getLocalAccounts();
+
+        final Handler handler;
+
+        if (null != Looper.myLooper() && Looper.getMainLooper() != Looper.myLooper()) {
+            handler = new Handler(Looper.myLooper());
+        } else {
+            handler = new Handler(Looper.getMainLooper());
+        }
+
+        if (accounts.isEmpty()) {
+            // Create the SharedPreferencesFileManager for the legacy accounts/credentials
+            final IStorageHelper storageHelper = new StorageHelper(mPublicClientConfiguration.getAppContext());
+            final ISharedPreferencesFileManager sharedPreferencesFileManager =
+                new SharedPreferencesFileManager(
+                    mPublicClientConfiguration.getAppContext(),
+                    "com.microsoft.aad.adal.cache",
+                    storageHelper
+                );
+
+            // Load the old TokenCacheItems as key/value JSON
+            final Map<String, String> credentials = sharedPreferencesFileManager.getAll();
+
+            final Map<String, String> redirects = new HashMap<>();
+            redirects.put(
+                mPublicClientConfiguration.mClientId, // Our client id
+                mPublicClientConfiguration.mRedirectUri // Our redirect uri
+            );
+
+            new TokenMigrationUtility<MicrosoftAccount, MicrosoftRefreshToken>()._import(
+                new AdalMigrationAdapter(
+                    mPublicClientConfiguration.getAppContext(),
+                    redirects,
+                    false
+                ),
+                credentials,
+                (IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken>) mPublicClientConfiguration.getOAuth2TokenCache(),
+                new TokenMigrationCallback() {
+                    @Override
+                    public void onMigrationFinished(int numberOfAccountsMigrated) {
+                        final String extendedMethodName = ":onMigrationFinished";
+                        com.microsoft.identity.common.internal.logging.Logger.info(
+                            TAG + methodName + extendedMethodName,
+                            "Migrated [" + numberOfAccountsMigrated + "] accounts"
+                        );
+                        // Merge migrated accounts with broker or local accounts.
+                        if (MSALControllerFactory.brokerEligible(
+                            mPublicClientConfiguration.getAppContext(),
+                            mPublicClientConfiguration.getDefaultAuthority(),
+                            mPublicClientConfiguration)) {
+                            postBrokerAndLocalAccountsResult(handler, callback);
+                        } else {
+                            postLocalAccountsResult(handler, callback);
+                        }
+                    }
+                }
+            );
+        } else {
+            // The cache contains items - mark migration as complete
+            new AdalMigrationAdapter(
+                mPublicClientConfiguration.getAppContext(),
+                null, // unused for this path
+                false
+            ).setMigrationStatus(true);
+
+            if (MSALControllerFactory.brokerEligible(
+                mPublicClientConfiguration.getAppContext(),
+                mPublicClientConfiguration.getDefaultAuthority(),
+                mPublicClientConfiguration)) {
+                postBrokerAndLocalAccountsResult(handler, callback);
+            } else {
+                postLocalAccountsResult(handler, callback);
+            }
+        }
+    }
+
+    /**
+     * Helper method which returns all the local accounts using {@link AccountsLoadedCallback}
+     * @param handler : handler to post
+     * @param callback: AccountsLoadedCallback
+     */
+    private void postLocalAccountsResult(final Handler handler, final AccountsLoadedCallback callback) {
+
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                List<IAccount> accountsToReturn = new ArrayList<>();
+                for (AccountRecord accountRecord : getLocalAccounts()) {
+                    accountsToReturn.add(AccountAdapter.adapt(accountRecord));
+                }
+
+                callback.onAccountsLoaded(accountsToReturn);
+            }
+        });
+    }
+
+    /**
+     * Helper method which returns both broker and local accounts using {@link AccountsLoadedCallback}
+     * @param handler : handler to post
+     * @param callback: AccountsLoadedCallback
+     */
+    private void postBrokerAndLocalAccountsResult(final Handler handler, final AccountsLoadedCallback callback) {
+
+        final String methodName = ":postBrokerAndLocalAccountsResult";
+
+        new BrokerMsalController().getBrokerAccounts(
+            mPublicClientConfiguration,
+            new BrokerAccountsLoadedCallback() {
+                @Override
+                public void onAccountsLoaded(final List<AccountRecord> accountRecords) {
+                    com.microsoft.identity.common.internal.logging.Logger.verbose(
+                        TAG + methodName,
+                        "Accounts loaded from broker "
+                            + (accountRecords == null ? 0 : accountRecords.size())
+                    );
+
+                    // merge account
+                    final List<IAccount> accountList = new ArrayList<>();
+                    final List<AccountRecord> accountRecordList = new ArrayList<>();
+
+                    if (accountRecords != null) {
+                        //Add broker accounts
+                        accountRecordList.addAll(accountRecords);
+                    }
+
+                    //Add local accounts
+                    accountRecordList.addAll(getLocalAccounts());
+
+                    if (accountRecordList.size() > 0) {
+                        for (AccountRecord accountRecord : accountRecordList) {
+                            accountList.add(AccountAdapter.adapt(accountRecord));
+                        }
+                    }
+                    handler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            callback.onAccountsLoaded(accountList);
+                        }
+                    });
+                }
+            });
+    }
+
+    /**
+     * Returns a List of {@link IAccount} objects for which this application has RefreshTokens.
+     *
+     * @return An immutable List of IAccount objects - empty if no IAccounts exist.
+     */
+    private List<AccountRecord> getLocalAccounts() {
+        // Grab the Accounts from the common cache
+        final List<AccountRecord> accountsInCache =
+            mPublicClientConfiguration
+                .getOAuth2TokenCache()
+                .getAccounts(
+                    null, // * wildcard
+                    mPublicClientConfiguration.getClientId()
+                );
+
+        return accountsInCache;
+    }
+
+    @Override
+    @Nullable
+    public IAccount getAccount(@NonNull final String homeAccountIdentifier,
+                               @Nullable final String authority) {
+        final String methodName = ":getAccount";
+
+        ApiDispatcher.initializeDiagnosticContext();
+
+        String realm = StringUtil.getTenantInfo(homeAccountIdentifier).second;
+
+        Authority authorityObj = Authority.getAuthorityFromAuthorityUrl(authority);
+
+        if (authorityObj instanceof AzureActiveDirectoryAuthority) {
+            final AzureActiveDirectoryAuthority aadAuthority = (AzureActiveDirectoryAuthority) authorityObj;
+            final AzureActiveDirectoryAudience audience = aadAuthority.getAudience();
+            realm = audience.getTenantId();
+        } else {
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                TAG + methodName,
+                "Provided authority was not AAD - defaulting to parsed home_account_id"
+            );
+        }
+
+        AccountRecord accountToReturn = null;
+
+        if (null != realm) {
+            accountToReturn = AccountAdapter.getAccountInternal(
+                mPublicClientConfiguration.getClientId(),
+                mPublicClientConfiguration.getOAuth2TokenCache(),
+                homeAccountIdentifier,
+                realm
+            );
+        } else {
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                TAG + methodName,
+                "Realm could not be resolved. Returning null."
+            );
+        }
+
+        return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
+    }
+
+    @Override
+    public void removeAccount(@Nullable final IAccount account, final AccountRemovedListener callback) {
+        ApiDispatcher.initializeDiagnosticContext();
+        if (null == account
+            || null == account.getHomeAccountIdentifier()
+            || StringUtil.isEmpty(account.getHomeAccountIdentifier().getIdentifier())) {
+            com.microsoft.identity.common.internal.logging.Logger.warn(
+                TAG,
+                "Requisite IAccount or IAccount fields were null. Insufficient criteria to remove IAccount."
+            );
+
+            callback.onAccountRemoved(false);
+        }
+
+        // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
+        final boolean deleteAccountsInAllTenants = true;
+
+        final String realm = deleteAccountsInAllTenants ? null : getRealm(account);
+
+        final boolean localRemoveAccountSuccess = !mPublicClientConfiguration
+            .getOAuth2TokenCache()
+            .removeAccount(
+                account.getEnvironment(),
+                mPublicClientConfiguration.getClientId(),
+                account.getHomeAccountIdentifier().getIdentifier(),
+                realm
+            ).isEmpty();
+
+        if (MSALControllerFactory.brokerEligible(
+            mPublicClientConfiguration.getAppContext(),
+            mPublicClientConfiguration.getDefaultAuthority(),
+            mPublicClientConfiguration)) {
+
+            //Remove the account from Broker
+            new BrokerMsalController().removeAccountFromBrokerCache(
+                account,
+                mPublicClientConfiguration,
+                callback
+            );
+        } else {
+            callback.onAccountRemoved(localRemoveAccountSuccess);
+        }
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -34,6 +34,17 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
     implements IMultipleAccountPublicClientApplication {
     private static final String TAG = MultipleAccountPublicClientApplication.class.getSimpleName();
 
+    /**
+     * Callback for asynchronous loading of broker AccountRecord accounts (in Multiple account mode).
+     */
+    public interface GetAccountRecordsFromBrokerCallback {
+        /**
+         * Called once Accounts have been loaded from the broker.
+         * @param accountRecords The accountRecords in broker.
+         */
+        void onAccountsLoaded(List<AccountRecord> accountRecords);
+    }
+
     protected MultipleAccountPublicClientApplication(@NonNull final Context context,
                                                      @NonNull final PublicClientApplicationConfiguration developerConfig) {
         super(context, developerConfig);
@@ -161,7 +172,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
         new BrokerMsalController().getBrokerAccounts(
             mPublicClientConfiguration,
-            new BrokerAccountsLoadedCallback() {
+            new GetAccountRecordsFromBrokerCallback() {
                 @Override
                 public void onAccountsLoaded(final List<AccountRecord> accountRecords) {
                     com.microsoft.identity.common.internal.logging.Logger.verbose(

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -291,7 +291,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
                 mPublicClientConfiguration)) {
 
             //Remove the account from Broker
-            new BrokerMsalController().removeAccountFromBrokerCache(
+            new BrokerMsalController().removeAccount(
                 account,
                 mPublicClientConfiguration,
                 callback

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -101,9 +101,9 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
                         );
                         // Merge migrated accounts with broker or local accounts.
                         if (MSALControllerFactory.brokerEligible(
-                            mPublicClientConfiguration.getAppContext(),
-                            mPublicClientConfiguration.getDefaultAuthority(),
-                            mPublicClientConfiguration)) {
+                                mPublicClientConfiguration.getAppContext(),
+                                mPublicClientConfiguration.getDefaultAuthority(),
+                                mPublicClientConfiguration)) {
                             postBrokerAndLocalAccountsResult(handler, callback);
                         } else {
                             postLocalAccountsResult(handler, callback);
@@ -120,9 +120,9 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             ).setMigrationStatus(true);
 
             if (MSALControllerFactory.brokerEligible(
-                mPublicClientConfiguration.getAppContext(),
-                mPublicClientConfiguration.getDefaultAuthority(),
-                mPublicClientConfiguration)) {
+                    mPublicClientConfiguration.getAppContext(),
+                    mPublicClientConfiguration.getDefaultAuthority(),
+                    mPublicClientConfiguration)) {
                 postBrokerAndLocalAccountsResult(handler, callback);
             } else {
                 postLocalAccountsResult(handler, callback);
@@ -286,9 +286,9 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             ).isEmpty();
 
         if (MSALControllerFactory.brokerEligible(
-            mPublicClientConfiguration.getAppContext(),
-            mPublicClientConfiguration.getDefaultAuthority(),
-            mPublicClientConfiguration)) {
+                mPublicClientConfiguration.getAppContext(),
+                mPublicClientConfiguration.getDefaultAuthority(),
+                mPublicClientConfiguration)) {
 
             //Remove the account from Broker
             new BrokerMsalController().removeAccountFromBrokerCache(

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -34,17 +34,6 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
     implements IMultipleAccountPublicClientApplication {
     private static final String TAG = MultipleAccountPublicClientApplication.class.getSimpleName();
 
-    /**
-     * Callback for asynchronous loading of broker AccountRecord accounts (in Multiple account mode).
-     */
-    public interface GetAccountRecordsFromBrokerCallback {
-        /**
-         * Called once Accounts have been loaded from the broker.
-         * @param accountRecords The accountRecords in broker.
-         */
-        void onAccountsLoaded(List<AccountRecord> accountRecords);
-    }
-
     protected MultipleAccountPublicClientApplication(@NonNull final Context context,
                                                      @NonNull final PublicClientApplicationConfiguration developerConfig) {
         super(context, developerConfig);
@@ -172,7 +161,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
         new BrokerMsalController().getBrokerAccounts(
             mPublicClientConfiguration,
-            new GetAccountRecordsFromBrokerCallback() {
+            new BrokerMsalController.GetAccountRecordsFromBrokerCallback() {
                 @Override
                 public void onAccountsLoaded(final List<AccountRecord> accountRecords) {
                     com.microsoft.identity.common.internal.logging.Logger.verbose(

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -234,6 +234,11 @@ public class PublicClientApplication implements IPublicClientApplication {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId));
                 }
             }
+
+            @Override
+            public void onError(MsalException exception) {
+                listener.onError(exception);
+            }
         });
     }
 
@@ -277,6 +282,11 @@ public class PublicClientApplication implements IPublicClientApplication {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId, authority));
                 }
             }
+
+            @Override
+            public void onError(MsalException exception) {
+                listener.onError(exception);
+            }
         });
     }
 
@@ -291,6 +301,11 @@ public class PublicClientApplication implements IPublicClientApplication {
                 } else {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context,  developerConfig));
                 }
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                listener.onError(exception);
             }
         });
     }
@@ -352,6 +367,11 @@ public class PublicClientApplication implements IPublicClientApplication {
          * Called once an IPublicClientApplication is successfully created.
          */
         void onCreated(final IPublicClientApplication application);
+
+        /**
+         * Called once IPublicClientApplication can't be created.
+         */
+        void onError(final MsalException exception);
     }
 
     /**
@@ -360,9 +380,14 @@ public class PublicClientApplication implements IPublicClientApplication {
     public interface BrokerAccountModeCallback {
         /**
          * Called once MSAL mode is retrieved from Broker.
-         * If the value can't be retrieved, this will fall back to the BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT mode.
+         * If Broker is not installed, this will fall back to the BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT mode.
          */
-        void onGetMode(String mode);
+        void onGetMode(final String mode);
+
+        /**
+         * Called once MSAL mode can't be retrieved from Broker.
+         */
+        void onError(final MsalException exception);
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -44,7 +44,6 @@ import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
 import com.microsoft.identity.client.internal.telemetry.DefaultEvent;
 import com.microsoft.identity.client.internal.telemetry.Defaults;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.exception.BaseException;
@@ -225,10 +224,10 @@ public class PublicClientApplication implements IPublicClientApplication {
             throw new IllegalArgumentException("client id is empty or null");
         }
 
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
+        new BrokerMsalController().getBrokerDeviceMode(context, new BrokerDeviceModeCallback() {
             @Override
-            public void onGetMode(String mode) {
-                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+            public void onGetMode(boolean isSharedDevice) {
+                if (isSharedDevice) {
                     listener.onCreated(new SingleAccountPublicClientApplication(context, clientId));
                 } else {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId));
@@ -273,10 +272,10 @@ public class PublicClientApplication implements IPublicClientApplication {
             throw new IllegalArgumentException("authority is null");
         }
 
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
+        new BrokerMsalController().getBrokerDeviceMode(context, new BrokerDeviceModeCallback() {
             @Override
-            public void onGetMode(String mode) {
-                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+            public void onGetMode(boolean isSharedDevice) {
+                if (isSharedDevice) {
                     listener.onCreated(new SingleAccountPublicClientApplication(context, clientId, authority));
                 } else {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId, authority));
@@ -293,10 +292,10 @@ public class PublicClientApplication implements IPublicClientApplication {
     private static void create(@NonNull final Context context,
                                final PublicClientApplicationConfiguration developerConfig,
                                @NonNull final ApplicationCreatedListener listener){
-        new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
+        new BrokerMsalController().getBrokerDeviceMode(context, new BrokerDeviceModeCallback() {
             @Override
-            public void onGetMode(String mode) {
-                if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
+            public void onGetMode(boolean isSharedDevice) {
+                if (isSharedDevice) {
                     listener.onCreated(new SingleAccountPublicClientApplication(context, developerConfig));
                 } else {
                     listener.onCreated(new MultipleAccountPublicClientApplication(context,  developerConfig));
@@ -377,12 +376,12 @@ public class PublicClientApplication implements IPublicClientApplication {
     /**
      * Listener callback for asynchronous loading of MSAL mode retrieval.
      */
-    public interface BrokerAccountModeCallback {
+    public interface BrokerDeviceModeCallback {
         /**
          * Called once MSAL mode is retrieved from Broker.
          * If Broker is not installed, this will fall back to the BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT mode.
          */
-        void onGetMode(final String mode);
+        void onGetMode(final boolean isSharedDevice);
 
         /**
          * Called once MSAL mode can't be retrieved from Broker.

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -27,8 +27,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.os.Handler;
-import android.os.Looper;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -54,11 +52,9 @@ import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AuthorityDeserializer;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudienceDeserializer;
-import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
 import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.ICacheKeyValueDelegate;
-import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
@@ -68,9 +64,6 @@ import com.microsoft.identity.common.internal.controllers.ApiDispatcher;
 import com.microsoft.identity.common.internal.controllers.InteractiveTokenCommand;
 import com.microsoft.identity.common.internal.controllers.TokenCommand;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
-import com.microsoft.identity.common.internal.migration.AdalMigrationAdapter;
-import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
-import com.microsoft.identity.common.internal.migration.TokenMigrationUtility;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
@@ -91,11 +84,8 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache.DEFAULT_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES;
 
@@ -145,13 +135,13 @@ import static com.microsoft.identity.common.internal.cache.SharedPreferencesAcco
  * </p>
  * </p>
  */
-public class PublicClientApplication implements IPublicClientApplication, IMultipleAccountPublicClientApplication {
+public class PublicClientApplication implements IPublicClientApplication {
     private static final String TAG = PublicClientApplication.class.getSimpleName();
 
     private static final String INTERNET_PERMISSION = "android.permission.INTERNET";
     private static final String ACCESS_NETWORK_STATE_PERMISSION = "android.permission.ACCESS_NETWORK_STATE";
 
-    private PublicClientApplicationConfiguration mPublicClientConfiguration;
+    protected PublicClientApplicationConfiguration mPublicClientConfiguration;
 
     /**
      * {@link PublicClientApplication#create(Context, int, ApplicationCreatedListener)} will read the client id and other configuration settings from the
@@ -167,6 +157,8 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
      *                             </p>
      * @param configFileResourceId The resource ID of the raw file containing the JSON configuration for the PublicClientApplication
      * @see <a href="https://developer.android.com/guide/topics/resources/providing-resources">Android app resource overview</a>
+     *
+     * @param listener a callback to be invoked when the object is successfully created.
      * <p>
      * For more information on the schema of the MSAL config json please
      * @see <a href="https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki">MSAL Github Wiki</a>
@@ -232,15 +224,14 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         if (MsalUtils.isEmpty(clientId)) {
             throw new IllegalArgumentException("client id is empty or null");
         }
+
         new BrokerMsalController().getBrokerAccountMode(context, new BrokerAccountModeCallback() {
             @Override
             public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
-                    // TODO: return SingleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context, clientId));
+                    listener.onCreated(new SingleAccountPublicClientApplication(context, clientId));
                 } else {
-                    // TODO: return MultipleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context, clientId));
+                    listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId));
                 }
             }
         });
@@ -281,11 +272,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
             @Override
             public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
-                    // TODO: return SingleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context, clientId, authority));
+                    listener.onCreated(new SingleAccountPublicClientApplication(context, clientId, authority));
                 } else {
-                    // TODO: return MultipleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context, clientId, authority));
+                    listener.onCreated(new MultipleAccountPublicClientApplication(context, clientId, authority));
                 }
             }
         });
@@ -298,11 +287,9 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
             @Override
             public void onGetMode(String mode) {
                 if (AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.equalsIgnoreCase(mode)) {
-                    // TODO: return SingleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context, developerConfig));
+                    listener.onCreated(new SingleAccountPublicClientApplication(context, developerConfig));
                 } else {
-                    // TODO: return MultipleAccountPublicClientApplication
-                    listener.onCreated(new PublicClientApplication(context,  developerConfig));
+                    listener.onCreated(new MultipleAccountPublicClientApplication(context,  developerConfig));
                 }
             }
         });
@@ -396,259 +383,8 @@ public class PublicClientApplication implements IPublicClientApplication, IMulti
         return mPublicClientConfiguration;
     }
 
-    @Override
-    public void getAccounts(@NonNull final AccountsLoadedCallback callback) {
-        ApiDispatcher.initializeDiagnosticContext();
-        final String methodName = ":getAccounts";
-        final List<AccountRecord> accounts = getLocalAccounts();
-
-        final Handler handler;
-
-        if (null != Looper.myLooper() && Looper.getMainLooper() != Looper.myLooper()) {
-            handler = new Handler(Looper.myLooper());
-        } else {
-            handler = new Handler(Looper.getMainLooper());
-        }
-
-        if (accounts.isEmpty()) {
-            // Create the SharedPreferencesFileManager for the legacy accounts/credentials
-            final IStorageHelper storageHelper = new StorageHelper(mPublicClientConfiguration.getAppContext());
-            final ISharedPreferencesFileManager sharedPreferencesFileManager =
-                    new SharedPreferencesFileManager(
-                            mPublicClientConfiguration.getAppContext(),
-                            "com.microsoft.aad.adal.cache",
-                            storageHelper
-                    );
-
-            // Load the old TokenCacheItems as key/value JSON
-            final Map<String, String> credentials = sharedPreferencesFileManager.getAll();
-
-            final Map<String, String> redirects = new HashMap<>();
-            redirects.put(
-                    mPublicClientConfiguration.mClientId, // Our client id
-                    mPublicClientConfiguration.mRedirectUri // Our redirect uri
-            );
-
-            new TokenMigrationUtility<MicrosoftAccount, MicrosoftRefreshToken>()._import(
-                    new AdalMigrationAdapter(
-                            mPublicClientConfiguration.getAppContext(),
-                            redirects,
-                            false
-                    ),
-                    credentials,
-                    (IShareSingleSignOnState<MicrosoftAccount, MicrosoftRefreshToken>) mPublicClientConfiguration.getOAuth2TokenCache(),
-                    new TokenMigrationCallback() {
-                        @Override
-                        public void onMigrationFinished(int numberOfAccountsMigrated) {
-                            final String extendedMethodName = ":onMigrationFinished";
-                            com.microsoft.identity.common.internal.logging.Logger.info(
-                                    TAG + methodName + extendedMethodName,
-                                    "Migrated [" + numberOfAccountsMigrated + "] accounts"
-                            );
-                            // Merge migrated accounts with broker or local accounts.
-                            if (MSALControllerFactory.brokerEligible(
-                                    mPublicClientConfiguration.getAppContext(),
-                                    mPublicClientConfiguration.getDefaultAuthority(),
-                                    mPublicClientConfiguration)) {
-                                postBrokerAndLocalAccountsResult(handler, callback);
-                            } else {
-                                postLocalAccountsResult(handler, callback);
-                            }
-                        }
-                    }
-            );
-        } else {
-            // The cache contains items - mark migration as complete
-            new AdalMigrationAdapter(
-                    mPublicClientConfiguration.getAppContext(),
-                    null, // unused for this path
-                    false
-            ).setMigrationStatus(true);
-
-            if (MSALControllerFactory.brokerEligible(
-                    mPublicClientConfiguration.getAppContext(),
-                    mPublicClientConfiguration.getDefaultAuthority(),
-                    mPublicClientConfiguration)) {
-                postBrokerAndLocalAccountsResult(handler, callback);
-            } else {
-                postLocalAccountsResult(handler, callback);
-            }
-        }
-    }
-
-    /**
-     * Helper method which returns all the local accounts using {@link AccountsLoadedCallback}
-     * @param handler : handler to post
-     * @param callback: AccountsLoadedCallback
-     */
-    private void postLocalAccountsResult(final Handler handler, final AccountsLoadedCallback callback) {
-
-        handler.post(new Runnable() {
-            @Override
-            public void run() {
-                List<IAccount> accountsToReturn = new ArrayList<>();
-                for (AccountRecord accountRecord : getLocalAccounts()) {
-                    accountsToReturn.add(AccountAdapter.adapt(accountRecord));
-                }
-
-                callback.onAccountsLoaded(accountsToReturn);
-            }
-        });
-    }
-
-    /**
-     * Helper method which returns both broker and local accounts using {@link AccountsLoadedCallback}
-     * @param handler : handler to post
-     * @param callback: AccountsLoadedCallback
-     */
-    private void postBrokerAndLocalAccountsResult(final Handler handler, final AccountsLoadedCallback callback) {
-
-        final String methodName = ":postBrokerAndLocalAccountsResult";
-
-        new BrokerMsalController().getBrokerAccounts(
-                mPublicClientConfiguration,
-                new BrokerAccountsLoadedCallback() {
-                    @Override
-                    public void onAccountsLoaded(final List<AccountRecord> accountRecords) {
-                        com.microsoft.identity.common.internal.logging.Logger.verbose(
-                                TAG + methodName,
-                                "Accounts loaded from broker "
-                                        + (accountRecords == null ? 0 : accountRecords.size())
-                        );
-
-                        // merge account
-                        final List<IAccount> accountList = new ArrayList<>();
-                        final List<AccountRecord> accountRecordList = new ArrayList<>();
-
-                        if (accountRecords != null) {
-                            //Add broker accounts
-                            accountRecordList.addAll(accountRecords);
-                        }
-
-                        //Add local accounts
-                        accountRecordList.addAll(getLocalAccounts());
-
-                        if (accountRecordList.size() > 0) {
-                            for (AccountRecord accountRecord : accountRecordList) {
-                                accountList.add(AccountAdapter.adapt(accountRecord));
-                            }
-                        }
-                        handler.post(new Runnable() {
-                            @Override
-                            public void run() {
-                                callback.onAccountsLoaded(accountList);
-                            }
-                        });
-                    }
-                });
-    }
-
-    /**
-     * Returns a List of {@link IAccount} objects for which this application has RefreshTokens.
-     *
-     * @return An immutable List of IAccount objects - empty if no IAccounts exist.
-     */
-    private List<AccountRecord> getLocalAccounts() {
-        // Grab the Accounts from the common cache
-        final List<AccountRecord> accountsInCache =
-                mPublicClientConfiguration
-                        .getOAuth2TokenCache()
-                        .getAccounts(
-                                null, // * wildcard
-                                mPublicClientConfiguration.getClientId()
-                        );
-
-        return accountsInCache;
-    }
-
-    @Override
     @Nullable
-    public IAccount getAccount(@NonNull final String homeAccountIdentifier,
-                               @Nullable final String authority) {
-        final String methodName = ":getAccount";
-
-        ApiDispatcher.initializeDiagnosticContext();
-
-        String realm = StringUtil.getTenantInfo(homeAccountIdentifier).second;
-
-        Authority authorityObj = Authority.getAuthorityFromAuthorityUrl(authority);
-
-        if (authorityObj instanceof AzureActiveDirectoryAuthority) {
-            final AzureActiveDirectoryAuthority aadAuthority = (AzureActiveDirectoryAuthority) authorityObj;
-            final AzureActiveDirectoryAudience audience = aadAuthority.getAudience();
-            realm = audience.getTenantId();
-        } else {
-            com.microsoft.identity.common.internal.logging.Logger.warn(
-                    TAG + methodName,
-                    "Provided authority was not AAD - defaulting to parsed home_account_id"
-            );
-        }
-
-        AccountRecord accountToReturn = null;
-
-        if (null != realm) {
-            accountToReturn = AccountAdapter.getAccountInternal(
-                    mPublicClientConfiguration.getClientId(),
-                    mPublicClientConfiguration.getOAuth2TokenCache(),
-                    homeAccountIdentifier,
-                    realm
-            );
-        } else {
-            com.microsoft.identity.common.internal.logging.Logger.warn(
-                    TAG + methodName,
-                    "Realm could not be resolved. Returning null."
-            );
-        }
-
-        return null == accountToReturn ? null : AccountAdapter.adapt(accountToReturn);
-    }
-
-    @Override
-    public void removeAccount(@Nullable final IAccount account, final AccountRemovedListener callback) {
-        ApiDispatcher.initializeDiagnosticContext();
-        if (null == account
-                || null == account.getHomeAccountIdentifier()
-                || StringUtil.isEmpty(account.getHomeAccountIdentifier().getIdentifier())) {
-            com.microsoft.identity.common.internal.logging.Logger.warn(
-                    TAG,
-                    "Requisite IAccount or IAccount fields were null. Insufficient criteria to remove IAccount."
-            );
-
-            callback.onAccountRemoved(false);
-        }
-
-        // FEATURE SWITCH: Set to false to allow deleting Accounts in a tenant-specific way.
-        final boolean deleteAccountsInAllTenants = true;
-
-        final String realm = deleteAccountsInAllTenants ? null : getRealm(account);
-
-        final boolean localRemoveAccountSuccess = !mPublicClientConfiguration
-                .getOAuth2TokenCache()
-                .removeAccount(
-                        account.getEnvironment(),
-                        mPublicClientConfiguration.getClientId(),
-                        account.getHomeAccountIdentifier().getIdentifier(),
-                        realm
-                ).isEmpty();
-
-        if (MSALControllerFactory.brokerEligible(
-                mPublicClientConfiguration.getAppContext(),
-                mPublicClientConfiguration.getDefaultAuthority(),
-                mPublicClientConfiguration)) {
-
-            //Remove the account from Broker
-            new BrokerMsalController().removeBrokerAccount(
-                    account,
-                    mPublicClientConfiguration,
-                    callback
-            );
-        } else {
-            callback.onAccountRemoved(localRemoveAccountSuccess);
-        }
-    }
-
-    @Nullable
-    private static String getRealm(@NonNull IAccount account) {
+    protected static String getRealm(@NonNull IAccount account) {
         String realm = null;
 
         if (null != account.getAccountIdentifier() // This is an AAD account w/ tenant info

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -70,8 +70,8 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public void globalSignOut(final AccountRemovedListener callback) throws MsalClientException {
-        final String methodName = ":globalSignOut";
+    public void removeCurrentAccount(final AccountRemovedListener callback) throws MsalClientException {
+        final String methodName = ":removeCurrentAccount";
         final PublicClientApplicationConfiguration configuration = getConfiguration();
 
         if (!MSALControllerFactory.brokerEligible(

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -15,6 +15,18 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     implements ISingleAccountPublicClientApplication {
     private static final String TAG = SingleAccountPublicClientApplication.class.getSimpleName();
 
+    /**
+     * Callback for asynchronous loading of broker AccountRecord account (in Single account mode).
+     */
+    public interface GetCurrentAccountRecordFromBrokerCallback {
+
+        /**
+         * Called once the signed-in account (if there is any), has been loaded from the broker.
+         * @param accountRecord The accountRecord in broker. This could be null.
+         */
+        void onAccountLoaded(@Nullable final AccountRecord accountRecord);
+    }
+
     private AccountRecord mLocalAccountRecord;
 
     protected SingleAccountPublicClientApplication(@NonNull final Context context,
@@ -49,7 +61,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
         new BrokerMsalController().getCurrentAccount(
                 configuration,
-                new SingleAccountLoadedCallback() {
+                new GetCurrentAccountRecordFromBrokerCallback() {
                     @Override
                     public void onAccountLoaded(@Nullable final AccountRecord accountRecordInBroker) {
                         IAccount localAccount = mLocalAccountRecord == null ? null : AccountAdapter.adapt(mLocalAccountRecord);

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -83,7 +83,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
             throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
         }
 
-        new BrokerMsalController().globalSignOut(
+        new BrokerMsalController().removeAccountFromSharedDevice(
                 AccountAdapter.adapt(mLocalAccountRecord),
                 configuration,
                 new AccountRemovedListener() {

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -1,0 +1,100 @@
+package com.microsoft.identity.client;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
+import com.microsoft.identity.common.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
+
+public class SingleAccountPublicClientApplication extends PublicClientApplication
+    implements ISingleAccountPublicClientApplication {
+    private static final String TAG = SingleAccountPublicClientApplication.class.getSimpleName();
+
+    private AccountRecord mLocalAccountRecord;
+
+    protected SingleAccountPublicClientApplication(@NonNull final Context context,
+                                                   @NonNull final PublicClientApplicationConfiguration developerConfig) {
+        super(context, developerConfig);
+    }
+
+    protected SingleAccountPublicClientApplication(@NonNull final Context context,
+                                                   @NonNull final String clientId) {
+        super(context, clientId);
+    }
+
+    protected SingleAccountPublicClientApplication(@NonNull final Context context,
+                                                   @NonNull final String clientId,
+                                                   @NonNull final String authority) {
+        super(context, clientId, authority);
+    }
+
+    @Override
+    public void getCurrentAccount(final CurrentAccountListener listener) throws MsalClientException {
+        final String methodName = ":getCurrentAccount";
+        final PublicClientApplicationConfiguration configuration = getConfiguration();
+
+        if (!MSALControllerFactory.brokerEligible(
+                configuration.getAppContext(),
+                configuration.getDefaultAuthority(),
+                configuration)) {
+            final String errorMessage = "Broker app is not installed on the device.";
+            com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
+            throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
+        }
+
+        new BrokerMsalController().getCurrentAccount(
+                configuration,
+                new SingleAccountLoadedCallback() {
+                    @Override
+                    public void onAccountLoaded(@Nullable final AccountRecord accountRecordInBroker) {
+                        IAccount localAccount = mLocalAccountRecord == null ? null : AccountAdapter.adapt(mLocalAccountRecord);
+                        IAccount accountInBroker = accountRecordInBroker == null ? null : AccountAdapter.adapt(accountRecordInBroker);
+
+                        if (mLocalAccountRecord == null){
+                            if (accountRecordInBroker != null) {
+                                listener.onAccountChanged(null, accountInBroker);
+                            }
+                        } else if (!mLocalAccountRecord.equals(accountRecordInBroker)) {
+                            listener.onAccountChanged(localAccount, accountInBroker);
+                        }
+
+                        mLocalAccountRecord = accountRecordInBroker;
+                        listener.onAccountLoaded(accountInBroker);
+                    }
+                });
+    }
+
+    @Override
+    public void globalSignOut(final AccountRemovedListener callback) throws MsalClientException {
+        final String methodName = ":globalSignOut";
+        final PublicClientApplicationConfiguration configuration = getConfiguration();
+
+        if (!MSALControllerFactory.brokerEligible(
+                configuration.getAppContext(),
+                configuration.getDefaultAuthority(),
+                configuration)) {
+            final String errorMessage = "Broker app is not installed on the device.";
+            com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
+            throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
+        }
+
+        new BrokerMsalController().globalSignOut(
+                AccountAdapter.adapt(mLocalAccountRecord),
+                configuration,
+                new AccountRemovedListener() {
+                    @Override
+                    public void onAccountRemoved(Boolean isSuccess) {
+                        if (isSuccess) {
+                            mLocalAccountRecord = null;
+                        }
+
+                        callback.onAccountRemoved(isSuccess);
+                    }
+                });
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -7,25 +7,11 @@ import android.support.annotation.Nullable;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
-import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
-import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectory;
 
 public class SingleAccountPublicClientApplication extends PublicClientApplication
     implements ISingleAccountPublicClientApplication {
     private static final String TAG = SingleAccountPublicClientApplication.class.getSimpleName();
-
-    /**
-     * Callback for asynchronous loading of broker AccountRecord account (in Single account mode).
-     */
-    public interface GetCurrentAccountRecordFromBrokerCallback {
-
-        /**
-         * Called once the signed-in account (if there is any), has been loaded from the broker.
-         * @param accountRecord The accountRecord in broker. This could be null.
-         */
-        void onAccountLoaded(@Nullable final AccountRecord accountRecord);
-    }
 
     private AccountRecord mLocalAccountRecord;
 
@@ -61,7 +47,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
         new BrokerMsalController().getCurrentAccount(
                 configuration,
-                new GetCurrentAccountRecordFromBrokerCallback() {
+                new BrokerMsalController.GetCurrentAccountRecordFromBrokerCallback() {
                     @Override
                     public void onAccountLoaded(@Nullable final AccountRecord accountRecordInBroker) {
                         IAccount localAccount = mLocalAccountRecord == null ? null : AccountAdapter.adapt(mLocalAccountRecord);

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -42,7 +42,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                 configuration.getAppContext(),
                 configuration.getDefaultAuthority(),
                 configuration)) {
-            final String errorMessage = "Broker app is not installed on the device.";
+            final String errorMessage = "This request is not eligible to use the broker.";
             com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
             throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
         }
@@ -78,7 +78,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                 configuration.getAppContext(),
                 configuration.getDefaultAuthority(),
                 configuration)) {
-            final String errorMessage = "Broker app is not installed on the device.";
+            final String errorMessage = "This request is not eligible to use the broker.";
             com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
             throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
         }

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -152,6 +152,11 @@ public final class MsalClientException extends MsalException {
     public static final String UNKNOWN_ERROR = ClientException.UNKNOWN_ERROR;
 
     /**
+     * Broker app is not installed.
+     */
+    public static final String BROKER_NOT_INSTALLED = "broker_not_installed";
+
+    /**
      * Temporary non-exposed error code to indicate that ADFS authority validation fails. ADFS as authority is not supported
      * for preview.
      */

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -206,18 +206,18 @@ public class BrokerMsalController extends BaseController {
     }
 
     /**
-     * Get MSAL PublicClientApplication mode from Broker.
+     * Get device mode from Broker.
      * */
-    public void getBrokerAccountMode(final Context appContext,
-                                     final PublicClientApplication.BrokerAccountModeCallback callback) {
+    public void getBrokerDeviceMode(final Context appContext,
+                                    final PublicClientApplication.BrokerDeviceModeCallback callback) {
 
         final String methodName = ":getBrokerAccountMode";
         final Handler handler = new Handler(Looper.getMainLooper());
 
         if (!MSALControllerFactory.brokerInstalled(appContext)) {
-            final String errorMessage = "Broker app is not installed on the device. Returning default mode.";
+            final String errorMessage = "Broker app is not installed on the device. Returning default (multiple account) mode.";
             com.microsoft.identity.common.internal.logging.Logger.verbose(TAG + methodName, errorMessage, null);
-            callback.onGetMode(AuthenticationConstants.Broker.BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT);
+            callback.onGetMode(false);
             return;
         }
 
@@ -231,10 +231,10 @@ public class BrokerMsalController extends BaseController {
 
                     service = authServiceFuture.get();
 
-                    final String mode =
+                    final boolean mode =
                         MsalBrokerResultAdapter
-                            .accountModeFromBundle(
-                                service.getAccountMode()
+                            .deviceModeFromBundle(
+                                service.getDeviceMode()
                             );
 
                     handler.post(new Runnable() {
@@ -467,7 +467,7 @@ public class BrokerMsalController extends BaseController {
                     final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
                     service = authServiceFuture.get();
                     final Bundle requestBundle = getRequestBundleForGlobalSignOut(account);
-                    final Bundle resultBundle = service.signOutFromSharedDevice(requestBundle);
+                    final Bundle resultBundle = service.removeAccountFromSharedDevice(requestBundle);
 
                     Handler handler = new Handler(Looper.getMainLooper());
                     handler.post(new Runnable() {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -396,9 +396,9 @@ public class BrokerMsalController extends BaseController {
         return requestBundle;
     }
 
-    public void removeAccountFromBrokerCache(@Nullable final IAccount account,
-                                             @NonNull final PublicClientApplicationConfiguration configuration,
-                                             @NonNull final IPublicClientApplication.AccountRemovedListener callback) {
+    public void removeAccount(@Nullable final IAccount account,
+                              @NonNull final PublicClientApplicationConfiguration configuration,
+                              @NonNull final IPublicClientApplication.AccountRemovedListener callback) {
         sBackgroundExecutor.submit(new Runnable() {
             @Override
             public void run() {
@@ -453,9 +453,9 @@ public class BrokerMsalController extends BaseController {
      * 3. Clear WebView cookies.
      * 4. Sign out from default browser.
      * */
-    public void globalSignOut(@NonNull final IAccount account,
-                              @NonNull final PublicClientApplicationConfiguration configuration,
-                              @NonNull final IPublicClientApplication.AccountRemovedListener callback) {
+    public void removeAccountFromSharedDevice(@NonNull final IAccount account,
+                                              @NonNull final PublicClientApplicationConfiguration configuration,
+                                              @NonNull final IPublicClientApplication.AccountRemovedListener callback) {
 
         sBackgroundExecutor.submit(new Runnable() {
             @Override

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -35,10 +35,8 @@ import com.google.gson.Gson;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IMicrosoftAuthService;
 import com.microsoft.identity.client.IPublicClientApplication;
-import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
-import com.microsoft.identity.client.SingleAccountPublicClientApplication;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
@@ -82,6 +80,29 @@ public class BrokerMsalController extends BaseController {
      * ExecutorService to handle background computation.
      */
     private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
+
+    /**
+     * Callback for asynchronous loading of broker AccountRecords (in multiple account mode).
+     */
+    public interface GetAccountRecordsFromBrokerCallback {
+        /**
+         * Called once Accounts have been loaded from the broker.
+         * @param accountRecords The accountRecords in broker.
+         */
+        void onAccountsLoaded(List<AccountRecord> accountRecords);
+    }
+
+    /**
+     * Callback for asynchronous loading of broker AccountRecord of the current account (in single account mode).
+     */
+    public interface GetCurrentAccountRecordFromBrokerCallback {
+
+        /**
+         * Called once the signed-in account (if there is any), has been loaded from the broker.
+         * @param accountRecord The accountRecord in broker. This could be null.
+         */
+        void onAccountLoaded(@Nullable final AccountRecord accountRecord);
+    }
 
     @Override
     public AcquireTokenResult acquireToken(AcquireTokenOperationParameters parameters)
@@ -287,7 +308,7 @@ public class BrokerMsalController extends BaseController {
      * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.
      * */
     public void getCurrentAccount(final PublicClientApplicationConfiguration configuration,
-                                  final SingleAccountPublicClientApplication.GetCurrentAccountRecordFromBrokerCallback callback) {
+                                  final GetCurrentAccountRecordFromBrokerCallback callback) {
 
         final String methodName = ":getCurrentAccount";
         final Handler handler = new Handler(Looper.getMainLooper());
@@ -341,7 +362,7 @@ public class BrokerMsalController extends BaseController {
      * this needs to be called on background thread.
      */
     public void getBrokerAccounts(final PublicClientApplicationConfiguration configuration,
-                                  final MultipleAccountPublicClientApplication.GetAccountRecordsFromBrokerCallback callback) {
+                                  final GetAccountRecordsFromBrokerCallback callback) {
 
         final String methodName = ":getBrokerAccounts";
         final Handler handler = new Handler(Looper.getMainLooper());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -34,11 +34,11 @@ import android.support.annotation.Nullable;
 import com.google.gson.Gson;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IMicrosoftAuthService;
-import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.IPublicClientApplication;
-import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
+import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
+import com.microsoft.identity.client.SingleAccountPublicClientApplication;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
@@ -287,7 +287,7 @@ public class BrokerMsalController extends BaseController {
      * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.
      * */
     public void getCurrentAccount(final PublicClientApplicationConfiguration configuration,
-                                  final ISingleAccountPublicClientApplication.SingleAccountLoadedCallback callback) {
+                                  final SingleAccountPublicClientApplication.GetCurrentAccountRecordFromBrokerCallback callback) {
 
         final String methodName = ":getCurrentAccount";
         final Handler handler = new Handler(Looper.getMainLooper());
@@ -341,7 +341,7 @@ public class BrokerMsalController extends BaseController {
      * this needs to be called on background thread.
      */
     public void getBrokerAccounts(final PublicClientApplicationConfiguration configuration,
-                                  final IMultipleAccountPublicClientApplication.BrokerAccountsLoadedCallback callback) {
+                                  final MultipleAccountPublicClientApplication.GetAccountRecordsFromBrokerCallback callback) {
 
         final String methodName = ":getBrokerAccounts";
         final Handler handler = new Handler(Looper.getMainLooper());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -146,7 +146,7 @@ public class MSALControllerFactory {
      * @param applicationContext
      * @return
      */
-    private static boolean brokerInstalled(@NonNull final Context applicationContext) {
+    protected static boolean brokerInstalled(@NonNull final Context applicationContext) {
         BrokerValidator brokerValidator = new BrokerValidator(applicationContext);
         AccountManager accountManager = AccountManager.get(applicationContext);
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -251,7 +251,7 @@ public class MsalWrapper {
         } else if (mApplication instanceof ISingleAccountPublicClientApplication) {
             final ISingleAccountPublicClientApplication application = (ISingleAccountPublicClientApplication)(mApplication);
             try {
-                application.globalSignOut(new IPublicClientApplication.AccountRemovedListener() {
+                application.removeCurrentAccount(new IPublicClientApplication.AccountRemovedListener() {
                     @Override
                     public void onAccountRemoved(Boolean isSuccess) {
                         if (isSuccess) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -82,6 +82,11 @@ public class MsalWrapper {
 
                     loadAccountFromBroker(notifyCallback);
                 }
+
+                @Override
+                public void onError(MsalException exception) {
+                    notifyCallback.notify("Failed to load MSAL Application: " + exception.getMessage());
+                }
             });
     }
 


### PR DESCRIPTION
This is a part of the FLW/End my Shift feature.

- Move codes (that should be under IMultipleAccountPublicCilentApplication) from PublicClientApplicaiton
- Implements SingleAccountPublicClientApplication
- Implements globalSignOut() and getCurrentAccount() in BrokerMsalController (for invoking broker operations).
- PublicClientApplication.create() now returns the right PublicClientApplication (based on Broker mode).