### PR TITLE
Utilize current account in SingleAccount mode for AcquireToken/AcquireTokenSilent

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -321,72 +321,8 @@ public final class PublicClientApplicationTest {
      */
     @Test
     @Ignore
-    public void testAuthoritySetInManifestGetTokenFailed()
-            throws PackageManager.NameNotFoundException, IOException, InterruptedException {
-
+    public void testAuthoritySetInManifestGetTokenFailed(){
         // TODO: Revisit this once we're ready to update test cases for ISingle and IMuliple PCA.
-//        new GetTokenBaseTestCase() {
-//
-//            @Override
-//            protected String getAlternateAuthorityInManifest() {
-//                return ALTERNATE_AUTHORITY;
-//            }
-//
-//            @Override
-//            void mockHttpRequest() throws IOException {
-//                final HttpURLConnection mockedConnection = AndroidTestMockUtil.getMockedConnectionWithFailureResponse(
-//                        HttpURLConnection.HTTP_BAD_REQUEST, AndroidTestUtil.getErrorResponseMessage("invalid_request"));
-//                Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
-//                HttpUrlConnectionFactory.addMockedConnection(mockedConnection);
-//            }
-//
-//            @Override
-//            void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
-//                                      final Activity activity,
-//                                      final CountDownLatch releaseLock) {
-//
-//                publicClientApplication.acquireToken(activity, SCOPE, "somehint", new AuthenticationCallback() {
-//                    @Override
-//                    public void onSuccess(IAuthenticationResult authenticationResult) {
-//                        fail();
-//                    }
-//
-//                    @Override
-//                    public void onError(MsalException exception) {
-//                        assertTrue(exception instanceof MsalServiceException);
-//
-//                        final MsalServiceException serviceException = (MsalServiceException) exception;
-//                        assertTrue(MsalServiceException.INVALID_REQUEST.equals(serviceException.getErrorCode()));
-//                        assertTrue(!serviceException.getMessage().isEmpty());
-//                        assertTrue(serviceException.getHttpStatusCode() == HttpURLConnection.HTTP_BAD_REQUEST);
-//                        releaseLock.countDown();
-//                    }
-//
-//                    @Override
-//                    public void onCancel() {
-//                        fail();
-//                    }
-//                });
-//            }
-//
-//            @Override
-//            String getFinalAuthUrl() throws UnsupportedEncodingException {
-//                return mRedirectUri + "?code=1234&state=" + AndroidTestUtil.encodeProtocolState(
-//                        ALTERNATE_AUTHORITY, new HashSet<>(Arrays.asList(SCOPE)));
-//            }
-//
-//            @Override
-//            protected void performAdditionalVerify(Activity testActivity) {
-//                Mockito.verify(testActivity).startActivityForResult(Mockito.argThat(
-//                        new ArgumentMatcher<Intent>() {
-//                            @Override
-//                            public boolean matches(Intent argument) {
-//                                final String data = argument.getStringExtra(Constants.REQUEST_URL_KEY);
-//                                return data.startsWith(ALTERNATE_AUTHORITY);
-//                            }
-//                        }), Matchers.eq(RequestCodes.LOCAL_AUTHORIZATION_REQUEST));
-//            }
-//        }.performTest();
     }
 
     /**

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -323,69 +323,70 @@ public final class PublicClientApplicationTest {
     @Ignore
     public void testAuthoritySetInManifestGetTokenFailed()
             throws PackageManager.NameNotFoundException, IOException, InterruptedException {
-        new GetTokenBaseTestCase() {
 
-            @Override
-            protected String getAlternateAuthorityInManifest() {
-                return ALTERNATE_AUTHORITY;
-            }
-
-            @Override
-            void mockHttpRequest() throws IOException {
-                final HttpURLConnection mockedConnection = AndroidTestMockUtil.getMockedConnectionWithFailureResponse(
-                        HttpURLConnection.HTTP_BAD_REQUEST, AndroidTestUtil.getErrorResponseMessage("invalid_request"));
-                Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
-                HttpUrlConnectionFactory.addMockedConnection(mockedConnection);
-            }
-
-            @Override
-            void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
-                                      final Activity activity,
-                                      final CountDownLatch releaseLock) {
-
-
-                publicClientApplication.acquireToken(activity, SCOPE, "somehint", new AuthenticationCallback() {
-                    @Override
-                    public void onSuccess(IAuthenticationResult authenticationResult) {
-                        fail();
-                    }
-
-                    @Override
-                    public void onError(MsalException exception) {
-                        assertTrue(exception instanceof MsalServiceException);
-
-                        final MsalServiceException serviceException = (MsalServiceException) exception;
-                        assertTrue(MsalServiceException.INVALID_REQUEST.equals(serviceException.getErrorCode()));
-                        assertTrue(!serviceException.getMessage().isEmpty());
-                        assertTrue(serviceException.getHttpStatusCode() == HttpURLConnection.HTTP_BAD_REQUEST);
-                        releaseLock.countDown();
-                    }
-
-                    @Override
-                    public void onCancel() {
-                        fail();
-                    }
-                });
-            }
-
-            @Override
-            String getFinalAuthUrl() throws UnsupportedEncodingException {
-                return mRedirectUri + "?code=1234&state=" + AndroidTestUtil.encodeProtocolState(
-                        ALTERNATE_AUTHORITY, new HashSet<>(Arrays.asList(SCOPE)));
-            }
-
-            @Override
-            protected void performAdditionalVerify(Activity testActivity) {
-                Mockito.verify(testActivity).startActivityForResult(Mockito.argThat(
-                        new ArgumentMatcher<Intent>() {
-                            @Override
-                            public boolean matches(Intent argument) {
-                                final String data = argument.getStringExtra(Constants.REQUEST_URL_KEY);
-                                return data.startsWith(ALTERNATE_AUTHORITY);
-                            }
-                        }), Matchers.eq(RequestCodes.LOCAL_AUTHORIZATION_REQUEST));
-            }
-        }.performTest();
+        // TODO: Revisit this once we're ready to update test cases for ISingle and IMuliple PCA.
+//        new GetTokenBaseTestCase() {
+//
+//            @Override
+//            protected String getAlternateAuthorityInManifest() {
+//                return ALTERNATE_AUTHORITY;
+//            }
+//
+//            @Override
+//            void mockHttpRequest() throws IOException {
+//                final HttpURLConnection mockedConnection = AndroidTestMockUtil.getMockedConnectionWithFailureResponse(
+//                        HttpURLConnection.HTTP_BAD_REQUEST, AndroidTestUtil.getErrorResponseMessage("invalid_request"));
+//                Mockito.when(mockedConnection.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+//                HttpUrlConnectionFactory.addMockedConnection(mockedConnection);
+//            }
+//
+//            @Override
+//            void makeAcquireTokenCall(final PublicClientApplication publicClientApplication,
+//                                      final Activity activity,
+//                                      final CountDownLatch releaseLock) {
+//
+//                publicClientApplication.acquireToken(activity, SCOPE, "somehint", new AuthenticationCallback() {
+//                    @Override
+//                    public void onSuccess(IAuthenticationResult authenticationResult) {
+//                        fail();
+//                    }
+//
+//                    @Override
+//                    public void onError(MsalException exception) {
+//                        assertTrue(exception instanceof MsalServiceException);
+//
+//                        final MsalServiceException serviceException = (MsalServiceException) exception;
+//                        assertTrue(MsalServiceException.INVALID_REQUEST.equals(serviceException.getErrorCode()));
+//                        assertTrue(!serviceException.getMessage().isEmpty());
+//                        assertTrue(serviceException.getHttpStatusCode() == HttpURLConnection.HTTP_BAD_REQUEST);
+//                        releaseLock.countDown();
+//                    }
+//
+//                    @Override
+//                    public void onCancel() {
+//                        fail();
+//                    }
+//                });
+//            }
+//
+//            @Override
+//            String getFinalAuthUrl() throws UnsupportedEncodingException {
+//                return mRedirectUri + "?code=1234&state=" + AndroidTestUtil.encodeProtocolState(
+//                        ALTERNATE_AUTHORITY, new HashSet<>(Arrays.asList(SCOPE)));
+//            }
+//
+//            @Override
+//            protected void performAdditionalVerify(Activity testActivity) {
+//                Mockito.verify(testActivity).startActivityForResult(Mockito.argThat(
+//                        new ArgumentMatcher<Intent>() {
+//                            @Override
+//                            public boolean matches(Intent argument) {
+//                                final String data = argument.getStringExtra(Constants.REQUEST_URL_KEY);
+//                                return data.startsWith(ALTERNATE_AUTHORITY);
+//                            }
+//                        }), Matchers.eq(RequestCodes.LOCAL_AUTHORIZATION_REQUEST));
+//            }
+//        }.performTest();
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
@@ -39,7 +39,6 @@ public class AcquireTokenParameters extends TokenParameters {
     private List<String> mExtraScopesToConsent;
     private List<Pair<String, String>> mExtraQueryStringParameters;
 
-
     public AcquireTokenParameters(AcquireTokenParameters.Builder builder) {
         super(builder);
         mActivity = builder.mActivity;
@@ -48,7 +47,6 @@ public class AcquireTokenParameters extends TokenParameters {
         mExtraScopesToConsent = builder.mExtraScopesToConsent;
         mExtraQueryStringParameters = builder.mExtraQueryStringParameters;
     }
-
 
     /**
      * Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import android.app.Activity;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -92,6 +94,29 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      */
     @WorkerThread
     boolean removeAccount(@Nullable final IAccount account) throws MsalException, InterruptedException;
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
+     *
+     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                  back via {@link AuthenticationCallback#onCancel()}.
+     *                  2) If the sdk successfully receives the token back, result will be sent back via
+     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                  3) All the other errors will be sent back via
+     *                  {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final String[] scopes,
+                      @Nullable final String loginHint,
+                      @NonNull final AuthenticationCallback callback
+    );
 
     /**
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -71,7 +71,6 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * The identifier could be homeAccountIdentifier, localAccountIdentifier or username.
      *
      * @param identifier String of the identifier
-     *
      */
     @WorkerThread
     IAccount getAccount(@NonNull final String identifier) throws InterruptedException, MsalException;
@@ -80,7 +79,6 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * Removes the Account and Credentials (tokens) for the supplied IAccount.
      *
      * @param account The IAccount whose entry and associated tokens should be removed.
-     *
      */
     void removeAccount(@Nullable final IAccount account,
                        @NonNull final RemoveAccountCallback callback
@@ -141,33 +139,33 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param scopes       The non-null array of scopes to be requested for the access token.
-     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account      {@link IAccount} represents the account to silently request tokens for.
-     * @param authority    Optional. Can be passed to override the configured authority.
-     *
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account   {@link IAccount} represents the account to silently request tokens for.
+     * @param authority Authority to issue the token.
      */
     @WorkerThread
     IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                              @NonNull final IAccount account,
-                                             @Nullable final String authority) throws MsalException, InterruptedException;
+                                             @NonNull final String authority) throws MsalException, InterruptedException;
 
     /**
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param scopes   The non-null array of scopes to be requested for the access token.
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param account  {@link IAccount} represents the account to silently request tokens for.
-     * @param callback {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                 sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                 Failure case will be sent back via {
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param account   {@link IAccount} represents the account to silently request tokens for.
+     * @param authority Authority to issue the token.
+     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
      * @link AuthenticationCallback#onError(MsalException)}.
      */
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                  @NonNull final IAccount account,
-                                 @Nullable final String authority,
+                                 @NonNull final String authority,
                                  @NonNull final AuthenticationCallback callback);
 
     interface GetAccountCallback extends TaskCompletedCallbackWithError<IAccount, MsalException> {

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -59,30 +59,6 @@ public interface IPublicClientApplication {
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
-     *
-     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}.
-     * @param scopes    The non-null array of scopes to be requested for the access token.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
-     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                  back via {@link AuthenticationCallback#onCancel()}.
-     *                  2) If the sdk successfully receives the token back, result will be sent back via
-     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                  3) All the other errors will be sent back via
-     *                  {@link AuthenticationCallback#onError(MsalException)}.
-     */
-    void acquireToken(@NonNull final Activity activity,
-                      @NonNull final String[] scopes,
-                      @Nullable final String loginHint,
-                      @NonNull final AuthenticationCallback callback
-    );
-
-
-    /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link UiBehavior} is {@link UiBehavior#SELECT_ACCOUNT}.
      * <p>
      * Convey parameters via the AquireTokenParameters object
      *

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -33,12 +33,16 @@ import com.microsoft.identity.client.exception.MsalException;
 
 /**
  * An interface that contains list of operations that are available when MSAL is in 'single account' mode.
- * - In this mode, the user can 'sign-in' an account to the device.
- * - Once an account is 'signed-in', every app on the device will be able to retrieve this account, and use them to silently perform API calls.
- * - If the user wants to acquire a token for another account, the previous account must be removed from the device first through globalSignOut().
- * Otherwise, the operation will fail.
- * <p>
- * Currently, this mode is only set when the device is registered as 'shared'.
+ * - In this mode, one account can be signed-in to the app.
+ * - If the user wants to acquire a token for another account, the previous account must be signed out first.
+ *
+ * When the device is registered as 'shared', this will be the only available PublicClientApplication the app can obtain.
+ * The calling app has to support ISingleAccountPublicClientApplication if it is planning to support shared device mode.
+ *
+ * In the shared device mode,
+ * - 'Sign-in' means that the user will be signed in to the device - not just this app.
+ * - Once an account is 'signed-in', every MSAL app on the device that support shared device mode will be able to retrieve this account, and use them to silently perform API calls.
+ * - 'Sign-out' means that user will be signed out from the device - every MSAL apps and the default browser.
  */
 public interface ISingleAccountPublicClientApplication extends IPublicClientApplication {
 

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -24,6 +24,7 @@
 package com.microsoft.identity.client;
 
 import android.app.Activity;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
@@ -99,16 +100,16 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param scopes       The non-null array of scopes to be requested for the access token.
-     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param authority    Optional. Can be passed to override the configured authority.
-     * @param callback     {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                     sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                     Failure case will be sent back via {
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param authority Authority to issue the token.
+     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
      * @link AuthenticationCallback#onError(MsalException)}.
      */
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
-                                 @Nullable final String authority,
+                                 @NonNull final String authority,
                                  @NonNull final AuthenticationCallback callback);
 
     /**
@@ -116,10 +117,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param scopes       The non-null array of scopes to be requested for the access token.
-     *                     MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param authority    Optional. Can be passed to override the configured authority.
-     *
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param authority Optional. Can be passed to override the configured authority.
      */
     @WorkerThread
     IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -230,7 +230,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             }
         });
 
-        AsyncResult<List<IAccount>> result = future.get();
+        final AsyncResult<List<IAccount>> result = future.get();
 
         if (result.getSuccess()) {
             return result.getResult();

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -22,9 +22,11 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -228,13 +230,13 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             }
         });
 
-         AsyncResult<List<IAccount>> result = future.get();
+        AsyncResult<List<IAccount>> result = future.get();
 
-         if(result.getSuccess()){
-             return result.getResult();
-         }else{
-             throw result.getException();
-         }
+        if (result.getSuccess()) {
+            return result.getResult();
+        } else {
+            throw result.getException();
+        }
     }
 
     /**
@@ -345,9 +347,9 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
         AsyncResult<IAccount> result = future.get();
 
-        if(result.getSuccess()){
+        if (result.getSuccess()) {
             return result.getResult();
-        }else{
+        } else {
             throw result.getException();
         }
 
@@ -429,11 +431,30 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
         AsyncResult<Boolean> result = future.get();
 
-        if(result.getSuccess()){
+        if (result.getSuccess()) {
             return result.getResult().booleanValue();
-        }else{
+        } else {
             throw result.getException();
         }
 
+    }
+
+    @Override
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String[] scopes,
+                             @Nullable final String loginHint,
+                             @NonNull final AuthenticationCallback callback) {
+        acquireToken(
+                activity,
+                scopes,
+                null, // account
+                null, // uiBehavior
+                null, // extraQueryParams
+                null, // extraScopes
+                null, // authority
+                callback,
+                loginHint,
+                null // claimsRequest
+        );
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -27,10 +27,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.os.Looper;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import androidx.annotation.WorkerThread;
+
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -859,25 +861,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 null, // authority
                 callback,
                 null, // loginHint
-                null // claimsRequest
-        );
-    }
-
-    @Override
-    public void acquireToken(@NonNull final Activity activity,
-                             @NonNull final String[] scopes,
-                             @Nullable final String loginHint,
-                             @NonNull final AuthenticationCallback callback) {
-        acquireToken(
-                activity,
-                scopes,
-                null, // account
-                null, // uiBehavior
-                null, // extraQueryParams
-                null, // extraScopes
-                null, // authority
-                callback,
-                loginHint,
                 null // claimsRequest
         );
     }

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -515,7 +515,9 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public void acquireToken(@NonNull Activity activity, @NonNull String[] scopes, @NonNull AuthenticationCallback callback) {
+    public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final String[] scopes,
+                             @NonNull final AuthenticationCallback callback) {
         acquireToken(
                 activity,
                 scopes,
@@ -575,7 +577,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public void acquireTokenSilentAsync(@NonNull AcquireTokenSilentParameters acquireTokenSilentParameters) {
+    public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
         IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             acquireTokenSilentParameters.getCallback().onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
@@ -588,7 +590,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public IAuthenticationResult acquireTokenSilent(@NonNull AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException {
+    public IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException {
         IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT);

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -57,7 +57,6 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         implements ISingleAccountPublicClientApplication {
     private static final String TAG = SingleAccountPublicClientApplication.class.getSimpleName();
 
-
     /**
      * Name of the shared preference cache for storing SingleAccountPublicClientApplication data.
      */
@@ -105,9 +104,8 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                 new StorageHelper(context));
     }
 
-
     @Override
-    public void getCurrentAccountAsync(final CurrentAccountCallback callback) {
+    public void getCurrentAccountAsync(@NonNull final CurrentAccountCallback callback) {
         final String methodName = ":getCurrentAccount";
         final PublicClientApplicationConfiguration configuration = getConfiguration();
 
@@ -219,13 +217,10 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         } else {
             throw result.getException();
         }
-
-
     }
 
-
-    private void getCurrentAccountFromSharedDevice(final CurrentAccountCallback callback,
-                                                   final PublicClientApplicationConfiguration configuration) {
+    private void getCurrentAccountFromSharedDevice(@NonNull final CurrentAccountCallback callback,
+                                                   @NonNull final PublicClientApplicationConfiguration configuration) {
         final String methodName = ":getCurrentAccountFromSharedDevice";
 
         //TODO: migrate to Command.
@@ -259,7 +254,8 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                 });
     }
 
-    private void checkCurrentAccountNotifyCallback(final CurrentAccountCallback callback, List<ICacheRecord> newAccountRecords) {
+    private void checkCurrentAccountNotifyCallback(@NonNull final CurrentAccountCallback callback,
+                                                   @Nullable final List<ICacheRecord> newAccountRecords) {
         MultiTenantAccount localAccount = getPersistedCurrentAccount();
         MultiTenantAccount newAccount = newAccountRecords == null ? null : getAccountFromICacheRecordList(newAccountRecords);
 
@@ -273,10 +269,9 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
 
     @Override
-    public void signIn(@NonNull Activity activity,
-
-                       @NonNull String[] scopes,
-                       @NonNull AuthenticationCallback callback) {
+    public void signIn(@NonNull final Activity activity,
+                       @NonNull final String[] scopes,
+                       @NonNull final AuthenticationCallback callback) {
         acquireToken(
                 activity,
                 new String[]{"user.read"},
@@ -292,7 +287,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    protected ILocalAuthenticationCallback getLocalAuthenticationCallback(final AuthenticationCallback authenticationCallback) {
+    protected ILocalAuthenticationCallback getLocalAuthenticationCallback(@NonNull final AuthenticationCallback authenticationCallback) {
 
         return new ILocalAuthenticationCallback() {
 
@@ -330,11 +325,11 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         };
     }
 
-    private boolean didCurrentAccountChange(final @Nullable MultiTenantAccount newAccount) {
-        MultiTenantAccount persistedAccount = getPersistedCurrentAccount();
+    private boolean didCurrentAccountChange(@Nullable final MultiTenantAccount newAccount) {
+        final MultiTenantAccount persistedAccount = getPersistedCurrentAccount();
 
-        String persistedAccountId = persistedAccount == null ? "" : persistedAccount.getHomeAccountId();
-        String newAccountId = newAccount == null ? "" : newAccount.getHomeAccountId();
+        final String persistedAccountId = persistedAccount == null ? "" : persistedAccount.getHomeAccountId();
+        final String newAccountId = newAccount == null ? "" : newAccount.getHomeAccountId();
 
         return !persistedAccountId.equalsIgnoreCase(newAccountId);
     }
@@ -409,7 +404,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
             }
         });
 
-        AsyncResult<Boolean> result = future.get();
+        final AsyncResult<Boolean> result = future.get();
 
         if (result.getSuccess()) {
             return result.getResult();
@@ -419,7 +414,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     private void removeAccountFromSharedDevice(@NonNull final SignOutCallback callback,
-                                               @NonNull PublicClientApplicationConfiguration configuration) {
+                                               @NonNull final PublicClientApplicationConfiguration configuration) {
         final String methodName = ":removeAccountFromSharedDevice";
 
         //TODO: migrate to Command.
@@ -460,12 +455,12 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
      * @return a persisted MultiTenantAccount. This could be null.
      */
     private MultiTenantAccount getPersistedCurrentAccount() {
-        String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
+        final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
         if (currentAccountJsonString == null) {
             return null;
         }
 
-        List<ICacheRecord> cacheRecordList = MsalBrokerResultAdapter.getICacheRecordListFromJsonString(currentAccountJsonString);
+        final List<ICacheRecord> cacheRecordList = MsalBrokerResultAdapter.getICacheRecordListFromJsonString(currentAccountJsonString);
         return getAccountFromICacheRecordList(cacheRecordList);
     }
 
@@ -475,7 +470,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
      * @param cacheRecords list of cache record that belongs to an account.
      *                     Please note that this layer will not verify if the list ubelongs to a single account or not.
      */
-    private void persistCurrentAccount(@Nullable List<ICacheRecord> cacheRecords) {
+    private void persistCurrentAccount(@Nullable final List<ICacheRecord> cacheRecords) {
 
         sharedPreferencesFileManager.clear();
 
@@ -495,7 +490,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
      *                     If the list can be converted to multiple accounts, only the first one will be returned.
      */
     @Nullable
-    private MultiTenantAccount getAccountFromICacheRecordList(@NonNull List<ICacheRecord> cacheRecords) {
+    private MultiTenantAccount getAccountFromICacheRecordList(@NonNull final List<ICacheRecord> cacheRecords) {
         final String methodName = ":getAccountFromICacheRecords";
         if (cacheRecords == null || cacheRecords.size() == 0) {
             return null;
@@ -533,8 +528,8 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     }
 
     @Override
-    public void acquireToken(@NonNull AcquireTokenParameters acquireTokenParameters) {
-        IAccount persistedAccount = getPersistedCurrentAccount();
+    public void acquireToken(@NonNull final AcquireTokenParameters acquireTokenParameters) {
+        final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount != null) {
             // If the account exists, overwrite Account and ignore loginHint.
             acquireTokenParameters.setAccount(persistedAccount);
@@ -549,7 +544,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
                                         @NonNull final String authority,
                                         @NonNull final AuthenticationCallback callback) {
 
-        IAccount persistedAccount = getPersistedCurrentAccount();
+        final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
         }
@@ -568,7 +563,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
     public IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                                     @NonNull final String authority) throws MsalException, InterruptedException {
 
-        IAccount persistedAccount = getPersistedCurrentAccount();
+        final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT);
         }
@@ -578,7 +573,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
-        IAccount persistedAccount = getPersistedCurrentAccount();
+        final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             acquireTokenSilentParameters.getCallback().onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
         }
@@ -591,7 +586,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException {
-        IAccount persistedAccount = getPersistedCurrentAccount();
+        final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
             throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT);
         }


### PR DESCRIPTION
1. Move acquireToken with loginHint to multiple account mode.
2. In SingleAccount mode
  a) for silent flow, always verify current account first and fail the request if it doesn't exist.
  b) for non-silent flow, use current account as a best-effort.
3. Commented out one ignored test case to allow test project to build.