### PR TITLE
(Recutting branch) Merging release/1.0.0 to dev

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -125,9 +125,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.10-SNAPSHOT', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '0.0.12-RC1', changing: true)
 
-    distApi("com.microsoft.identity:common:0.0.10") {
+    distApi("com.microsoft.identity:common:0.0.12-RC1") {
         transitive = false
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ITokenShare.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ITokenShare.java
@@ -34,12 +34,24 @@ public interface ITokenShare extends ITokenShareInternal {
      * {@inheritDoc}
      */
     @Override
-    String getWrappedFamilyRefreshToken(String identifier) throws MsalClientException;
+    String getOrgIdFamilyRefreshToken(String identifier) throws MsalClientException;
 
     /**
      * {@inheritDoc}
      */
     @Override
-    void saveFamilyRefreshToken(String tokenCacheItemJson) throws MsalClientException;
+    void saveOrgIdFamilyRefreshToken(String ssoStateSerializerBlob) throws MsalClientException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    String getMsaFamilyRefreshToken(String identifier) throws MsalClientException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void saveMsaFamilyRefreshToken(String refreshToken) throws MsalClientException;
 
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=0.3.1-RC4
+versionName=1.0.0-RC1
 versionCode=0


### PR DESCRIPTION
Text lifted from: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/551

The original plan was to create new releases branches for ad-accounts (release/3.1.0), common(0.0.12) and MSAL (release/1.0.0)  for the July MSAL with v2 broker release. However due to unexpected fix which needs to be targeted to master of ad-accounts (v1 broker) we couldn't merge [this PR](https://github.com/AzureAD/ad-accounts-for-android/pull/1040) and thus couldn't create a ad-accounts release branch (release/3.1.0) 

So effectively common 0.0.12 doesn't have a corresponding counterpart in ad-accounts. Hence merging back these release branches to dev and using that as a base of July release until we can cut a branch in ad-accounts.