### PR TITLE
Adds getUsername() accessor to IAccount, ITenantProfile

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -68,7 +68,8 @@ public class Account implements IAccount {
     }
 
     @NonNull
-    String getTenantId() {
+    @Override
+    public String getTenantId() {
         return mHomeTenantId;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -97,4 +97,20 @@ public class Account implements IAccount {
     public Map<String, ?> getClaims() {
         return mIdTokenClaims;
     }
+
+    @NonNull
+    @Override
+    public String getUsername() {
+        String username = "";
+
+        if (null != getClaims()) {
+            final String usernameClaim = (String) getClaims().get(IDToken.PREFERRED_USERNAME);
+
+            if (null != usernameClaim) {
+                username = usernameClaim;
+            }
+        }
+
+        return username;
+    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.Map;
@@ -29,11 +30,19 @@ import java.util.Map;
 public interface IClaimable {
 
     /**
-     * Gets the claims associated with this account's IdToken.
+     * Gets the claims associated with this IClaimable's IdToken.
      *
      * @return A Map of claims.
      */
     @Nullable
     Map<String, ?> getClaims();
+
+    /**
+     * Gets the prefrerreed_username claim associated with this IClaimable.
+     *
+     * @return The preferred_username claim or "" (empty string) if not available.
+     */
+    @NonNull
+    String getUsername();
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
@@ -39,6 +39,9 @@ public interface IClaimable {
 
     /**
      * Gets the preferred_username claim associated with this IClaimable.
+     * <p>
+     * Note: On the Microsoft B2C Identity Platform, this claim may be unavailable when external
+     * identity providers are used.
      *
      * @return The preferred_username claim or "" (empty string) if not available.
      */

--- a/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IClaimable.java
@@ -38,11 +38,19 @@ public interface IClaimable {
     Map<String, ?> getClaims();
 
     /**
-     * Gets the prefrerreed_username claim associated with this IClaimable.
+     * Gets the preferred_username claim associated with this IClaimable.
      *
      * @return The preferred_username claim or "" (empty string) if not available.
      */
     @NonNull
     String getUsername();
+
+    /**
+     * Gets the tid claim associated with this IClaimable.
+     *
+     * @return The tid claim or "" (empty string) if not available.
+     */
+    @NonNull
+    String getTenantId();
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/ITenantProfile.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ITenantProfile.java
@@ -22,10 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
-import android.support.annotation.NonNull;
-
 public interface ITenantProfile extends IAccount {
-
-    @NonNull
-    String getTenantId();
+    // Intentionally left blank.
 }

--- a/msal/src/main/java/com/microsoft/identity/client/TenantProfile.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TenantProfile.java
@@ -36,6 +36,16 @@ public class TenantProfile extends Account implements ITenantProfile {
     @NonNull
     @Override
     public String getTenantId() {
-        return (String) getClaims().get(MicrosoftIdToken.TENANT_ID);
+        String tenantId = "";
+
+        if (null != getClaims()) {
+            final String tidClaim = (String) getClaims().get(MicrosoftIdToken.TENANT_ID);
+
+            if (null != tidClaim) {
+                tenantId = tidClaim;
+            }
+        }
+
+        return tenantId;
     }
 }


### PR DESCRIPTION
Makes a couple of minor changes:
- Adds `getUsername()` to both `IAccount` and `ITenantProfile` (through shared superinterface `IClaimable`)
- Enforces `@NonNull` by eagerly initializing to `""` and overwriting if the respective IdToken claim is not-null
- Applies similar behavior to `getTenantId()` - formerly available only on `ITenantProfile` this is now surfaced on `IAccount` too through `IClaimable`
    * Similar nullability behavior applies