### PR TITLE
Add tenantProfile support in FLW flows

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -26,6 +26,8 @@ package com.microsoft.identity.client;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
+
 /**
  * An interface that contains list of operations that are available when MSAL is in 'multiple account' mode.
  * - This mode allows an application to make API calls with more than one accounts.
@@ -60,6 +62,6 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * @return True, if the account was removed. False otherwise.
      */
     void removeAccount(@Nullable final IAccount account,
-                       final PublicClientApplication.RemoveAccountCallback callback
+                       @NonNull final TaskCompletedCallbackWithError<Boolean, Exception> callback
     );
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -23,7 +23,10 @@
 
 package com.microsoft.identity.client;
 
-import com.microsoft.identity.client.exception.MsalClientException;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 
 /**
  * An interface that contains list of operations that are available when MSAL is in 'single account' mode.
@@ -40,29 +43,26 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * This method must be called whenever the application is resumed or prior to running a scheduled background operation.
      *
      * @param listener a callback to be invoked when the operation finishes.
-     * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
      */
-    void getCurrentAccount(final CurrentAccountListener listener) throws MsalClientException;
+    void getCurrentAccount(@NonNull final CurrentAccountCallback listener);
 
     /**
      * Removes the Account and Credentials (tokens) of the account that is currently signed into the device.
      *
      * @param callback a callback to be invoked when the operation finishes.
-     * @throws MsalClientException if this function is invoked when the app is no longer in the single account mode.
      */
-    void removeCurrentAccount(final PublicClientApplication.RemoveAccountCallback callback) throws MsalClientException;
+    void removeCurrentAccount(@NonNull final TaskCompletedCallbackWithError<Boolean, Exception> callback);
 
     /**
      * Callback for asynchronous loading of the msal IAccount account.
      */
-    interface CurrentAccountListener {
+    interface CurrentAccountCallback {
         /**
          * Invoked when the account is loaded.
-         * The calling app is responsible for keeping track of this account and cleaning its states if the account changes.
          *
          * @param activeAccount the signed-in account. This could be nil.
          */
-        void onAccountLoaded(final IAccount activeAccount);
+        void onAccountLoaded(@Nullable final IAccount activeAccount);
 
         /**
          * Invoked when signed-in account is changed after the application resumes, or prior to running a scheduled background operation.
@@ -71,6 +71,13 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
          * @param priorAccount   the previous signed-in account. This could be nil.
          * @param currentAccount the current signed-in account. This could be nil.
          */
-        void onAccountChanged(final IAccount priorAccount, final IAccount currentAccount);
+        void onAccountChanged(@Nullable final IAccount priorAccount, @Nullable final IAccount currentAccount);
+
+        /**
+         * Invoked when the account failed to load.
+         *
+         * @param exception the exception object.
+         */
+        void onError(@NonNull final Exception exception);
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -239,7 +239,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
     @Override
     public void removeAccount(@Nullable final IAccount account,
-                              @NonNull final RemoveAccountCallback callback) {
+                              @NonNull final TaskCompletedCallbackWithError<Boolean, Exception> callback) {
         ApiDispatcher.initializeDiagnosticContext();
 
         // First, cast the input IAccount to a MultiTenantAccount

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -508,22 +508,6 @@ public class PublicClientApplication implements IPublicClientApplication {
         void onError(Exception exception);
     }
 
-    public interface RemoveAccountCallback extends TaskCompletedCallbackWithError<Boolean, Exception> {
-        /**
-         * Called once succeed and pass the result object.
-         *
-         * @param result the success result.
-         */
-        void onTaskCompleted(Boolean result);
-
-        /**
-         * Called once exception thrown.
-         *
-         * @param exception
-         */
-        void onError(Exception exception);
-    }
-
     @Override
     public void handleInteractiveRequestRedirect(final int requestCode,
                                                  final int resultCode,

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -4,19 +4,32 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
-import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
+import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
+import com.microsoft.identity.common.internal.cache.CacheKeyValueDelegate;
+import com.microsoft.identity.common.internal.cache.CacheRecord;
+import com.microsoft.identity.common.internal.cache.IAccountCredentialCache;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.cache.MicrosoftStsAccountCredentialAdapter;
+import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesAccountCredentialCache;
+import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
+import com.microsoft.identity.common.internal.dto.IdTokenRecord;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class SingleAccountPublicClientApplication extends PublicClientApplication
         implements ISingleAccountPublicClientApplication {
     private static final String TAG = SingleAccountPublicClientApplication.class.getSimpleName();
 
-    private AccountRecord mLocalAccountRecord;
+    /**
+     * Name of the shared preference cache for storing current account.
+     * */
+    public static final String SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES =
+            "com.microsoft.identity.client.single_account_credential_cache";
 
     protected SingleAccountPublicClientApplication(@NonNull final Context context,
                                                    @NonNull final PublicClientApplicationConfiguration developerConfig) {
@@ -35,55 +48,47 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public void getCurrentAccount(final CurrentAccountListener listener) throws MsalClientException {
-        final String methodName = ":getCurrentAccount";
+    public void getCurrentAccount(@NonNull final CurrentAccountCallback callback) {
         final PublicClientApplicationConfiguration configuration = getConfiguration();
-
-        if (!MSALControllerFactory.brokerEligible(
-                configuration.getAppContext(),
-                configuration.getDefaultAuthority(),
-                configuration)) {
-            final String errorMessage = "This request is not eligible to use the broker.";
-            com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
-            throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
-        }
 
         new BrokerMsalController().getCurrentAccount(
                 configuration,
-                new BrokerMsalController.GetCurrentAccountRecordFromBrokerCallback() {
+                new TaskCompletedCallbackWithError<List<ICacheRecord>, Exception>() {
                     @Override
-                    public void onAccountLoaded(@Nullable final List<ICacheRecord> cacheRecords) {
-                        // TODO implement...
-                        // TODO check if the cache records are null before trying to adapt...
-                        // TODO the List that is returned should adapt into a single IAccount
-                        // TODO Dome... you can use this return type to support FLW
-                        final List<IAccount> account = AccountAdapter.adapt(cacheRecords);
+                    public void onTaskCompleted(List<ICacheRecord> cacheRecords) {
+                        MultiTenantAccount currentAccount = getPersistedCurrentAccount(configuration.getAppContext());
+                        MultiTenantAccount newAccount = getAccountFromICacheRecordList(cacheRecords);
+
+                        String currentAccountHomeAccountId = currentAccount == null ? "" : currentAccount.getHomeAccountId();
+                        String newAccountHomeAccountId = newAccount == null ? "" :  newAccount.getHomeAccountId();
+
+                        boolean isCurrentAccountChanged = !currentAccountHomeAccountId.equalsIgnoreCase(newAccountHomeAccountId);
+                        if (isCurrentAccountChanged){
+                            persistCurrentAccount(configuration.getAppContext(), cacheRecords);
+                            callback.onAccountChanged(currentAccount, newAccount);
+                        }
+
+                        callback.onAccountLoaded(newAccount);
+                    }
+
+                    @Override
+                    public void onError(Exception exception) {
+                        callback.onError(exception);
                     }
                 });
     }
 
     @Override
-    public void removeCurrentAccount(final RemoveAccountCallback callback) throws MsalClientException {
-        final String methodName = ":removeCurrentAccount";
+    public void removeCurrentAccount(@NonNull final TaskCompletedCallbackWithError<Boolean, Exception> callback) {
         final PublicClientApplicationConfiguration configuration = getConfiguration();
 
-        if (!MSALControllerFactory.brokerEligible(
-                configuration.getAppContext(),
-                configuration.getDefaultAuthority(),
-                configuration)) {
-            final String errorMessage = "This request is not eligible to use the broker.";
-            com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
-            throw new MsalClientException(MsalClientException.BROKER_NOT_INSTALLED, errorMessage);
-        }
-
         new BrokerMsalController().removeAccountFromSharedDevice(
-                null, // TODO for Dome... this should be the IAccount
                 configuration,
-                new RemoveAccountCallback() {
+                new TaskCompletedCallbackWithError<Boolean, Exception>() {
                     @Override
                     public void onTaskCompleted(Boolean success) {
                         if (success) {
-                            mLocalAccountRecord = null;
+                            persistCurrentAccount(configuration.getAppContext(), null);
                         }
 
                         callback.onTaskCompleted(success);
@@ -94,5 +99,115 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                         callback.onError(exception);
                     }
                 });
+    }
+
+    private MsalOAuth2TokenCache getTokenCache(@NonNull final Context appContext,
+                                               @NonNull final IAccountCredentialCache accountCredentialCache) {
+        return new MsalOAuth2TokenCache(
+                appContext,
+                accountCredentialCache,
+                new MicrosoftStsAccountCredentialAdapter());
+    }
+
+    private IAccountCredentialCache getCurrentAccountCredentialCache(final Context appContext){
+        return new SharedPreferencesAccountCredentialCache(
+                new CacheKeyValueDelegate(),
+                new SharedPreferencesFileManager(
+                        appContext,
+                        SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES,
+                        new StorageHelper(appContext)
+                )
+        );
+    }
+
+    /**
+     * Get current account that is persisted in shared preference.
+     *
+     * @param appContext
+     * @return a persisted MultiTenantAccount. This could be null.
+     * */
+    @Nullable
+    private MultiTenantAccount getPersistedCurrentAccount(@NonNull final Context appContext) {
+        final String methodName = ":getPersistedCurrentAccount";
+        final IAccountCredentialCache accountCredentialCache = getCurrentAccountCredentialCache(appContext);
+        final MsalOAuth2TokenCache msalOAuth2TokenCache = getTokenCache(appContext, accountCredentialCache);
+
+        List<AccountRecord> accountRecords = accountCredentialCache.getAccounts();
+        if (accountRecords.size() == 0) {
+            return null;
+        } else if (accountRecords.size() > 1) {
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Returned accountRecords are larger than 1. " +
+                            "This is unexpected in Single account mode." +
+                            "Clear the cache and return null.");
+
+            accountCredentialCache.clearAll();
+            return null;
+        }
+
+        AccountRecord accountRecord = accountRecords.get(0);
+        List<IdTokenRecord> idTokenRecordList = msalOAuth2TokenCache.getIdTokensForAccountRecord(null, accountRecord);
+
+        List<ICacheRecord> cacheRecordList = new ArrayList<>();
+        for (final IdTokenRecord idTokenRecord : idTokenRecordList) {
+            CacheRecord cacheRecord = new CacheRecord();
+            cacheRecord.setAccount(accountRecord);
+            cacheRecord.setIdToken(idTokenRecord);
+            cacheRecordList.add(cacheRecord);
+        }
+
+        return getAccountFromICacheRecordList(cacheRecordList);
+    }
+
+    /**
+     * Persists current account to shared preference.
+     *
+     * @param appContext
+     * @param cacheRecords list of cache record that belongs to an account.
+     *                     Please note that this layer will not verify if the list belongs to a single account or not.
+     * */
+    private void persistCurrentAccount(@NonNull final Context appContext,
+                                       @Nullable List<ICacheRecord> cacheRecords) {
+        final IAccountCredentialCache accountCredentialCache = getCurrentAccountCredentialCache(appContext);
+        final MsalOAuth2TokenCache msalOAuth2TokenCache = getTokenCache(appContext, accountCredentialCache);
+
+        // clear the current entry.
+        accountCredentialCache.clearAll();
+
+        if (cacheRecords == null || cacheRecords.size() == 0) {
+            // Do nothing.
+            return;
+        }
+
+        for(ICacheRecord record : cacheRecords){
+            msalOAuth2TokenCache.save(record.getAccount(), record.getIdToken());
+        }
+    }
+
+    /**
+     * Get a MultiTenantAccount from a list of ICacheRecord.
+     *
+     * @param cacheRecords list of cache record that belongs to an account.
+     *                     If the list can be converted to multiple accounts, only the first one will be returned.
+     * */
+    @Nullable
+    private MultiTenantAccount getAccountFromICacheRecordList(@NonNull List<ICacheRecord> cacheRecords) {
+        final String methodName = ":getAccountFromICacheRecords";
+        if (cacheRecords == null || cacheRecords.size() == 0) {
+            return null;
+        }
+
+        final List<IAccount> account = AccountAdapter.adapt(cacheRecords);
+
+        if (account.size() != 1) {
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Returned cacheRecords were adapted into multiple IAccount. " +
+                            "This is unexpected in Single account mode." +
+                            "Returning the first adapted account.");
+        }
+
+        return (MultiTenantAccount) account.get(0);
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -163,6 +163,11 @@ public final class MsalClientException extends MsalException {
     public static final String BROKER_NOT_INSTALLED = "broker_not_installed";
 
     /**
+     * Not eligible to use Broker.
+     */
+    public static final String NOT_ELIGIBLE_TO_USE_BROKER = "not_eligible_to_use_broker";
+
+    /**
      * Temporary non-exposed error code to indicate that ADFS authority validation fails. ADFS as authority is not supported
      * for preview.
      */

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -686,7 +686,7 @@ public class BrokerMsalController extends BaseController {
                 callback,
                 new BrokerTask<List<ICacheRecord>>() {
                     @Override
-                    public List<ICacheRecord> perform(IMicrosoftAuthService service) throws RemoteException {
+                    public List<ICacheRecord> perform(IMicrosoftAuthService service) throws ClientException, RemoteException {
                         // TODO also pass clientID and redirectURL so that it gets ICacheRecord specific to this particular app.
                         return MsalBrokerResultAdapter
                                 .currentAccountFromBundle(

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -937,7 +937,7 @@ public class BrokerMsalController extends BaseController {
                         if (resultBundle == null) {
                             return true;
                         } else {
-                            BrokerResult brokerResult = (BrokerResult) resultBundle.getSerializable(AuthenticationConstants.Broker.BROKER_RESULT_V2);
+                            final BrokerResult brokerResult = MsalBrokerResultAdapter.brokerResultFromBundle(resultBundle);
                             com.microsoft.identity.common.internal.logging.Logger.error(
                                     TAG,
                                     "Failed to perform global sign-out."

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -276,7 +276,11 @@ public class MsalWrapper {
             mApplication.acquireTokenSilentAsync(
                     requestOptions.getScopes().toLowerCase().split(" "),
                     mLoadedAccount.get(0),
-                    null,
+                    mApplication
+                            .getConfiguration()
+                            .getDefaultAuthority()
+                            .getAuthorityUri()
+                            .toString(),
                     requestOptions.forceRefresh(),
                     getAuthenticationCallback(notifyCallback));
         }


### PR DESCRIPTION
- Get back ICacheRecord lists from Broker
- Persists ICacheRecords of the current account in SharedPreference, and use that to keep track of the currently signed-in account. (#624)
- In BrokerMsalController.java, Extract boiler plate code into performBrokerTask().
- ISingleAccountPublicApplication now uses callback that supports exception (instead of just throwing it).

Flows are verified. Broker changes will follow.