### PR TITLE
Put login_hint in interactiveRequest intent

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -105,6 +105,8 @@ public class BrokerMsalController extends BaseController {
                         BrokerRequest.class)
         );
 
+        interactiveRequestIntent.putExtra(AuthenticationConstants.Broker.ACCOUNT_NAME, parameters.getLoginHint());
+
         //Pass this intent to the BrokerActivity which will be used to start this activity
         final Intent brokerActivityIntent = new Intent(parameters.getAppContext(), BrokerActivity.class);
         brokerActivityIntent.putExtra(BrokerActivity.BROKER_INTENT, interactiveRequestIntent);


### PR DESCRIPTION
as of now, login_hint is not passed to AccountChooserActivity.

MSAuthenticator app's AccountChooserActivity is relying on login hint (to determine whether it should show the account list).