### PR TITLE
Add backward compability for 'preferred_username'

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -28,6 +28,7 @@ import androidx.annotation.Nullable;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftIdToken;
+import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
 
 import java.util.Map;
@@ -129,18 +130,20 @@ public class Account implements IAccount {
     @NonNull
     @Override
     public String getUsername() {
-        String username = "";
-
         if (null != getClaims()) {
-            final String usernameClaim = (String) getClaims().get(IDToken.PREFERRED_USERNAME);
+            final String preferredUsername = (String) getClaims().get(IDToken.PREFERRED_USERNAME);
+            if (null != preferredUsername) {
+                return preferredUsername;
+            }
 
-            if (null != usernameClaim) {
-                username = usernameClaim;
-            } else {
-                username = MISSING_FROM_THE_TOKEN_RESPONSE;
+            // For backward compatibility.
+            // If AcquireToken was done in ADAL, cached id_token might not have the "preferred_username" field.
+            final String upn = (String) getClaims().get(AzureActiveDirectoryIdToken.UPN);
+            if (null != upn) {
+                return upn;
             }
         }
 
-        return username;
+        return MISSING_FROM_THE_TOKEN_RESPONSE;
     }
 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -194,7 +194,7 @@ public class MainActivity extends AppCompatActivity
             final Bundle bundle = new Bundle();
             if (mAuthResult != null) {
                 bundle.putString(ResultFragment.ACCESS_TOKEN, mAuthResult.getAccessToken());
-                bundle.putString(ResultFragment.DISPLAYABLE, MsalWrapper.getPreferredUsername(mAuthResult.getAccount()));
+                bundle.putString(ResultFragment.DISPLAYABLE, mAuthResult.getAccount().getUsername());
             }
 
             fragment.setArguments(bundle);
@@ -281,7 +281,7 @@ public class MainActivity extends AppCompatActivity
                 new ArrayList<String>() {{
                     if (accounts != null) {
                         for (IAccount account : accounts)
-                            add(MsalWrapper.getPreferredUsername(account));
+                            add(account.getUsername());
                     }
                 }}
         );

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -431,9 +431,9 @@ public class MsalWrapper {
                 public void onAccountChanged(IAccount priorAccount, IAccount currentAccount) {
                     notifyCallback.notify(
                             "signed-in account is changed from "
-                                    + (null == priorAccount ? "null" : getPreferredUsername(priorAccount))
+                                    + (null == priorAccount ? "null" : priorAccount.getUsername())
                                     + " to "
-                                    + (null == currentAccount ? "null" : getPreferredUsername(currentAccount))
+                                    + (null == currentAccount ? "null" : currentAccount.getUsername())
                     );
                 }
 
@@ -443,27 +443,6 @@ public class MsalWrapper {
                 }
             });
         }
-    }
-
-    @NonNull
-    static String getPreferredUsername(@NonNull final IAccount account) {
-        Map<String, ?> claims = null;
-
-        // First inspect the root (the home account) - if there are claims, source the username from here
-        if (null != account.getClaims()) {
-            claims = account.getClaims();
-        } else { // We did not have a home account... fallback on iterating over the guests profiles...
-            final MultiTenantAccount multiTenantAccount = (MultiTenantAccount) account;
-
-            for (final ITenantProfile profile : multiTenantAccount.getTenantProfiles().values()) {
-                if (null != profile.getClaims()) {
-                    claims = profile.getClaims();
-                    break;
-                }
-            }
-        }
-
-        return SchemaUtil.getDisplayableId(claims);
     }
 
     private void performPostAccountLoadedJobs() {


### PR DESCRIPTION
When an app is migrated from ADAL -> MSAL, the cached id_token won't have 'preferred_username'. This breaks UX and ATS as we're using this field as username in Broker token request.