### PR TITLE
Resolves #605 (Removes AccountAdapter from public API surface)

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -35,7 +35,7 @@ import com.microsoft.identity.common.internal.util.StringUtil;
 /**
  * Adapter class for Account transformations.
  */
-public class AccountAdapter {
+class AccountAdapter {
 
     private static final String TAG = AccountAdapter.class.getSimpleName();
 


### PR DESCRIPTION
Closes #605 

I've elected _not_ to move this class to the `internal` package and instead remove the `public` access modifier. This class unfortunately cannot move to `internal` without _increasing_ the visibility of [`setObjectIdentifier`](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/AzureActiveDirectoryAccountIdentifier.java#L45-L47) and [`setTenantIdentifier()`](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/AzureActiveDirectoryAccountIdentifier.java#L63-L65) which we don't wish to expose externally (these values should be `read-only` to the external developer)