### PR TITLE
Disabling Failing Emulator, Fixing Compilation in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,23 @@
 language: android
 jdk: oraclejdk8
 dist: trusty
+
+# Build Variables
+env:
+  global:
+    - BUILD_TOOLS_VERSION=28.0.3
+    - ANDROID_COMPILE_API_LEVEL=27
+
 android:
   components:
     - tools
     - platform-tools
 
     # BuildTools version used by this project
-    - build-tools-28.0.3
+    - build-tools-$BUILD_TOOLS_VERSION
 
     # Compilation SDK version
-    - android-27
+    - android-$ANDROID_COMPILE_API_LEVEL
 
     # Additional Components
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,27 @@
 language: android
 jdk: oraclejdk8
-
-# Don't use the Travis Container-Based Infrastructure
-sudo: true
+dist: trusty
 
 # Build Variables
 env:
   global:
     - BUILD_TOOLS_VERSION=28.0.3
-    - COMPILE_SDK_VERSION=27
-    - EMULATOR_API_VERSION=21
-
-    # This is to guarantee a clean gradle log
-    - TERM=dumb
+    - ANDROID_COMPILE_API_LEVEL=27
 
 android:
   components:
     - tools
     - platform-tools
+
+    # BuildTools version used by this project
     - build-tools-$BUILD_TOOLS_VERSION
-    - android-$COMPILE_SDK_VERSION
+
+    # Compilation SDK version
+    - android-$ANDROID_COMPILE_API_LEVEL
+
+    # Additional Components
     - extra-google-m2repository
-
-    ## Emulator config ##
-    # The SDK version used for the emulator
-    - android-$EMULATOR_API_VERSION
-
-    #system images
-    - sys-img-armeabi-v7a-android-$EMULATOR_API_VERSION
+    - extra-android-m2repository
 
 before_install:
   - chmod +x gradlew
@@ -35,6 +29,7 @@ before_install:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -43,11 +38,7 @@ cache:
 
 before_script:
   - android list targets
-  - echo no | android create avd --force -n test -t android-$EMULATOR_API_VERSION --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
 
 script:
   - cd $PWD
-  - ./gradlew clean msal:assembleLocal msal:connectedLocalDebugAndroidTest -PdisablePreDex
+  - ./gradlew clean msal:assembleLocal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,33 @@
 language: android
 jdk: oraclejdk8
-dist: trusty
+
+# Don't use the Travis Container-Based Infrastructure
+sudo: true
 
 # Build Variables
 env:
   global:
     - BUILD_TOOLS_VERSION=28.0.3
-    - ANDROID_COMPILE_API_LEVEL=27
+    - COMPILE_SDK_VERSION=27
+    - EMULATOR_API_VERSION=21
+
+    # This is to guarantee a clean gradle log
+    - TERM=dumb
 
 android:
   components:
     - tools
     - platform-tools
-
-    # BuildTools version used by this project
     - build-tools-$BUILD_TOOLS_VERSION
-
-    # Compilation SDK version
-    - android-$ANDROID_COMPILE_API_LEVEL
-
-    # Additional Components
+    - android-$COMPILE_SDK_VERSION
     - extra-google-m2repository
-    - extra-android-m2repository
+
+    ## Emulator config ##
+    # The SDK version used for the emulator
+    - android-$EMULATOR_API_VERSION
+
+    #system images
+    - sys-img-armeabi-v7a-android-$EMULATOR_API_VERSION
 
 before_install:
   - chmod +x gradlew
@@ -29,7 +35,6 @@ before_install:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
-
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -38,7 +43,11 @@ cache:
 
 before_script:
   - android list targets
+  - echo no | android create avd --force -n test -t android-$EMULATOR_API_VERSION --abi armeabi-v7a
+  - emulator -avd test -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
 
 script:
   - cd $PWD
-  - ./gradlew clean msal:assembleLocal
+  - ./gradlew clean msal:assembleLocal msal:connectedLocalDebugAndroidTest -PdisablePreDex

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,20 @@
-# ./travis.yml for MSAL android
-
 language: android
-dist: precise
-
-jdk:
-  - oraclejdk8
-
-# Don't use the Travis Container-Based Infrastructure
-sudo: true
-
+jdk: oraclejdk8
+dist: trusty
 android:
   components:
-    # Travis has a bug that we need to workaround to use sdk 25
-    # https://github.com/travis-ci/travis-ci/issues/6059
     - tools
     - platform-tools
+
+    # BuildTools version used by this project
     - build-tools-28.0.3
-    - android-25
+
+    # Compilation SDK version
     - android-27
-    - extra
-    - extra-android-m2repository
+
+    # Additional Components
     - extra-google-m2repository
-    - addon-google_apis-google-21
-    ## Emulator config ##
-    # The SDK version used for the emulator
-    - android-21
-    #system images
-    - sys-img-armeabi-v7a-addon-google_apis-google-21
-
-licenses:
-    - 'android-sdk-preview-license-.+'
-    - 'android-sdk-license-.+'
-    - 'google-gdk-license-.+'
-
-env:
-    global:
-      # This is to guaratee a clean gradle log
-      - TERM=dumb
-    matrix:
-      - ANDROID_SDKS=android-27 ANDROID_TARGET=android-27
+    - extra-android-m2repository
 
 before_install:
   - chmod +x gradlew
@@ -46,6 +22,7 @@ before_install:
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+
 cache:
   directories:
     - $HOME/.gradle/caches/
@@ -53,11 +30,8 @@ cache:
     - $HOME/.android/build-cache
 
 before_script:
-  - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
-  - emulator -avd test -no-audio -no-window &
-  - android-wait-for-emulator
-  - adb shell input keyevent 82 &
+  - android list targets
 
 script:
   - cd $PWD
-  - ./gradlew clean msal:assembleLocal msal:connectedLocalDebugAndroidTest -PdisablePreDex
+  - ./gradlew clean msal:assembleLocal


### PR DESCRIPTION
After much flailing, this PR is disabling emulators + `connectedTest`.

What was tested:
- API 16 (Boots, fails with bytecode errors)
- API 21 (armv7) (Fails to boot, Timeout)
- API 22 (armv7) (Fails to boot, Timeout)
- API 24 (armv7) (Fails to boot, Timeout)
- API 25 (armv7) (Fails to boot, Timeout)
- API 25 (x86, hardware accel disabled) (Fails to boot, Timeout)
- API 25 (x86-64, hardware accel disabled) (Fails to boot, Timeout)