### PR TITLE
MSAL can talk to Broker with AccountManager | Part 1/3

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -46,7 +46,7 @@ public class AccountAdapter {
      * @return A representation of the supplied Account, as an IAccount.
      */
     @NonNull
-    static IAccount adapt(@NonNull final IAccountRecord accountIn) {
+    public static IAccount adapt(@NonNull final IAccountRecord accountIn) {
         final String methodName = ":adapt";
         final com.microsoft.identity.client.Account accountOut
                 = new com.microsoft.identity.client.Account();

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -46,7 +46,7 @@ class AccountAdapter {
      * @return A representation of the supplied Account, as an IAccount.
      */
     @NonNull
-    public static IAccount adapt(@NonNull final IAccountRecord accountIn) {
+    static IAccount adapt(@NonNull final IAccountRecord accountIn) {
         final String methodName = ":adapt";
         final com.microsoft.identity.client.Account accountOut
                 = new com.microsoft.identity.client.Account();
@@ -62,11 +62,6 @@ class AccountAdapter {
             );
 
             // This account came from AAD
-            accountId = new AzureActiveDirectoryAccountIdentifier() {{ // This is the local_account_id
-                setIdentifier(accountIn.getLocalAccountId());
-                setObjectIdentifier(accountIn.getLocalAccountId());
-                setTenantIdentifier(accountIn.getRealm());
-            }};
             homeAccountId = new AzureActiveDirectoryAccountIdentifier() {{ // This is the home_account_id
                 // Grab the homeAccountId
                 final String homeAccountIdStr = accountIn.getHomeAccountId();
@@ -83,13 +78,26 @@ class AccountAdapter {
                 // Set the utid as the tenantId
                 setTenantIdentifier(components[1]);
             }};
+
+            if (StringUtil.isEmpty(accountIn.getLocalAccountId())) {
+                accountId = homeAccountId;
+            } else {
+                accountId = new AzureActiveDirectoryAccountIdentifier() {{ // This is the local_account_id
+                    setIdentifier(accountIn.getLocalAccountId());
+                    setObjectIdentifier(accountIn.getLocalAccountId());
+                    setTenantIdentifier(accountIn.getRealm());
+                }};
+            }
+
         } else { // This Account came from IdP other than AAD.
             Logger.info(
                     TAG + methodName,
                     "Account is non-AAD"
             );
             accountId = new AccountIdentifier() {{
-                setIdentifier(accountIn.getLocalAccountId());
+                setIdentifier(StringUtil.isEmpty(accountIn.getLocalAccountId())?
+                        accountIn.getHomeAccountId() : accountIn.getLocalAccountId()
+                );
             }};
             homeAccountId = new AccountIdentifier() {{
                 setIdentifier(accountIn.getHomeAccountId());

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -439,14 +439,14 @@ public final class PublicClientApplication {
                                     "Migrated [" + numberOfAccountsMigrated + "] accounts"
                             );
                             // Merge migrated accounts with broker or local accounts.
-//                            if (MSALControllerFactory.brokerEligible(
-//                                    mPublicClientConfiguration.getAppContext(),
-//                                    mPublicClientConfiguration.getDefaultAuthority(),
-//                                    mPublicClientConfiguration)) {
-//                                postBrokerAndLocalAccountsResult(handler, callback);
-//                            } else {
+                            if (MSALControllerFactory.brokerEligible(
+                                    mPublicClientConfiguration.getAppContext(),
+                                    mPublicClientConfiguration.getDefaultAuthority(),
+                                    mPublicClientConfiguration)) {
+                                postBrokerAndLocalAccountsResult(handler, callback);
+                            } else {
                                 postLocalAccountsResult(handler, callback);
-                           // }
+                            }
                         }
                     }
             );
@@ -458,14 +458,14 @@ public final class PublicClientApplication {
                     false
             ).setMigrationStatus(true);
 
-//            if (MSALControllerFactory.brokerEligible(
-//                    mPublicClientConfiguration.getAppContext(),
-//                    mPublicClientConfiguration.getDefaultAuthority(),
-//                    mPublicClientConfiguration)) {
-//                postBrokerAndLocalAccountsResult(handler, callback);
-//            } else {
+            if (MSALControllerFactory.brokerEligible(
+                    mPublicClientConfiguration.getAppContext(),
+                    mPublicClientConfiguration.getDefaultAuthority(),
+                    mPublicClientConfiguration)) {
+                postBrokerAndLocalAccountsResult(handler, callback);
+            } else {
                 postLocalAccountsResult(handler, callback);
-//            }
+            }
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -439,14 +439,14 @@ public final class PublicClientApplication {
                                     "Migrated [" + numberOfAccountsMigrated + "] accounts"
                             );
                             // Merge migrated accounts with broker or local accounts.
-                            if (MSALControllerFactory.brokerEligible(
-                                    mPublicClientConfiguration.getAppContext(),
-                                    mPublicClientConfiguration.getDefaultAuthority(),
-                                    mPublicClientConfiguration)) {
-                                postBrokerAndLocalAccountsResult(handler, callback);
-                            } else {
+//                            if (MSALControllerFactory.brokerEligible(
+//                                    mPublicClientConfiguration.getAppContext(),
+//                                    mPublicClientConfiguration.getDefaultAuthority(),
+//                                    mPublicClientConfiguration)) {
+//                                postBrokerAndLocalAccountsResult(handler, callback);
+//                            } else {
                                 postLocalAccountsResult(handler, callback);
-                            }
+                           // }
                         }
                     }
             );
@@ -458,14 +458,14 @@ public final class PublicClientApplication {
                     false
             ).setMigrationStatus(true);
 
-            if (MSALControllerFactory.brokerEligible(
-                    mPublicClientConfiguration.getAppContext(),
-                    mPublicClientConfiguration.getDefaultAuthority(),
-                    mPublicClientConfiguration)) {
-                postBrokerAndLocalAccountsResult(handler, callback);
-            } else {
+//            if (MSALControllerFactory.brokerEligible(
+//                    mPublicClientConfiguration.getAppContext(),
+//                    mPublicClientConfiguration.getDefaultAuthority(),
+//                    mPublicClientConfiguration)) {
+//                postBrokerAndLocalAccountsResult(handler, callback);
+//            } else {
                 postLocalAccountsResult(handler, callback);
-            }
+//            }
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -51,6 +51,7 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REDIRECT_URI;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.USE_BROKER;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ENVIRONMENT;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REQUIRED_BROKER_PROTOCOL_VERSION;
 
 public class PublicClientApplicationConfiguration {
 
@@ -64,6 +65,7 @@ public class PublicClientApplicationConfiguration {
         static final String MULTIPLE_CLOUDS_SUPPORTED = "multiple_clouds_supported";
         static final String USE_BROKER = "broker_redirect_uri_registered";
         static final String ENVIRONMENT = "environment";
+        static final String REQUIRED_BROKER_PROTOCOL_VERSION = "minimum_required_broker_protocol_version";
     }
 
     @SerializedName(CLIENT_ID)
@@ -92,6 +94,9 @@ public class PublicClientApplicationConfiguration {
 
     @SerializedName(ENVIRONMENT)
     Environment mEnvironment;
+
+    @SerializedName(REQUIRED_BROKER_PROTOCOL_VERSION)
+    String mRequiredBrokerProtocolVersion;
 
     @SerializedName("browser_safelist")
     List<BrowserDescriptor> mBrowserSafeList;
@@ -202,6 +207,14 @@ public class PublicClientApplicationConfiguration {
      */
     public Boolean getUseBroker() {
         return mUseBroker;
+    }
+
+    /**
+     * Indicates the minimum required broker protocol version number.
+     * @return String of broker protocol version
+     */
+    public String getRequiredBrokerProtocolVersion() {
+        return mRequiredBrokerProtocolVersion;
     }
 
     public Context getAppContext() {

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.client.exception;
 
 import com.microsoft.identity.client.AuthenticationActivity;
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
 
 /**
  * This exception class represents general errors that are local to the library. Below is the table of proposed codes and a short description of each.
@@ -145,6 +146,11 @@ public final class MsalClientException extends MsalException {
      * Extra query parameters set by the client app is already sent by the sdk.
      */
     public static final String DUPLICATE_QUERY_PARAMETER = ClientException.DUPLICATE_QUERY_PARAMETER;
+
+    /**
+     * Failed to bind the service in broker app.
+     */
+    public static final String BROKER_BIND_FAILURE = ErrorStrings.BROKER_BIND_SERVICE_FAILED;
 
     /**
      * Extra query parameters set by the client app is already sent by the sdk.

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -91,11 +91,6 @@ public class BrokerMsalController extends BaseController {
 
     private BrokerResultFuture mBrokerResultFuture;
 
-    /**
-     * ExecutorService to handle background computation.
-     */
-    private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
-
     @Override
     public AcquireTokenResult acquireToken(AcquireTokenOperationParameters parameters)
             throws InterruptedException, BaseException {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -112,14 +112,6 @@ public class BrokerMsalController extends BaseController {
         //Get the broker interactive parameters intent
         final Intent interactiveRequestIntent = getBrokerAuthorizationIntent(parameters);
 
-        final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
-        interactiveRequestIntent.putExtra(
-                AuthenticationConstants.Broker.BROKER_REQUEST_V2,
-                new Gson().toJson(
-                        msalBrokerRequestAdapter.brokerRequestFromAcquireTokenParameters(parameters),
-                        BrokerRequest.class)
-        );
-
         //Pass this intent to the BrokerActivity which will be used to start this activity
         final Intent brokerActivityIntent = new Intent(parameters.getAppContext(), BrokerActivity.class);
         brokerActivityIntent.putExtra(BrokerActivity.BROKER_INTENT, interactiveRequestIntent);
@@ -150,6 +142,13 @@ public class BrokerMsalController extends BaseController {
             Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
             Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
             interactiveRequestIntent = getBrokerAuthorizationIntentFromAuthService(parameters);
+            final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
+            interactiveRequestIntent.putExtra(
+                    AuthenticationConstants.Broker.BROKER_REQUEST_V2,
+                    new Gson().toJson(
+                            msalBrokerRequestAdapter.brokerRequestFromAcquireTokenParameters(parameters),
+                            BrokerRequest.class)
+            );
         } else {
             Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
             Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
@@ -743,9 +742,10 @@ public class BrokerMsalController extends BaseController {
     }
 
     static boolean isMicrosoftAuthServiceSupported(@NonNull final Context context) {
-        final MicrosoftAuthClient client = new MicrosoftAuthClient(context);
-        final Intent microsoftAuthServiceIntent = client.getIntentForAuthService(context);
-        return null != microsoftAuthServiceIntent;
+//        final MicrosoftAuthClient client = new MicrosoftAuthClient(context);
+//        final Intent microsoftAuthServiceIntent = client.getIntentForAuthService(context);
+//        return null != microsoftAuthServiceIntent;
+        return false;
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -750,10 +750,9 @@ public class BrokerMsalController extends BaseController {
     }
 
     static boolean isMicrosoftAuthServiceSupported(@NonNull final Context context) {
-//        final MicrosoftAuthClient client = new MicrosoftAuthClient(context);
-//        final Intent microsoftAuthServiceIntent = client.getIntentForAuthService(context);
-//        return null != microsoftAuthServiceIntent;
-        return false;
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(context);
+        final Intent microsoftAuthServiceIntent = client.getIntentForAuthService(context);
+        return null != microsoftAuthServiceIntent;
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -89,6 +89,9 @@ public class BrokerMsalController extends BaseController {
     private static final String TAG = BrokerMsalController.class.getSimpleName();
 
     private static final String DATA_USER_INFO = "com.microsoft.workaccount.user.info";
+    private static final String MANIFEST_PERMISSION_GET_ACCOUNTS = "android.permission.GET_ACCOUNTS";
+    private static final String MANIFEST_PERMISSION_MANAGE_ACCOUNTS = "android.permission.MANAGE_ACCOUNTS";
+    private static final String MANIFEST_PERMISSION_USE_CREDENTIALS = "android.permission.USE_CREDENTIALS";
 
     private BrokerResultFuture mBrokerResultFuture;
 
@@ -730,11 +733,11 @@ public class BrokerMsalController extends BaseController {
      */
     static boolean isAccountManagerPermissionsGranted(@NonNull final Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            return isPermissionGranted(context, "android.permission.GET_ACCOUNTS");
+            return isPermissionGranted(context, MANIFEST_PERMISSION_GET_ACCOUNTS);
         } else {
-            return isPermissionGranted(context, "android.permission.GET_ACCOUNTS")
-                    && isPermissionGranted(context, "android.permission.MANAGE_ACCOUNTS")
-                    && isPermissionGranted(context, "android.permission.USE_CREDENTIALS");
+            return isPermissionGranted(context, MANIFEST_PERMISSION_GET_ACCOUNTS)
+                    && isPermissionGranted(context, MANIFEST_PERMISSION_MANAGE_ACCOUNTS)
+                    && isPermissionGranted(context, MANIFEST_PERMISSION_USE_CREDENTIALS);
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -625,9 +625,8 @@ public class BrokerMsalController extends BaseController {
         accountRecord.setFirstName(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_GIVEN_NAME));
         accountRecord.setFamilyName(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_FAMILY_NAME));
         accountRecord.setName(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_USERID_DISPLAYABLE));
-        //TODO double check the realm and enviroment
-        accountRecord.setRealm(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER));
-        accountRecord.setEnvironment(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID));
+        accountRecord.setEnvironment(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_IDENTITY_PROVIDER));
+        accountRecord.setRealm(userInfoBundle.getString(AuthenticationConstants.Broker.ACCOUNT_USERINFO_TENANTID));
         return accountRecord;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -31,6 +31,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -70,7 +71,6 @@ import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperatio
 import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
-import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -217,6 +217,10 @@ public class BrokerMsalController extends BaseController {
             // Authenticator should throw OperationCanceledException if
             // token is not available
             intent = bundleResult.getParcelable(AccountManager.KEY_INTENT);
+            intent.putExtra(
+                    AuthenticationConstants.Broker.CALLER_INFO_UID,
+                    Binder.getCallingUid()
+            );
         } catch (final OperationCanceledException e) {
             Logger.error(
                     TAG + methodName,
@@ -415,6 +419,11 @@ public class BrokerMsalController extends BaseController {
         requestBundle.putString(
                 AuthenticationConstants.Broker.BROKER_REQUEST_V2,
                 new Gson().toJson(brokerRequest, BrokerRequest.class)
+        );
+
+        requestBundle.putInt(
+                AuthenticationConstants.Broker.CALLER_INFO_UID,
+                Binder.getCallingUid()
         );
 
         return requestBundle;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -136,14 +136,10 @@ public class MSALControllerFactory {
         }
 
         // Use broker if installed and verified
-        if (brokerInstalled(applicationContext)) {
+        if (brokerInstalled(applicationContext)
+                && (BrokerMsalController.isMicrosoftAuthServiceSupported(applicationContext)
+                || BrokerMsalController.isAccountManagerPermissionsGranted(applicationContext))) {
             return true;
-//            try {
-//                sayHelloToBroker(applicationConfiguration);
-//                return true;
-//            } catch (final ClientException exception) {
-//                return false;
-//            }
         }
 
         return false;
@@ -226,6 +222,4 @@ public class MSALControllerFactory {
             client.disconnect();
         }
     }
-
-
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -51,6 +51,20 @@ public class OperationParametersAdapter {
 
     private static final String TAG = OperationParameters.class.getName();
 
+    public static OperationParameters createOperationParameters (
+            PublicClientApplicationConfiguration configuration) {
+        final OperationParameters parameters = new OperationParameters();
+        parameters.setAppContext(configuration.getAppContext());
+        parameters.setTokenCache(configuration.getOAuth2TokenCache());
+        parameters.setClientId(configuration.getClientId());
+        parameters.setRedirectUri(configuration.getRedirectUri());
+        parameters.setAuthority(configuration.getDefaultAuthority());
+        parameters.setApplicationName(configuration.getAppContext().getPackageName());
+        parameters.setApplicationVersion(getPackageVersion(configuration.getAppContext()));
+        parameters.setSdkVersion(PublicClientApplication.getSdkVersion());
+        return parameters;
+    }
+
     public static AcquireTokenOperationParameters createAcquireTokenOperationParameters(
             AcquireTokenParameters acquireTokenParameters,
             PublicClientApplicationConfiguration publicClientApplicationConfiguration) {

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -55,14 +55,15 @@
                 <category android:name="android.intent.category.BROWSABLE" />
                 <!-- To Test PPE:  msal7cc2dd84-bb0f-4711-8fca-4c7d01249f56 -->
                 <!-- To Test Sovereign: msalcb7faed4-b8c0-49ee-b421-f5ed16894c83 -->
-                <data android:scheme="msal9851987a-55e5-46e2-8d70-75f8dc060f21"
-                    android:host="auth" />
+                <data android:scheme="msauth"
+                    android:host="com.microsoft.identity.client.sample.local"
+                    android:path="/QK0hWtPIQviyU3IX8AhunaS0IY4="/>
             </intent-filter>
         </activity>
 
         <meta-data
             android:name="com.microsoft.identity.client.ClientId"
-            android:value="9851987a-55e5-46e2-8d70-75f8dc060f21"/>
+            android:value="2652503c-ba8e-4ed9-b2ea-6512b9f16c98"/>
     </application>
 
 </manifest>

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -29,6 +29,9 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
+    <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
+    <uses-permission android:name="android.permission.USE_CREDENTIALS" />
 
     <application
         android:name="com.microsoft.identity.client.testapp.MsalSampleApp"

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -60,7 +60,7 @@
                 <!-- To Test Sovereign: msalcb7faed4-b8c0-49ee-b421-f5ed16894c83 -->
                 <data android:scheme="msauth"
                     android:host="com.microsoft.identity.client.sample.local"
-                    android:path="/QK0hWtPIQviyU3IX8AhunaS0IY4="/>
+                    android:path="/gwdiktUBDmQq+fbWiJoa+/YH070="/>
             </intent-filter>
         </activity>
 

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -63,10 +63,6 @@
                     android:path="/gwdiktUBDmQq+fbWiJoa+/YH070="/>
             </intent-filter>
         </activity>
-
-        <meta-data
-            android:name="com.microsoft.identity.client.ClientId"
-            android:value="2652503c-ba8e-4ed9-b2ea-6512b9f16c98"/>
     </application>
 
 </manifest>

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -354,7 +354,6 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     public void onAcquireTokenSilentClicked(final AcquireTokenFragment.RequestOptions requestOptions) {
         prepareRequestParameters(requestOptions);
 
-        //TODO need an adapt layer to adapt the AccountRecord to IAccount
         mApplication.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
             public void onTaskCompleted(final List<IAccount> accounts) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -58,7 +58,7 @@ import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.exception.MsalServiceException;
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
-import com.microsoft.identity.common.internal.controllers.IAccountCallback;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.Serializable;
@@ -276,9 +276,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         prepareRequestParameters(requestOptions);
 
         //final IAccount requestAccount = getAccount();
-        mApplication.getAccounts(new IAccountCallback<List<IAccount>>() {
+        mApplication.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
-            public void onSuccess(final List<IAccount> accounts) {
+            public void onTaskCompleted(final List<IAccount> accounts) {
                 IAccount requestAccount = null;
 
                 for (final IAccount account : accounts) {
@@ -311,16 +311,16 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
     }
 
     public void onRemoveUserClicked(final String username) {
-        mApplication.getAccounts(new IAccountCallback<List<IAccount>>() {
+        mApplication.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
-            public void onSuccess(List<IAccount> accountsToRemove) {
+            public void onTaskCompleted(List<IAccount> accountsToRemove) {
                 for (final IAccount accountToRemove : accountsToRemove) {
                     if (StringUtil.isEmpty(username) || accountToRemove.getUsername().equalsIgnoreCase(username.trim())) {
                         mApplication.removeAccount(
                                 accountToRemove,
-                                new IAccountCallback<Boolean>() {
+                                new PublicClientApplication.RemoveAccountCallback() {
                                     @Override
-                                    public void onSuccess(Boolean isSuccess) {
+                                    public void onTaskCompleted(Boolean isSuccess) {
                                         if (isSuccess) {
                                             showMessage("The account is successfully removed.");
                                         } else {
@@ -355,9 +355,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         prepareRequestParameters(requestOptions);
 
         //TODO need an adapt layer to adapt the AccountRecord to IAccount
-        mApplication.getAccounts(new IAccountCallback<List<IAccount>>() {
+        mApplication.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
-            public void onSuccess(final List<IAccount> accounts) {
+            public void onTaskCompleted(final List<IAccount> accounts) {
                 IAccount requestAccount = null;
 
                 for (final IAccount account : accounts) {
@@ -384,9 +384,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
     @Override
     public void bindSelectAccountSpinner(final Spinner selectUser) {
-        mApplication.getAccounts(new IAccountCallback<List<IAccount>>() {
+        mApplication.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
-            public void onSuccess(final List<IAccount> accounts) {
+            public void onTaskCompleted(final List<IAccount> accounts) {
                 final ArrayAdapter<String> userAdapter = new ArrayAdapter<>(
                         getApplicationContext(), android.R.layout.simple_spinner_item,
                         new ArrayList<String>() {{

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -57,6 +57,7 @@ import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.exception.MsalServiceException;
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
 
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -39,8 +39,7 @@ import com.google.gson.JsonObject;
 import com.microsoft.identity.client.AzureActiveDirectoryAccountIdentifier;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.PublicClientApplication;
-import com.microsoft.identity.common.internal.controllers.IAccountCallback;
-import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,9 +66,9 @@ public class UsersFragment extends Fragment {
         mUserList = view.findViewById(R.id.user_list);
 
         final PublicClientApplication pca = ((MainActivity) this.getActivity()).getPublicClientApplication();
-        pca.getAccounts(new IAccountCallback<List<IAccount>>() {
+        pca.getAccounts(new PublicClientApplication.LoadAccountCallback() {
             @Override
-            public void onSuccess(final List<IAccount> accounts) {
+            public void onTaskCompleted(final List<IAccount> accounts) {
                 mGson = new GsonBuilder().setPrettyPrinting().create();
                 final List<String> serializedUsers = new ArrayList<>(accounts.size());
                 for (final IAccount account : accounts) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -36,9 +36,13 @@ import android.widget.ListView;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import com.microsoft.identity.client.AccountAdapter;
 import com.microsoft.identity.client.AzureActiveDirectoryAccountIdentifier;
 import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.common.internal.controllers.IAccountCallback;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,13 +69,13 @@ public class UsersFragment extends Fragment {
         mUserList = view.findViewById(R.id.user_list);
 
         final PublicClientApplication pca = ((MainActivity) this.getActivity()).getPublicClientApplication();
-        pca.getAccounts(new PublicClientApplication.AccountsLoadedCallback() {
+        pca.getAccounts(new IAccountCallback<List<AccountRecord>>() {
             @Override
-            public void onAccountsLoaded(final List<IAccount> accounts) {
+            public void onSuccess(final List<AccountRecord> accounts) {
                 mGson = new GsonBuilder().setPrettyPrinting().create();
                 final List<String> serializedUsers = new ArrayList<>(accounts.size());
-                for (final IAccount account : accounts) {
-                    JsonObject jsonAcct = transformToJson(account);
+                for (final AccountRecord account : accounts) {
+                    JsonObject jsonAcct = transformToJson(AccountAdapter.adapt(account));
                     serializedUsers.add(mGson.toJson(jsonAcct));
                 }
 
@@ -81,11 +85,16 @@ public class UsersFragment extends Fragment {
                 mUserList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        final IAccount selectedAccount = accounts.get(position);
-                        ((MainActivity) getActivity()).setUser(selectedAccount);
+                        final AccountRecord selectedAccount = accounts.get(position);
+                        ((MainActivity) getActivity()).setUser(AccountAdapter.adapt(selectedAccount));
                         getFragmentManager().popBackStack();
                     }
                 });
+            }
+
+            @Override
+            public void onError(final Exception e) {
+                //TODO
             }
         });
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -36,10 +36,8 @@ import android.widget.ListView;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import com.microsoft.identity.client.AccountAdapter;
 import com.microsoft.identity.client.AzureActiveDirectoryAccountIdentifier;
 import com.microsoft.identity.client.IAccount;
-import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.common.internal.controllers.IAccountCallback;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -69,13 +67,13 @@ public class UsersFragment extends Fragment {
         mUserList = view.findViewById(R.id.user_list);
 
         final PublicClientApplication pca = ((MainActivity) this.getActivity()).getPublicClientApplication();
-        pca.getAccounts(new IAccountCallback<List<AccountRecord>>() {
+        pca.getAccounts(new IAccountCallback<List<IAccount>>() {
             @Override
-            public void onSuccess(final List<AccountRecord> accounts) {
+            public void onSuccess(final List<IAccount> accounts) {
                 mGson = new GsonBuilder().setPrettyPrinting().create();
                 final List<String> serializedUsers = new ArrayList<>(accounts.size());
-                for (final AccountRecord account : accounts) {
-                    JsonObject jsonAcct = transformToJson(AccountAdapter.adapt(account));
+                for (final IAccount account : accounts) {
+                    JsonObject jsonAcct = transformToJson(account);
                     serializedUsers.add(mGson.toJson(jsonAcct));
                 }
 
@@ -85,8 +83,8 @@ public class UsersFragment extends Fragment {
                 mUserList.setOnItemClickListener(new AdapterView.OnItemClickListener() {
                     @Override
                     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                        final AccountRecord selectedAccount = accounts.get(position);
-                        ((MainActivity) getActivity()).setUser(AccountAdapter.adapt(selectedAccount));
+                        final IAccount selectedAccount = accounts.get(position);
+                        ((MainActivity) getActivity()).setUser(selectedAccount);
                         getFragmentManager().popBackStack();
                     }
                 });

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -4,7 +4,6 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/gwdiktUBDmQq%2BfbWiJoa%2B%2FYH070%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
-  "minimum.required.broker.protocol.version":"2.0",
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -1,9 +1,10 @@
 {
-  "client_id" : "9851987a-55e5-46e2-8d70-75f8dc060f21",
+  "client_id" : "2652503c-ba8e-4ed9-b2ea-6512b9f16c98",
   "authorization_user_agent" : "DEFAULT",
-  "redirect_uri" : "msal9851987a-55e5-46e2-8d70-75f8dc060f21://auth",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
+  "minimum.required.broker.protocol.version":"2.0",
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -1,7 +1,7 @@
 {
   "client_id" : "2652503c-ba8e-4ed9-b2ea-6512b9f16c98",
   "authorization_user_agent" : "DEFAULT",
-  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/gwdiktUBDmQq%2BfbWiJoa%2B%2FYH070%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
   "minimum.required.broker.protocol.version":"2.0",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -1,7 +1,10 @@
 {
-  "client_id" : "9851987a-55e5-46e2-8d70-75f8dc060f21",
+  "client_id" : "2652503c-ba8e-4ed9-b2ea-6512b9f16c98",
   "authorization_user_agent" : "WEBVIEW",
-  "redirect_uri" : "msal9851987a-55e5-46e2-8d70-75f8dc060f21://auth",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
+  "multiple_clouds_supported":true,
+  "broker_redirect_uri_registered": true,
+  "minimum.required.broker.protocol.version":"2.0",
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -1,7 +1,7 @@
 {
   "client_id" : "2652503c-ba8e-4ed9-b2ea-6512b9f16c98",
   "authorization_user_agent" : "WEBVIEW",
-  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/QK0hWtPIQviyU3IX8AhunaS0IY4%3D",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/gwdiktUBDmQq%2BfbWiJoa%2B%2FYH070%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
   "minimum.required.broker.protocol.version":"2.0",


### PR DESCRIPTION
- Add the eligibility checking for account manager
- Fix the eligibility checking to talk to broker
- Add the fallback logic when bound service is not supported
- Add the implementation for getAccount through AccountManager
- Add the implementation for removeAccount through AccountManager
- Add the implementation for interactive acquire token through AccountManager
- Add the implementation for silent acquire token through AccountManager

E2E testing
1. [single account] Add account through AccountManager [**passed**]
2. [single account] Silent acquireToken through AccountManager [**passed**]
3. [single account] get the account from broker through AccountManager [**passed**]
4. [single account] remove account through AccountManager [**passed**]
5. [multiple accounts] Add account through AccountManager [**passed**]
6. [multiple accounts] Silent acquireToken through AccountManager [**passed**]
7. [multiple accounts] get the account from broker through AccountManager [**passed**]
8. [multiple accounts] remove account through AccountManager [**passed**]