### PR TITLE
Broker Strategies and the protocol verification with MSAL | part2/3

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -339,6 +339,7 @@ public class PublicClientApplicationConfiguration {
         this.mMultipleCloudsSupported = config.mMultipleCloudsSupported == null ? this.mMultipleCloudsSupported : config.mMultipleCloudsSupported;
         this.mUseBroker = config.mUseBroker == null ? this.mUseBroker : config.mUseBroker;
         this.mTelemetryConfiguration = config.mTelemetryConfiguration == null ? this.mTelemetryConfiguration : config.mTelemetryConfiguration;
+        this.mRequiredBrokerProtocolVersion = config.mRequiredBrokerProtocolVersion == null ? this.mRequiredBrokerProtocolVersion : config.mRequiredBrokerProtocolVersion;
         if (this.mBrowserSafeList == null) {
             this.mBrowserSafeList = config.mBrowserSafeList;
         } else if (config.mBrowserSafeList != null){

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -1,0 +1,359 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.internal.controllers;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.annotation.SuppressLint;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
+
+import com.google.gson.Gson;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.broker.BrokerRequest;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
+import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
+import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
+import com.microsoft.identity.common.internal.request.OperationParameters;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
+
+public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
+    private static final String TAG = BrokerAccountManagerStrategy.class.getSimpleName();
+
+    private static final String DATA_USER_INFO = "com.microsoft.workaccount.user.info";
+    private static final String DATA_CACHE_RECORD = "com.microsoft.workaccount.cache.record";
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    @WorkerThread
+    Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
+        final String methodName = ":getBrokerAuthorizationIntent";
+        Intent interactiveRequestIntent;
+
+
+        Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
+        Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
+        interactiveRequestIntent = getBrokerAuthorizationIntentFromAccountManager(parameters);
+
+        return interactiveRequestIntent;
+    }
+
+    @SuppressLint("MissingPermission")
+    private Intent getBrokerAuthorizationIntentFromAccountManager(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
+        final String methodName = ":getBrokerAuthorizationIntentFromAccountManager";
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+        );
+        Intent intent;
+        try {
+            final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
+
+            final Bundle requestBundle = new Bundle();
+            final BrokerRequest brokerRequest = msalBrokerRequestAdapter.
+                    brokerRequestFromAcquireTokenParameters(parameters);
+
+            requestBundle.putString(
+                    AuthenticationConstants.Broker.BROKER_REQUEST_V2,
+                    new Gson().toJson(brokerRequest, BrokerRequest.class)
+            );
+
+            final AccountManager accountManager = AccountManager.get(parameters.getAppContext());
+            final AccountManagerFuture<Bundle> result =
+                    accountManager.addAccount(
+                            AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
+                            AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                            null,
+                            requestBundle,
+                            null,
+                            null,
+                            getPreferredHandler()
+                    );
+
+            // Making blocking request here
+            Bundle bundleResult = result.getResult();
+            // Authenticator should throw OperationCanceledException if
+            // token is not available
+            intent = bundleResult.getParcelable(AccountManager.KEY_INTENT);
+            intent.putExtra(
+                    AuthenticationConstants.Broker.CALLER_INFO_UID,
+                    Binder.getCallingUid()
+            );
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(true)
+            );
+        } catch (final OperationCanceledException e) {
+            Logger.error(
+                    TAG + methodName,
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "Exception thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
+                            .putErrorDescription("OperationCanceledException thrown when talking to account manager. The broker request cancelled.")
+            );
+
+            throw new ClientException(
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "OperationCanceledException thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+        } catch (final AuthenticatorException e) {
+            Logger.error(
+                    TAG + methodName,
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
+                            .putErrorDescription("AuthenticatorException thrown when talking to account manager. The broker request cancelled.")
+            );
+
+            throw new ClientException(
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+        } catch (final IOException e) {
+            // Authenticator gets problem from webrequest or file read/write
+            Logger.error(
+                    TAG + methodName,
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "IOException thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
+                            .putErrorDescription("IOException thrown when talking to account manager. The broker request cancelled.")
+            );
+
+            throw new ClientException(
+                    ErrorStrings.BROKER_REQUEST_CANCELLED,
+                    "IOException thrown when talking to account manager. The broker request cancelled.",
+                    e
+            );
+        }
+
+        return intent;
+    }
+
+    @WorkerThread
+    @SuppressLint("MissingPermission")
+    AcquireTokenResult acquireTokenSilent(final AcquireTokenSilentOperationParameters parameters)
+            throws BaseException {
+        // if there is not any user added to account, it returns empty
+        final String methodName = ":acquireTokenSilentWithAccountManager";
+        Bundle bundleResult = null;
+        if (parameters.getAccount() != null) {
+            // blocking call to get token from cache or refresh request in
+            // background at Authenticator
+            try {
+
+                final Bundle requestBundle = getSilentBrokerRequestBundle(parameters);
+
+                // It does not expect activity to be launched.
+                // AuthenticatorService is handling the request at
+                // AccountManager.
+                final AccountManager accountManager = AccountManager.get(parameters.getAppContext());
+                final AccountManagerFuture<Bundle> result =
+                        accountManager.getAuthToken(
+                                getTargetAccount(parameters.getAppContext(), parameters.getAccount()),
+                                AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                                requestBundle,
+                                false,
+                                null, //set to null to avoid callback
+                                getPreferredHandler()
+                        );
+
+                // Making blocking request here
+                Logger.verbose(TAG + methodName, "Received result from broker");
+                bundleResult = result.getResult();
+            } catch (final OperationCanceledException e) {
+                Logger.error(
+                        TAG + methodName,
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "Exception thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+
+                throw new ClientException(
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "OperationCanceledException thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+            } catch (final AuthenticatorException e) {
+                Logger.error(
+                        TAG + methodName,
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+
+                throw new ClientException(
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+            } catch (final IOException e) {
+                // Authenticator gets problem from webrequest or file read/write
+                Logger.error(
+                        TAG + methodName,
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "IOException thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+
+                throw new ClientException(
+                        ErrorStrings.BROKER_REQUEST_CANCELLED,
+                        "IOException thrown when talking to account manager. The broker request cancelled.",
+                        e
+                );
+            }
+        }
+
+        return getAcquireTokenResult(bundleResult);
+    }
+
+    @WorkerThread
+    @SuppressLint("MissingPermission")
+    protected List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters)
+            throws OperationCanceledException, IOException, AuthenticatorException, ClientException {
+        final String methodName = ":getBrokerAccountsFromAccountManager";
+        final Account[] accountList = AccountManager.get(parameters.getAppContext()).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
+        final List<ICacheRecord> cacheRecords = new ArrayList<>();
+        Logger.verbose(
+                TAG + methodName,
+                "Retrieve all the accounts from account manager with broker account type, "
+                        + "and the account length is: " + accountList.length
+        );
+
+        if (accountList == null || accountList.length == 0) {
+            return cacheRecords;
+        } else {
+            final Bundle bundle = new Bundle();
+            bundle.putBoolean(DATA_CACHE_RECORD, true);
+            bundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
+
+            for (final Account eachAccount : accountList) {
+                // Use AccountManager Api method to get extended user info
+
+                final AccountManagerFuture<Bundle> result = AccountManager.get(parameters.getAppContext())
+                        .updateCredentials(
+                                eachAccount,
+                                AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                                bundle,
+                                null,
+                                null,
+                                null
+                        );
+
+                final Bundle userInfoBundle = result.getResult();
+                cacheRecords.addAll(
+                        MsalBrokerResultAdapter.accountsFromBundle(userInfoBundle)
+                );
+            }
+
+            return cacheRecords;
+        }
+    }
+
+    @WorkerThread
+    @SuppressLint("MissingPermission")
+    protected boolean removeBrokerAccount(@NonNull final OperationParameters parameters) {
+        final String methodName = ":removeBrokerAccountFromAccountManager";
+        // getAuthToken call will execute in async as well
+        Logger.verbose(TAG + methodName, "Try to remove account from account manager.");
+
+        //If account is null, remove all accounts from broker
+        //Otherwise, get the target account and remove it from broker
+        Account[] accountList = AccountManager.get(parameters.getAppContext()).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
+        if (accountList != null && accountList.length > 0) {
+            for (final Account eachAccount : accountList) {
+                if (parameters.getAccount() == null || eachAccount.name.equalsIgnoreCase(parameters.getAccount().getUsername())) {
+                    //create remove request bundle
+                    Bundle brokerOptions = new Bundle();
+                    brokerOptions.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
+                    brokerOptions.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
+                    brokerOptions.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
+                    brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS,
+                            AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS_VALUE);
+                    AccountManager.get(parameters.getAppContext()).getAuthToken(
+                            eachAccount,
+                            AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
+                            brokerOptions,
+                            false,
+                            null, //set to null to avoid callback
+                            getPreferredHandler()
+                    );
+                }
+            }
+        }
+
+        return true;
+    }
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -75,14 +75,8 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @WorkerThread
     Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
         final String methodName = ":getBrokerAuthorizationIntent";
-        Intent interactiveRequestIntent;
-
-
-        Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
         Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
-        interactiveRequestIntent = getBrokerAuthorizationIntentFromAccountManager(parameters);
-
-        return interactiveRequestIntent;
+        return getBrokerAuthorizationIntentFromAccountManager(parameters);
     }
 
     @SuppressLint("MissingPermission")
@@ -99,7 +93,10 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
             final Bundle requestBundle = new Bundle();
             final BrokerRequest brokerRequest = msalBrokerRequestAdapter.
                     brokerRequestFromAcquireTokenParameters(parameters);
-
+            requestBundle.putInt(
+                    AuthenticationConstants.Broker.CALLER_INFO_UID,
+                    Binder.getCallingUid()
+            );
             requestBundle.putString(
                     AuthenticationConstants.Broker.BROKER_REQUEST_V2,
                     new Gson().toJson(brokerRequest, BrokerRequest.class)
@@ -296,6 +293,8 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
         } else {
             final Bundle bundle = new Bundle();
             bundle.putBoolean(DATA_CACHE_RECORD, true);
+            bundle.putInt(AuthenticationConstants.Broker.CALLER_INFO_UID,
+                    Binder.getCallingUid());
             bundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
 
             for (final Account eachAccount : accountList) {
@@ -338,6 +337,8 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
                     Bundle brokerOptions = new Bundle();
                     brokerOptions.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
                     brokerOptions.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
+                    brokerOptions.putInt(AuthenticationConstants.Broker.CALLER_INFO_UID,
+                            Binder.getCallingUid());
                     brokerOptions.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
                     brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS,
                             AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS_VALUE);

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -69,9 +69,8 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
     @WorkerThread
     Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
         final String methodName = ":getBrokerAuthorizationIntent";
-        Intent interactiveRequestIntent;
-        Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
         Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
+        Intent interactiveRequestIntent;
         interactiveRequestIntent = getBrokerAuthorizationIntentFromAuthService(parameters);
         final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
         interactiveRequestIntent.putExtra(

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -1,0 +1,269 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.internal.controllers;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.RemoteException;
+import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
+
+import com.google.gson.Gson;
+import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+import com.microsoft.identity.common.internal.broker.BrokerRequest;
+import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
+import com.microsoft.identity.common.internal.broker.MicrosoftAuthServiceFuture;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
+import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
+import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
+import com.microsoft.identity.common.internal.request.OperationParameters;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+import com.microsoft.identity.common.internal.telemetry.Telemetry;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
+import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
+
+public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
+    private static final String TAG = BrokerAuthServiceStrategy.class.getSimpleName();
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    @WorkerThread
+    Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
+        final String methodName = ":getBrokerAuthorizationIntent";
+        Intent interactiveRequestIntent;
+        Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
+        Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
+        interactiveRequestIntent = getBrokerAuthorizationIntentFromAuthService(parameters);
+        final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
+        interactiveRequestIntent.putExtra(
+                AuthenticationConstants.Broker.BROKER_REQUEST_V2,
+                new Gson().toJson(
+                        msalBrokerRequestAdapter.brokerRequestFromAcquireTokenParameters(parameters),
+                        BrokerRequest.class)
+        );
+        interactiveRequestIntent.putExtra(AuthenticationConstants.Broker.ACCOUNT_NAME, parameters.getLoginHint());
+
+
+        return interactiveRequestIntent;
+    }
+
+    private Intent getBrokerAuthorizationIntentFromAuthService(@NonNull final AcquireTokenOperationParameters parameters)
+            throws ClientException {
+        final String methodName = ":getBrokerAuthorizationIntentFromAuthService";
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+        );
+        IMicrosoftAuthService service;
+        Intent resultIntent;
+
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
+        final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+
+        try {
+            service = authServiceFuture.get();
+            resultIntent = service.getIntentForInteractiveRequest();
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(true)
+            );
+        } catch (final RemoteException e) {
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
+                            .putErrorDescription(e.getLocalizedMessage())
+            );
+            throw new ClientException(ErrorStrings.BROKER_BIND_SERVICE_FAILED,
+                    "Exception occurred while attempting to invoke remote service",
+                    e);
+        } catch (final Exception e) {
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
+                            .putErrorDescription(e.getLocalizedMessage())
+            );
+            throw new ClientException(ErrorStrings.BROKER_BIND_SERVICE_FAILED,
+                    "Exception occurred while awaiting (get) return of MicrosoftAuthService",
+                    e);
+        } finally {
+            client.disconnect();
+        }
+
+        return resultIntent;
+    }
+
+    @WorkerThread
+    AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException {
+        final String methodName = ":acquireTokenSilentWithAuthService";
+        Telemetry.emit(
+                new BrokerStartEvent()
+                        .putAction(methodName)
+        );
+
+        IMicrosoftAuthService service;
+
+        MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
+        MicrosoftAuthServiceFuture future = client.connect();
+
+        try {
+            //Do we want a time out here?
+            service = future.get();
+        } catch (Exception e) {
+            throw new RuntimeException("Exception occurred while awaiting (get) return of MicrosoftAuthService", e);
+        }
+
+        try {
+            final Bundle requestBundle = getSilentBrokerRequestBundle(parameters);
+            final Bundle resultBundle = service.acquireTokenSilently(requestBundle);
+            final AcquireTokenResult result = getAcquireTokenResult(resultBundle);
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(true)
+            );
+
+            return result;
+        } catch (final RemoteException e) {
+
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
+                            .putErrorDescription("RemoteException occurred while attempting to invoke remote service")
+            );
+
+            throw new ClientException(
+                    ErrorStrings.BROKER_BIND_SERVICE_FAILED,
+                    "Exception occurred while attempting to invoke remote service",
+                    e
+            );
+        } finally {
+            client.disconnect();
+        }
+    }
+
+    @WorkerThread
+    protected List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters)
+            throws ClientException, InterruptedException, ExecutionException, RemoteException {
+        final String methodName = ":getBrokerAccountsWithAuthService";
+        IMicrosoftAuthService service;
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
+        try {
+            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+            service = authServiceFuture.get();
+            final Bundle requestBundle = getRequestBundleForGetAccounts(parameters);
+
+            final List<ICacheRecord> cacheRecords =
+                    MsalBrokerResultAdapter
+                            .accountsFromBundle(
+                                    service.getAccounts(requestBundle)
+                            );
+
+            return cacheRecords;
+        } catch (final ClientException | InterruptedException | ExecutionException | RemoteException e) {
+            com.microsoft.identity.common.internal.logging.Logger.error(
+                    TAG + methodName,
+                    "Exception is thrown when trying to get account from Broker, returning empty list."
+                            + e.getMessage(),
+                    ErrorStrings.IO_ERROR,
+                    e);
+            throw e;
+        } finally {
+            client.disconnect();
+        }
+    }
+
+    private Bundle getRequestBundleForGetAccounts(@NonNull final OperationParameters parameters) {
+        final Bundle requestBundle = new Bundle();
+        requestBundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
+        requestBundle.putString(ACCOUNT_REDIRECT, parameters.getRedirectUri());
+        //Disable the environment and tenantID. Just return all accounts belong to this clientID.
+        return requestBundle;
+    }
+
+    @WorkerThread
+    protected boolean removeBrokerAccount(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+        final String methodName = ":removeBrokerAccountWithAuthService";
+
+        IMicrosoftAuthService service;
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
+
+        try {
+            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+
+            service = authServiceFuture.get();
+
+            Bundle requestBundle = getRequestBundleForRemoveAccount(parameters);
+            service.removeAccount(requestBundle);
+            return true;
+        } catch (final BaseException | InterruptedException | ExecutionException | RemoteException e) {
+            com.microsoft.identity.common.internal.logging.Logger.error(
+                    TAG + methodName,
+                    "Exception is thrown when trying to get target account."
+                            + e.getMessage(),
+                    ErrorStrings.IO_ERROR,
+                    e);
+            throw e;
+        } finally {
+            client.disconnect();
+        }
+    }
+
+    static Bundle getRequestBundleForRemoveAccount(@NonNull final OperationParameters parameters) {
+        final Bundle requestBundle = new Bundle();
+        requestBundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
+        if (null != parameters.getAccount()) {
+            requestBundle.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
+            requestBundle.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
+        }
+
+        return requestBundle;
+    }
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
@@ -1,0 +1,133 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.internal.controllers;
+
+import android.accounts.Account;
+import android.accounts.AccountManager;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Binder;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.RemoteException;
+import android.support.annotation.NonNull;
+
+import com.google.gson.Gson;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.broker.BrokerRequest;
+import com.microsoft.identity.common.internal.cache.ICacheRecord;
+import com.microsoft.identity.common.internal.dto.IAccountRecord;
+import com.microsoft.identity.common.internal.logging.Logger;
+import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
+import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
+import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
+import com.microsoft.identity.common.internal.request.OperationParameters;
+import com.microsoft.identity.common.internal.result.AcquireTokenResult;
+import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+abstract class BrokerBaseStrategy {
+    private static final String TAG = BrokerBaseStrategy.class.getSimpleName();
+
+    abstract Intent getBrokerAuthorizationIntent(@NonNull AcquireTokenOperationParameters parameters) throws ClientException;
+
+    abstract AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException;
+
+    abstract List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters) throws InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException, ClientException;
+
+    abstract boolean removeBrokerAccount(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+
+    Handler getPreferredHandler() {
+        if (null != Looper.myLooper() && Looper.getMainLooper() != Looper.myLooper()) {
+            return new Handler(Looper.myLooper());
+        } else {
+            return new Handler(Looper.getMainLooper());
+        }
+    }
+
+    Bundle getSilentBrokerRequestBundle(final AcquireTokenSilentOperationParameters parameters) {
+        final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
+
+        final Bundle requestBundle = new Bundle();
+        final BrokerRequest brokerRequest = msalBrokerRequestAdapter.
+                brokerRequestFromSilentOperationParameters(parameters);
+
+        requestBundle.putString(
+                AuthenticationConstants.Broker.BROKER_REQUEST_V2,
+                new Gson().toJson(brokerRequest, BrokerRequest.class)
+        );
+
+        requestBundle.putInt(
+                AuthenticationConstants.Broker.CALLER_INFO_UID,
+                Binder.getCallingUid()
+        );
+
+        return requestBundle;
+    }
+
+    @SuppressLint("MissingPermission")
+    Account getTargetAccount(final Context context, final IAccountRecord accountRecord) {
+        final String methodName = ":getTargetAccount";
+        Account targetAccount = null;
+        final Account[] accountList = AccountManager.get(context).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
+        if (accountList != null) {
+            for (Account account : accountList) {
+                if (account != null && account.name != null && account.name.equalsIgnoreCase(accountRecord.getUsername())) {
+                    targetAccount = account;
+                }
+            }
+        }
+
+        return targetAccount;
+    }
+
+    static AcquireTokenResult getAcquireTokenResult(@NonNull final Bundle resultBundle) throws BaseException {
+
+        final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
+
+        if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
+            Logger.verbose(TAG, "Successful result from the broker ");
+
+            final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
+            acquireTokenResult.setLocalAuthenticationResult(
+                    resultAdapter.authenticationResultFromBundle(resultBundle)
+            );
+
+            return acquireTokenResult;
+        }
+
+        Logger.warn(TAG, "Exception returned from broker, retrieving exception details ");
+
+        throw resultAdapter.baseExceptionFromBundle(resultBundle);
+    }
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -171,7 +171,7 @@ public class BrokerMsalController extends BaseController {
      */
     private Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
         final String methodName = ":getBrokerAuthorizationIntent";
-        initializeBrokerMsalController(parameters);
+        helloBroker(parameters);
 
         Intent interactiveRequestIntent = null;
 
@@ -237,7 +237,7 @@ public class BrokerMsalController extends BaseController {
     @Override
     public AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException {
         final String methodName = ":acquireTokenSilent";
-        initializeBrokerMsalController(parameters);
+        helloBroker(parameters);
 
         Telemetry.emit(
                 new ApiStartEvent()
@@ -289,7 +289,7 @@ public class BrokerMsalController extends BaseController {
     public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters)
             throws ClientException, InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException {
         final String methodName = ":getBrokerAccounts";
-        initializeBrokerMsalController(parameters);
+        helloBroker(parameters);
         List<ICacheRecord> result = null;
 
         for (int ii = 0; ii < getStrategies().size(); ii++) {
@@ -322,7 +322,7 @@ public class BrokerMsalController extends BaseController {
     public boolean removeAccount(@NonNull final OperationParameters parameters)
             throws BaseException, InterruptedException, ExecutionException, RemoteException {
         final String methodName = ":removeBrokerAccount";
-        initializeBrokerMsalController(parameters);
+        helloBroker(parameters);
         boolean result = false;
 
 
@@ -775,7 +775,7 @@ public class BrokerMsalController extends BaseController {
         return isGranted;
     }
 
-    private void initializeBrokerMsalController(@NonNull final OperationParameters parameters)
+    private void helloBroker(@NonNull final OperationParameters parameters)
             throws ClientException {
         final String methodName = ":initializeBrokerMsalController";
         if (!getStrategies().isEmpty()) {
@@ -788,7 +788,6 @@ public class BrokerMsalController extends BaseController {
             this.addBrokerStrategy(new BrokerAuthServiceStrategy());
         }
 
-
         //check if account manager available
         if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
             Logger.verbose(TAG + methodName, "Add the account manager strategy.");
@@ -797,7 +796,7 @@ public class BrokerMsalController extends BaseController {
 
         if (getStrategies().isEmpty()) {
             throw new ClientException(
-                    ErrorStrings.BROKER_PROTOCOL_VERSION_INCOMPATIBLE,
+                    ErrorStrings.UNSUPPORTED_BROKER_VERSION,
                     "The protocol versions between the MSAL client app and broker do not compatible. "
             );
         }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -662,6 +662,12 @@ public class BrokerMsalController extends BaseController {
             throws ClientException {
         final String methodName = ":helloWithAccountManager";
         final String DATA_HELLO = "com.microsoft.workaccount.hello";
+
+        if (BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())) {
+            //If the account manager permissions are not granted, return false.
+            return false;
+        }
+
         try {
             Account[] accountList = AccountManager.get(applicationContext).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
             //get result bundle
@@ -782,9 +788,9 @@ public class BrokerMsalController extends BaseController {
             this.addBrokerStrategy(new BrokerAuthServiceStrategy());
         }
 
+
         //check if account manager available
-        if (BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())
-                && BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
+        if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
             Logger.verbose(TAG + methodName, "Add the account manager strategy.");
             this.addBrokerStrategy(new BrokerAccountManagerStrategy());
         }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -632,7 +632,9 @@ public class BrokerMsalController extends BaseController {
             service = authServiceFuture.get();
             final Bundle requestBundle = MsalBrokerRequestAdapter.getBrokerHelloBundle(parameters);
             final BrokerResult result = MsalBrokerResultAdapter.brokerResultFromBundle(service.hello(requestBundle));
-            if (result.isSuccess()) {
+            if (result == null) {
+                return false;
+            } else if (result.isSuccess()) {
                 return true;
             } else {
                 throw new ClientException(result.getErrorCode(), result.getErrorMessage());
@@ -676,14 +678,13 @@ public class BrokerMsalController extends BaseController {
                                 null
                         );
 
-                final Bundle resultBundle = result.getResult();
-
-                if (null != resultBundle
-                        && null != resultBundle.getString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY)
-                        && !resultBundle.getString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY).isEmpty()) {
+                final BrokerResult brokerResult = MsalBrokerResultAdapter.brokerResultFromBundle(result.getResult());
+                if (result == null) {
+                    return false;
+                } else if (brokerResult.isSuccess()) {
                     return true;
                 } else {
-                    return false;
+                    throw new ClientException(brokerResult.getErrorCode(), brokerResult.getErrorMessage());
                 }
             } else {
                 return false;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -783,7 +783,8 @@ public class BrokerMsalController extends BaseController {
         }
 
         //check if account manager available
-        if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
+        if (BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())
+                && BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
             Logger.verbose(TAG + methodName, "Add the account manager strategy.");
             this.addBrokerStrategy(new BrokerAccountManagerStrategy());
         }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -31,7 +31,6 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.os.Binder;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -40,20 +39,19 @@ import android.os.RemoteException;
 import android.support.annotation.NonNull;
 import android.support.annotation.WorkerThread;
 
-import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.microsoft.identity.client.IMicrosoftAuthService;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.client.internal.AsyncResult;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
-import com.microsoft.identity.common.internal.broker.BrokerRequest;
 import com.microsoft.identity.common.internal.broker.BrokerResult;
 import com.microsoft.identity.common.internal.broker.BrokerResultFuture;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;
@@ -63,7 +61,6 @@ import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.ExceptionAdapter;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
-import com.microsoft.identity.common.internal.dto.IAccountRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
@@ -75,6 +72,7 @@ import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
 import com.microsoft.identity.common.internal.request.OperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
+import com.microsoft.identity.common.internal.result.ResultFuture;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
@@ -92,11 +90,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
+import static com.microsoft.identity.client.internal.controllers.BrokerBaseStrategy.getAcquireTokenResult;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.DEFAULT_BROWSER_PACKAGE_NAME;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
 
 /**
  * The implementation of MSAL Controller for Broker
@@ -105,13 +100,21 @@ public class BrokerMsalController extends BaseController {
 
     private static final String TAG = BrokerMsalController.class.getSimpleName();
 
-    private static final String DATA_USER_INFO = "com.microsoft.workaccount.user.info";
-    private static final String DATA_CACHE_RECORD = "com.microsoft.workaccount.cache.record";
+    private List<BrokerBaseStrategy> mStrategies = new ArrayList<>();
+
     private static final String MANIFEST_PERMISSION_GET_ACCOUNTS = "android.permission.GET_ACCOUNTS";
     private static final String MANIFEST_PERMISSION_MANAGE_ACCOUNTS = "android.permission.MANAGE_ACCOUNTS";
     private static final String MANIFEST_PERMISSION_USE_CREDENTIALS = "android.permission.USE_CREDENTIALS";
 
     private BrokerResultFuture mBrokerResultFuture;
+
+    List<BrokerBaseStrategy> getStrategies() {
+        return mStrategies;
+    }
+
+    void addBrokerStrategy(@NonNull final BrokerBaseStrategy strategy) {
+        mStrategies.add(strategy);
+    }
 
     /**
      * ExecutorService to handle background computation.
@@ -168,195 +171,32 @@ public class BrokerMsalController extends BaseController {
      */
     private Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
         final String methodName = ":getBrokerAuthorizationIntent";
-        Intent interactiveRequestIntent;
+        initializeBrokerMsalController(parameters);
 
-        if (isMicrosoftAuthServiceSupported(parameters.getAppContext()) && helloWithMicrosoftAuthService(parameters)) {
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
-            Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
-            interactiveRequestIntent = getBrokerAuthorizationIntentFromAuthService(parameters);
-            final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
-            interactiveRequestIntent.putExtra(
-                    AuthenticationConstants.Broker.BROKER_REQUEST_V2,
-                    new Gson().toJson(
-                            msalBrokerRequestAdapter.brokerRequestFromAcquireTokenParameters(parameters),
-                            BrokerRequest.class)
+        Intent interactiveRequestIntent = null;
+
+        for (int ii = 0; ii < getStrategies().size(); ii++) {
+            final BrokerBaseStrategy strategy = getStrategies().get(ii);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Executing with strategy: "
+                            + strategy.getClass().getSimpleName()
             );
-            interactiveRequestIntent.putExtra(AuthenticationConstants.Broker.ACCOUNT_NAME, parameters.getLoginHint());
-        } else if (helloWithAccountManager(parameters)){
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
-            Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
-            interactiveRequestIntent = getBrokerAuthorizationIntentFromAccountManager(parameters);
-        } else {
-            interactiveRequestIntent = null;
+
+            try {
+                interactiveRequestIntent = strategy.getBrokerAuthorizationIntent(parameters);
+                if (interactiveRequestIntent != null) {
+                    break;
+                }
+            } catch (final Exception exception) {
+                if (ii == (getStrategies().size() - 1)) {
+                    //throw the exception for the last trying of strategies.
+                    throw exception;
+                }
+            }
         }
 
         return interactiveRequestIntent;
-    }
-
-    private Intent getBrokerAuthorizationIntentFromAuthService(@NonNull final AcquireTokenOperationParameters parameters)
-            throws ClientException {
-        final String methodName = ":getBrokerAuthorizationIntentFromAuthService";
-        Telemetry.emit(
-                new BrokerStartEvent()
-                        .putAction(methodName)
-        );
-        IMicrosoftAuthService service;
-        Intent resultIntent;
-
-        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
-        final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
-
-        try {
-            service = authServiceFuture.get();
-            resultIntent = service.getIntentForInteractiveRequest();
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(true)
-            );
-        } catch (final RemoteException e) {
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
-                            .putErrorDescription(e.getLocalizedMessage())
-            );
-            throw new ClientException(ErrorStrings.BROKER_BIND_SERVICE_FAILED,
-                    "Exception occurred while attempting to invoke remote service",
-                    e);
-        } catch (final Exception e) {
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
-                            .putErrorDescription(e.getLocalizedMessage())
-            );
-            throw new ClientException(ErrorStrings.BROKER_BIND_SERVICE_FAILED,
-                    "Exception occurred while awaiting (get) return of MicrosoftAuthService",
-                    e);
-        } finally {
-            client.disconnect();
-        }
-
-        return resultIntent;
-    }
-
-    @SuppressLint("MissingPermission")
-    private Intent getBrokerAuthorizationIntentFromAccountManager(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
-        final String methodName = ":getBrokerAuthorizationIntentFromAccountManager";
-        Telemetry.emit(
-                new BrokerStartEvent()
-                        .putAction(methodName)
-        );
-        Intent intent = null;
-        try {
-            final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
-
-            final Bundle requestBundle = new Bundle();
-            final BrokerRequest brokerRequest = msalBrokerRequestAdapter.
-                    brokerRequestFromAcquireTokenParameters(parameters);
-
-            requestBundle.putString(
-                    AuthenticationConstants.Broker.BROKER_REQUEST_V2,
-                    new Gson().toJson(brokerRequest, BrokerRequest.class)
-            );
-
-            final AccountManager accountManager = AccountManager.get(parameters.getAppContext());
-            final AccountManagerFuture<Bundle> result =
-                    accountManager.addAccount(
-                            AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE,
-                            AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
-                            null,
-                            requestBundle,
-                            null,
-                            null,
-                            getPreferredHandler()
-                    );
-
-            // Making blocking request here
-            Bundle bundleResult = result.getResult();
-            // Authenticator should throw OperationCanceledException if
-            // token is not available
-            intent = bundleResult.getParcelable(AccountManager.KEY_INTENT);
-            intent.putExtra(
-                    AuthenticationConstants.Broker.CALLER_INFO_UID,
-                    Binder.getCallingUid()
-            );
-
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(true)
-            );
-        } catch (final OperationCanceledException e) {
-            Logger.error(
-                    TAG + methodName,
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "Exception thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
-                            .putErrorDescription("OperationCanceledException thrown when talking to account manager. The broker request cancelled.")
-            );
-
-            throw new ClientException(
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "OperationCanceledException thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-        } catch (final AuthenticatorException e) {
-            Logger.error(
-                    TAG + methodName,
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
-                            .putErrorDescription("AuthenticatorException thrown when talking to account manager. The broker request cancelled.")
-            );
-
-            throw new ClientException(
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-        } catch (final IOException e) {
-            // Authenticator gets problem from webrequest or file read/write
-            Logger.error(
-                    TAG + methodName,
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "IOException thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_REQUEST_CANCELLED)
-                            .putErrorDescription("IOException thrown when talking to account manager. The broker request cancelled.")
-            );
-
-            throw new ClientException(
-                    ErrorStrings.BROKER_REQUEST_CANCELLED,
-                    "IOException thrown when talking to account manager. The broker request cancelled.",
-                    e
-            );
-        }
-
-        return intent;
     }
 
     private Handler getPreferredHandler() {
@@ -397,6 +237,7 @@ public class BrokerMsalController extends BaseController {
     @Override
     public AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException {
         final String methodName = ":acquireTokenSilent";
+        initializeBrokerMsalController(parameters);
 
         Telemetry.emit(
                 new ApiStartEvent()
@@ -404,19 +245,27 @@ public class BrokerMsalController extends BaseController {
                         .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT)
         );
 
-        AcquireTokenResult acquireTokenResult;
+        AcquireTokenResult acquireTokenResult = null;
 
-        if (isMicrosoftAuthServiceSupported(parameters.getAppContext())) {
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
-            Logger.verbose(TAG + methodName, "Get the broker authorization intent from auth service.");
+        for (int ii = 0; ii < getStrategies().size(); ii++) {
+            final BrokerBaseStrategy strategy = getStrategies().get(ii);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Executing with strategy: "
+                            + strategy.getClass().getSimpleName()
+            );
 
-            acquireTokenResult = acquireTokenSilentWithAuthService(parameters);
-        } else if (helloWithAccountManager(parameters)){
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
-            Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
-            acquireTokenResult = acquireTokenSilentWithAccountManager(parameters);
-        } else {
-            acquireTokenResult = null;
+            try {
+                acquireTokenResult = strategy.acquireTokenSilent(parameters);
+                if (acquireTokenResult != null) {
+                    break;
+                }
+            } catch (final Exception exception) {
+                if (ii == (getStrategies().size() - 1)) {
+                    //throw the exception for the last trying of strategies.
+                    throw exception;
+                }
+            }
         }
 
         Telemetry.emit(
@@ -428,55 +277,74 @@ public class BrokerMsalController extends BaseController {
         return acquireTokenResult;
     }
 
-    private AcquireTokenResult acquireTokenSilentWithAuthService(AcquireTokenSilentOperationParameters parameters) throws BaseException {
-        final String methodName = ":acquireTokenSilentWithAuthService";
-        Telemetry.emit(
-                new BrokerStartEvent()
-                        .putAction(methodName)
-        );
 
-        IMicrosoftAuthService service;
+    /**
+     * Returns list of accounts that has previously been used to acquire token with broker through the calling app.
+     * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT.
+     * <p>
+     * This method might be called on an UI thread, since we connect to broker,
+     * this needs to be called on background thread.
+     */
+    @Override
+    public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters)
+            throws ClientException, InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException {
+        final String methodName = ":getBrokerAccounts";
+        initializeBrokerMsalController(parameters);
+        List<ICacheRecord> result = null;
 
-        MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
-        MicrosoftAuthServiceFuture future = client.connect();
+        for (int ii = 0; ii < getStrategies().size(); ii++) {
+            final BrokerBaseStrategy strategy = getStrategies().get(ii);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Executing with strategy: "
+                            + strategy.getClass().getSimpleName()
+            );
 
-        try {
-            //Do we want a time out here?
-            service = future.get();
-        } catch (Exception e) {
-            throw new RuntimeException("Exception occurred while awaiting (get) return of MicrosoftAuthService", e);
+            try {
+                result = strategy.getBrokerAccounts(parameters);
+                if (!result.isEmpty()) {
+                    break;
+                }
+            } catch (final Exception exception) {
+                if (ii == (getStrategies().size() - 1)) {
+                    //throw the exception for the last trying of strategies.
+                    throw exception;
+                }
+            }
         }
 
-        try {
-            final Bundle requestBundle = getSilentBrokerRequestBundle(parameters);
-            final Bundle resultBundle = service.acquireTokenSilently(requestBundle);
-            final AcquireTokenResult result = getAcquireTokenResult(resultBundle);
+        return result;
+    }
 
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(true)
+
+    @Override
+    @WorkerThread
+    public boolean removeAccount(@NonNull final OperationParameters parameters)
+            throws BaseException, InterruptedException, ExecutionException, RemoteException {
+        final String methodName = ":removeBrokerAccount";
+        initializeBrokerMsalController(parameters);
+        boolean result = false;
+
+
+        for (int ii = 0; ii < getStrategies().size(); ii++) {
+            final BrokerBaseStrategy strategy = getStrategies().get(ii);
+            com.microsoft.identity.common.internal.logging.Logger.verbose(
+                    TAG + methodName,
+                    "Executing with strategy: "
+                            + strategy.getClass().getSimpleName()
             );
 
-            return result;
-        } catch (final RemoteException e) {
-
-            Telemetry.emit(
-                    new BrokerEndEvent()
-                            .putAction(methodName)
-                            .isSuccessful(false)
-                            .putErrorCode(ErrorStrings.BROKER_BIND_SERVICE_FAILED)
-                            .putErrorDescription("RemoteException occurred while attempting to invoke remote service")
-            );
-
-            throw new ClientException(
-                    ErrorStrings.BROKER_BIND_SERVICE_FAILED,
-                    "Exception occurred while attempting to invoke remote service",
-                    e
-            );
-        } finally {
-            client.disconnect();
+            try {
+                result = strategy.removeBrokerAccount(parameters);
+            } catch (final Exception exception) {
+                if (ii == (getStrategies().size() - 1)) {
+                    //throw the exception for the last trying of strategies.
+                    throw exception;
+                }
+            }
         }
+
+        return result;
     }
 
     /**
@@ -545,138 +413,6 @@ public class BrokerMsalController extends BaseController {
                 }
             }
         });
-    }
-
-    @SuppressLint("MissingPermission")
-    private AcquireTokenResult acquireTokenSilentWithAccountManager(final AcquireTokenSilentOperationParameters parameters)
-            throws BaseException {
-        // if there is not any user added to account, it returns empty
-        final String methodName = ":acquireTokenSilentWithAccountManager";
-        Bundle bundleResult = null;
-        if (parameters.getAccount() != null) {
-            // blocking call to get token from cache or refresh request in
-            // background at Authenticator
-            try {
-
-                final Bundle requestBundle = getSilentBrokerRequestBundle(parameters);
-
-                // It does not expect activity to be launched.
-                // AuthenticatorService is handling the request at
-                // AccountManager.
-                final AccountManager accountManager = AccountManager.get(parameters.getAppContext());
-                final AccountManagerFuture<Bundle> result =
-                        accountManager.getAuthToken(
-                                getTargetAccount(parameters.getAppContext(), parameters.getAccount()),
-                                AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
-                                requestBundle,
-                                false,
-                                null, //set to null to avoid callback
-                                getPreferredHandler()
-                        );
-
-                // Making blocking request here
-                Logger.verbose(TAG + methodName, "Received result from broker");
-                bundleResult = result.getResult();
-            } catch (final OperationCanceledException e) {
-                Logger.error(
-                        TAG + methodName,
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "Exception thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-
-                throw new ClientException(
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "OperationCanceledException thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-            } catch (final AuthenticatorException e) {
-                Logger.error(
-                        TAG + methodName,
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-
-                throw new ClientException(
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "AuthenticatorException thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-            } catch (final IOException e) {
-                // Authenticator gets problem from webrequest or file read/write
-                Logger.error(
-                        TAG + methodName,
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "IOException thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-
-                throw new ClientException(
-                        ErrorStrings.BROKER_REQUEST_CANCELLED,
-                        "IOException thrown when talking to account manager. The broker request cancelled.",
-                        e
-                );
-            }
-        }
-
-        return getAcquireTokenResult(bundleResult);
-    }
-
-    private Bundle getSilentBrokerRequestBundle(final AcquireTokenSilentOperationParameters parameters) {
-        final MsalBrokerRequestAdapter msalBrokerRequestAdapter = new MsalBrokerRequestAdapter();
-
-        final Bundle requestBundle = new Bundle();
-        final BrokerRequest brokerRequest = msalBrokerRequestAdapter.
-                brokerRequestFromSilentOperationParameters(parameters);
-
-        requestBundle.putString(
-                AuthenticationConstants.Broker.BROKER_REQUEST_V2,
-                new Gson().toJson(brokerRequest, BrokerRequest.class)
-        );
-
-        requestBundle.putInt(
-                AuthenticationConstants.Broker.CALLER_INFO_UID,
-                Binder.getCallingUid()
-        );
-
-        return requestBundle;
-    }
-
-    @SuppressLint("MissingPermission")
-    private Account getTargetAccount(final Context context, final IAccountRecord accountRecord) {
-        final String methodName = ":getTargetAccount";
-        Account targetAccount = null;
-        final Account[] accountList = AccountManager.get(context).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
-        if (accountList != null) {
-            for (Account account : accountList) {
-                if (account != null && account.name != null && account.name.equalsIgnoreCase(accountRecord.getUsername())) {
-                    targetAccount = account;
-                }
-            }
-        }
-
-        return targetAccount;
-    }
-
-    private AcquireTokenResult getAcquireTokenResult(@NonNull final Bundle resultBundle) throws BaseException {
-
-        final MsalBrokerResultAdapter resultAdapter = new MsalBrokerResultAdapter();
-
-        if (resultBundle.getBoolean(AuthenticationConstants.Broker.BROKER_REQUEST_V2_SUCCESS)) {
-            Logger.verbose(TAG, "Successful result from the broker ");
-
-            final AcquireTokenResult acquireTokenResult = new AcquireTokenResult();
-            acquireTokenResult.setLocalAuthenticationResult(
-                    resultAdapter.authenticationResultFromBundle(resultBundle)
-            );
-
-            return acquireTokenResult;
-        }
-
-        Logger.warn(TAG, "Exception returned from broker, retrieving exception details ");
-
-        throw resultAdapter.baseExceptionFromBundle(resultBundle);
     }
 
     /**
@@ -753,9 +489,9 @@ public class BrokerMsalController extends BaseController {
     /**
      * Perform an operation with Broker's MicrosoftAuthService on a background thread.
      *
-     * @param appContext    app context.
-     * @param callback      a callback function to be invoked to return result/error of the performed task.
-     * @param brokerTask    the task to be performed.
+     * @param appContext app context.
+     * @param callback   a callback function to be invoked to return result/error of the performed task.
+     * @param brokerTask the task to be performed.
      */
     private <T> void performBrokerTask(@NonNull final Context appContext,
                                        @NonNull final TaskCompletedCallbackWithError<T, MsalException> callback,
@@ -815,7 +551,7 @@ public class BrokerMsalController extends BaseController {
                     public List<ICacheRecord> perform(IMicrosoftAuthService service) throws ClientException, RemoteException {
                         return MsalBrokerResultAdapter
                                 .accountsFromBundle(
-                                        service.getCurrentAccount(getRequestBundleForGetAccounts(OperationParametersAdapter.createOperationParameters(configuration)))
+                                        service.getCurrentAccount(BrokerAuthServiceStrategy.getRequestBundleForRemoveAccount(OperationParametersAdapter.createOperationParameters(configuration)))
                                 );
                     }
 
@@ -824,203 +560,6 @@ public class BrokerMsalController extends BaseController {
                         return methodName;
                     }
                 });
-    }
-
-    /**
-     * Returns list of accounts that has previously been used to acquire token with broker through the calling app.
-     * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_MULTIPLE_ACCOUNT.
-     * <p>
-     * This method might be called on an UI thread, since we connect to broker,
-     * this needs to be called on background thread.
-     */
-    @Override
-    public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters)
-            throws ClientException, InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException {
-        final String methodName = ":getBrokerAccounts";
-        if (isMicrosoftAuthServiceSupported(parameters.getAppContext())) {
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
-            Logger.verbose(TAG + methodName, "Get the broker accounts from auth service.");
-            return getBrokerAccountsWithAuthService(parameters);
-        } else if (helloWithAccountManager(parameters)){
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
-            Logger.verbose(TAG + methodName, "Get the broker accounts from Account Manager.");
-            return getBrokerAccountsFromAccountManager(parameters);
-        } else {
-            return null;
-        }
-    }
-
-    @WorkerThread
-    private List<ICacheRecord> getBrokerAccountsWithAuthService(@NonNull final OperationParameters parameters)
-            throws ClientException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":getBrokerAccountsWithAuthService";
-        IMicrosoftAuthService service;
-        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
-        try {
-            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
-            service = authServiceFuture.get();
-            final Bundle requestBundle = getRequestBundleForGetAccounts(parameters);
-
-            final List<ICacheRecord> cacheRecords =
-                    MsalBrokerResultAdapter
-                            .accountsFromBundle(
-                                    service.getAccounts(requestBundle)
-                            );
-
-            return cacheRecords;
-        } catch (final ClientException | InterruptedException | ExecutionException | RemoteException e) {
-            com.microsoft.identity.common.internal.logging.Logger.error(
-                    TAG + methodName,
-                    "Exception is thrown when trying to get account from Broker, returning empty list."
-                            + e.getMessage(),
-                    ErrorStrings.IO_ERROR,
-                    e);
-            throw e;
-        } finally {
-            client.disconnect();
-        }
-    }
-
-    @WorkerThread
-    @SuppressLint("MissingPermission")
-    private List<ICacheRecord> getBrokerAccountsFromAccountManager(@NonNull final OperationParameters parameters)
-            throws OperationCanceledException, IOException, AuthenticatorException, ClientException {
-        final String methodName = ":getBrokerAccountsFromAccountManager";
-        final Account[] accountList = AccountManager.get(parameters.getAppContext()).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
-        final List<ICacheRecord> cacheRecords = new ArrayList<>();
-        Logger.verbose(
-                TAG + methodName,
-                "Retrieve all the accounts from account manager with broker account type, "
-                        + "and the account length is: " + accountList.length
-        );
-
-        if (accountList == null || accountList.length == 0) {
-            return cacheRecords;
-        } else {
-            final Bundle bundle = new Bundle();
-            bundle.putBoolean(DATA_CACHE_RECORD, true);
-            bundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
-
-            for (final Account eachAccount : accountList) {
-                // Use AccountManager Api method to get extended user info
-
-                final AccountManagerFuture<Bundle> result = AccountManager.get(parameters.getAppContext())
-                        .updateCredentials(
-                                eachAccount,
-                                AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
-                                bundle,
-                                null,
-                                null,
-                                null
-                        );
-
-                final Bundle userInfoBundle = result.getResult();
-                cacheRecords.addAll(
-                        MsalBrokerResultAdapter.accountsFromBundle(userInfoBundle)
-                );
-            }
-
-            return cacheRecords;
-        }
-    }
-
-    private Bundle getRequestBundleForGetAccounts(@NonNull final OperationParameters parameters) {
-        final Bundle requestBundle = new Bundle();
-        requestBundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
-        requestBundle.putString(ACCOUNT_REDIRECT, parameters.getRedirectUri());
-        //Disable the environment and tenantID. Just return all accounts belong to this clientID.
-        return requestBundle;
-    }
-
-    @Override
-    @WorkerThread
-    public boolean removeAccount(@NonNull final OperationParameters parameters)
-            throws BaseException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":removeBrokerAccount";
-        if (isMicrosoftAuthServiceSupported(parameters.getAppContext())) {
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[yes]");
-            Logger.verbose(TAG + methodName, "Remove the account(s) from auth service.");
-            return removeBrokerAccountWithAuthService(parameters);
-        } else if (helloWithAccountManager(parameters)){
-            Logger.verbose(TAG + methodName, "Is microsoft auth service supported? " + "[no]");
-            Logger.verbose(TAG + methodName, "Remove the account(s) from Account Manager.");
-            return removeBrokerAccountFromAccountManager(parameters);
-        } else {
-            return false;
-        }
-    }
-
-    @SuppressLint("MissingPermission")
-    private boolean removeBrokerAccountFromAccountManager(@NonNull final OperationParameters parameters) {
-        final String methodName = ":removeBrokerAccountFromAccountManager";
-        // getAuthToken call will execute in async as well
-        Logger.verbose(TAG + methodName, "Try to remove account from account manager.");
-
-        //If account is null, remove all accounts from broker
-        //Otherwise, get the target account and remove it from broker
-        Account[] accountList = AccountManager.get(parameters.getAppContext()).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
-        if (accountList != null && accountList.length > 0) {
-            for (final Account eachAccount : accountList) {
-                if (parameters.getAccount() == null || eachAccount.name.equalsIgnoreCase(parameters.getAccount().getUsername())) {
-                    //create remove request bundle
-                    Bundle brokerOptions = new Bundle();
-                    brokerOptions.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
-                    brokerOptions.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
-                    brokerOptions.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
-                    brokerOptions.putString(AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS,
-                            AuthenticationConstants.Broker.ACCOUNT_REMOVE_TOKENS_VALUE);
-                    AccountManager.get(parameters.getAppContext()).getAuthToken(
-                            eachAccount,
-                            AuthenticationConstants.Broker.AUTHTOKEN_TYPE,
-                            brokerOptions,
-                            false,
-                            null, //set to null to avoid callback
-                            getPreferredHandler()
-                    );
-                }
-            }
-        }
-
-        return true;
-    }
-
-    private boolean removeBrokerAccountWithAuthService(@NonNull final OperationParameters parameters)
-            throws BaseException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":removeBrokerAccountWithAuthService";
-
-        IMicrosoftAuthService service;
-        final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
-
-        try {
-            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
-
-            service = authServiceFuture.get();
-
-            Bundle requestBundle = getRequestBundleForRemoveAccount(parameters);
-            service.removeAccount(requestBundle);
-            return true;
-        } catch (final BaseException | InterruptedException | ExecutionException | RemoteException e) {
-            com.microsoft.identity.common.internal.logging.Logger.error(
-                    TAG + methodName,
-                    "Exception is thrown when trying to get target account."
-                            + e.getMessage(),
-                    ErrorStrings.IO_ERROR,
-                    e);
-            throw e;
-        } finally {
-            client.disconnect();
-        }
-    }
-
-    private Bundle getRequestBundleForRemoveAccount(@NonNull final OperationParameters parameters) {
-        final Bundle requestBundle = new Bundle();
-        requestBundle.putString(ACCOUNT_CLIENTID_KEY, parameters.getClientId());
-        if (null != parameters.getAccount()) {
-            requestBundle.putString(ENVIRONMENT, parameters.getAccount().getEnvironment());
-            requestBundle.putString(ACCOUNT_HOME_ACCOUNT_ID, parameters.getAccount().getHomeAccountId());
-        }
-
-        return requestBundle;
     }
 
     /**
@@ -1082,50 +621,46 @@ public class BrokerMsalController extends BaseController {
         return requestBundle;
     }
 
-    private static boolean helloWithMicrosoftAuthService(@NonNull final OperationParameters parameters) throws ClientException {
-            final String methodName = ":helloWithMicrosoftAuthService";
+    @WorkerThread
+    static boolean helloWithMicrosoftAuthService(@NonNull final Context applicationContext, @NonNull final OperationParameters parameters) throws ClientException {
+        final String methodName = ":helloWithMicrosoftAuthService";
+        IMicrosoftAuthService service;
+        final MicrosoftAuthClient client = new MicrosoftAuthClient(applicationContext);
 
-            IMicrosoftAuthService service;
-            final MicrosoftAuthClient client = new MicrosoftAuthClient(parameters.getAppContext());
-
-            try {
-                final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
-
-                service = authServiceFuture.get();
-
-                Bundle requestBundle = MsalBrokerRequestAdapter.getBrokerHelloBundle(parameters);
-
-                final Bundle resultBundle = service.hello(requestBundle);
-                if (!resultBundle.getString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY).isEmpty()) {
-                    return true;
-                } else {
-                    return false;
-                }
-            } catch (final BaseException | InterruptedException | ExecutionException | RemoteException e) {
-                com.microsoft.identity.common.internal.logging.Logger.error(
-                        TAG + methodName,
-                        "Exception is thrown when trying to verify the broker protocol version."
-                                + e.getMessage(),
-                        ErrorStrings.IO_ERROR,
-                        e);
-                throw new ClientException(
-                        ErrorStrings.IO_ERROR,
-                        e.getMessage(),
-                        e
-                );
-            } finally {
-                client.disconnect();
+        try {
+            final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+            service = authServiceFuture.get();
+            final Bundle requestBundle = MsalBrokerRequestAdapter.getBrokerHelloBundle(parameters);
+            final Bundle resultBundle = service.hello(requestBundle);
+            if (!resultBundle.getString(AuthenticationConstants.Broker.NEGOTIATED_BP_VERSION_KEY).isEmpty()) {
+                return true;
+            } else {
+                return false;
             }
+        } catch (final ClientException | InterruptedException | ExecutionException | RemoteException e) {
+            com.microsoft.identity.common.internal.logging.Logger.error(
+                    TAG + methodName,
+                    "Exception is thrown when trying to verify the broker protocol version."
+                            + e.getMessage(),
+                    ErrorStrings.IO_ERROR,
+                    e);
+            throw new ClientException(
+                    ErrorStrings.IO_ERROR,
+                    e.getMessage(),
+                    e
+            );
+        } finally {
+            client.disconnect();
+        }
     }
 
     @WorkerThread
     @SuppressLint("MissingPermission")
-    private static boolean helloWithAccountManager(@NonNull final OperationParameters parameters)
+    static boolean helloWithAccountManager(@NonNull final Context applicationContext, @NonNull final OperationParameters parameters)
             throws ClientException {
         final String methodName = ":helloWithAccountManager";
-
         try {
-            Account[] accountList = AccountManager.get(parameters.getAppContext()).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
+            Account[] accountList = AccountManager.get(applicationContext).getAccountsByType(AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE);
             //get result bundle
             if (accountList.length > 0) {
                 final Bundle requestBundle = MsalBrokerRequestAdapter.getBrokerHelloBundle(parameters);
@@ -1226,5 +761,32 @@ public class BrokerMsalController extends BaseController {
                 == PackageManager.PERMISSION_GRANTED;
         Logger.verbose(TAG + methodName, "is " + permissionName + " granted? [" + isGranted + "]");
         return isGranted;
+    }
+
+    private void initializeBrokerMsalController(@NonNull final OperationParameters parameters)
+            throws ClientException {
+        final String methodName = ":initializeBrokerMsalController";
+        if (!getStrategies().isEmpty()) {
+            mStrategies = new ArrayList<>();
+        }
+
+        //check if bound service available
+        if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
+            Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
+            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
+        }
+
+        //check if account manager available
+        if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
+            Logger.verbose(TAG + methodName, "Add the account manager strategy.");
+            this.addBrokerStrategy(new BrokerAccountManagerStrategy());
+        }
+
+        if (getStrategies().isEmpty()) {
+            throw new ClientException(
+                    ErrorStrings.BROKER_PROTOCOL_VERSION_INCOMPATIBLE,
+                    "The protocol versions between the MSAL client app and broker do not compatible. "
+            );
+        }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -777,10 +777,10 @@ public class BrokerMsalController extends BaseController {
         }
 
         //check if bound service available
-        if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
-            Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
-            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
-        }
+//        if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
+//            Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
+//            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
+//        }
 
         //check if account manager available
         if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -777,10 +777,10 @@ public class BrokerMsalController extends BaseController {
         }
 
         //check if bound service available
-//        if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
-//            Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
-//            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
-//        }
+        if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
+            Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
+            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
+        }
 
         //check if account manager available
         if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -72,6 +72,7 @@ public class OperationParametersAdapter {
         parameters.setApplicationName(configuration.getAppContext().getPackageName());
         parameters.setApplicationVersion(getPackageVersion(configuration.getAppContext()));
         parameters.setSdkVersion(PublicClientApplication.getSdkVersion());
+        parameters.setRequiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion());
         return parameters;
     }
 

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -9,6 +9,7 @@
     }
   ],
   "authorization_user_agent": "DEFAULT",
+  "minimum_required_broker_protocol_version":"3.0",
   "multiple_clouds_supported": false,
   "broker_redirect_uri_registered": false,
   "environment": "Production",

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -405,7 +405,11 @@ public class MsalWrapper {
                 @Override
                 public void onError(MsalException exception) {
                     exception.printStackTrace();
-                    notifyCallback.notify("Failed to load account from broker");
+                    notifyCallback.notify
+                            ("Failed to load account from broker. "
+                                    + "Error code: " + exception.getErrorCode()
+                                    + " Error Message: " + exception.getMessage()
+                            );
                 }
 
             });

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -4,7 +4,6 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
-  "minimum_required_broker_protocol_version":"3.0",
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
+  "minimum_required_broker_protocol_version":"3.0",
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
This change is limited to multiAccountsPCA.

with compatible broker
- Broker Version 3.0
- MSAL Client required version 3.0

|  with compatible broker version      | MicrosoftAuthService           | AccountManager  |
| ------------- |:-------------:| -----:|
| AT    | passed | passed|
| ATS    | passed      |   fixed* |
| GetAccounts | passed     |    fixed* |
| RemoveAccount | passed    |    fixed* |
* this is an unrelated bug, filed #682 

with incompatible broker
- Broker Version 2.0
- MSAL Client required version 3.0

|   with incompatible broker version     | MicrosoftAuthService           | AccountManager  |
| ------------- |:-------------:| -----:|
| AT    | passed | passed|
| ATS    |passed      |  passed |
| GetAccounts | passed     |    passed |
| RemoveAccount | passed      |    passed|