### PR TITLE
Fixes for single account

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -302,9 +302,12 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                 MultiTenantAccount newAccount = getAccountFromICacheRecordList(localAuthenticationResult.getCacheRecordWithTenantProfileData());
 
                 if (didCurrentAccountChange(newAccount)) {
-                    //Throw on Error with UserMismatchException
-                    authenticationCallback.onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH));
-                    return;
+                    if(getPersistedCurrentAccount() != null) {
+                        authenticationCallback.onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH));
+                        return;
+                    }else{
+                        persistCurrentAccount(localAuthenticationResult.getCacheRecordWithTenantProfileData());
+                    }
                 } else {
                     persistCurrentAccount(localAuthenticationResult.getCacheRecordWithTenantProfileData());
                 }


### PR DESCRIPTION
The state transition from null to an account was not being handled correctly.  This fix ensures that sign in may complete successfully.