### PR TITLE
Resolves #718, fixes ATS for B2C

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -208,6 +208,7 @@ class AccountAdapter {
         for (final Map.Entry<String, List<ICacheRecord>> entry : bucketedRecords.entrySet()) {
             // Create our empty root...
             final MultiTenantAccount emptyRoot = new MultiTenantAccount(
+                    null,
                     null // home tenant IdToken.... doesn't exist!
             );
 
@@ -228,7 +229,10 @@ class AccountAdapter {
 
             for (final ICacheRecord cacheRecord : entry.getValue()) {
                 final String tenantId = cacheRecord.getAccount().getRealm();
-                final TenantProfile profile = new TenantProfile(getIdToken(cacheRecord));
+                final TenantProfile profile = new TenantProfile(
+                        null,
+                        getIdToken(cacheRecord)
+                );
 
                 tenantProfileMap.put(tenantId, profile);
             }
@@ -251,7 +255,10 @@ class AccountAdapter {
                 final String guestRecordHomeAccountId = guestRecord.getAccount().getHomeAccountId();
 
                 if (guestRecordHomeAccountId.contains(account.getId())) {
-                    final TenantProfile profile = new TenantProfile(getIdToken(guestRecord));
+                    final TenantProfile profile = new TenantProfile(
+                            null,
+                            getIdToken(guestRecord)
+                    );
                     tenantProfiles.put(guestRecord.getAccount().getRealm(), profile);
                 }
             }
@@ -271,7 +278,10 @@ class AccountAdapter {
             // Each IAccount will be initialized as a MultiTenantAccount whether it really is or not...
             // This allows us to cast the results however the caller sees fit...
             final IAccount rootAccount;
-            rootAccount = new MultiTenantAccount(getIdToken(homeCacheRecord));
+            rootAccount = new MultiTenantAccount(
+                    homeCacheRecord.getAccount().getClientInfo(),
+                    getIdToken(homeCacheRecord)
+            );
 
             // Set the tenant_id
             ((MultiTenantAccount) rootAccount).setTenantId(

--- a/msal/src/main/java/com/microsoft/identity/client/MultiTenantAccount.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultiTenantAccount.java
@@ -35,8 +35,10 @@ public class MultiTenantAccount extends Account implements IMultiTenantAccount {
 
     private Map<String, ITenantProfile> mTenantProfiles = new HashMap<>();
 
-    MultiTenantAccount(@Nullable final IDToken homeTenantIdToken) {
-        super(homeTenantIdToken);
+    MultiTenantAccount(
+            @Nullable final String clientInfo,
+            @Nullable final IDToken homeTenantIdToken) {
+        super(clientInfo, homeTenantIdToken);
     }
 
     void setTenantProfiles(@NonNull final Map<String, ITenantProfile> profiles) {

--- a/msal/src/main/java/com/microsoft/identity/client/TenantProfile.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TenantProfile.java
@@ -23,14 +23,16 @@
 package com.microsoft.identity.client;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftIdToken;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
 public class TenantProfile extends Account implements ITenantProfile {
 
-    public TenantProfile(@NonNull final IDToken idToken) {
-        super(idToken);
+    public TenantProfile(@Nullable final String clientInfo,
+                         @NonNull final IDToken idToken) {
+        super(clientInfo, idToken);
     }
 
     @NonNull


### PR DESCRIPTION
B2C ATS is broken because `idToken.oid != clientInfo.uid` for accounts we consider to be "home".