### PR TITLE
Makes AT/ATS Params Immutable After Calling build()

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
@@ -59,14 +59,6 @@ public class AcquireTokenParameters extends TokenParameters {
         return mActivity;
     }
 
-    /**
-     * Non-null {@link Activity} that will be used as the parent activity for launching the {@link AuthenticationActivity}
-     *
-     * @param activity
-     */
-    public void setActivity(Activity activity) {
-        this.mActivity = activity;
-    }
 
     /**
      * Optional. Gets the login hint sent along with the authorization request.
@@ -82,7 +74,7 @@ public class AcquireTokenParameters extends TokenParameters {
      *
      * @param loginHint
      */
-    public void setLoginHint(String loginHint) {
+    void setLoginHint(String loginHint) {
         this.mLoginHint = loginHint;
     }
 
@@ -96,15 +88,6 @@ public class AcquireTokenParameters extends TokenParameters {
     }
 
     /**
-     * Controls the value of the prompt parameter sent along with the authorization request.
-     *
-     * @param uiBehavior
-     */
-    public void setUiBehavior(UiBehavior uiBehavior) {
-        this.mUiBehavior = uiBehavior;
-    }
-
-    /**
      * These are additional scopes that you would like the user to authorize the use of, while getting consent
      * for the first set of scopes
      *
@@ -115,16 +98,6 @@ public class AcquireTokenParameters extends TokenParameters {
     }
 
     /**
-     * These are additional scopes that you would like the user to authorize the use of, while getting consent
-     * for the first set of scopes
-     *
-     * @param extraScopesToConsent
-     */
-    public void setExtraScopesToConsent(List<String> extraScopesToConsent) {
-        this.mExtraScopesToConsent = extraScopesToConsent;
-    }
-
-    /**
      * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can get these here.
      * Otherwise... would recommend not touching.
      *
@@ -132,16 +105,6 @@ public class AcquireTokenParameters extends TokenParameters {
      */
     public List<Pair<String, String>> getExtraQueryStringParameters() {
         return mExtraQueryStringParameters;
-    }
-
-    /**
-     * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can set these here.
-     * Otherwise... would recommend not touching.
-     *
-     * @param extraQueryStringParameters
-     */
-    public void setExtraQueryStringParameters(List<Pair<String, String>> extraQueryStringParameters) {
-        this.mExtraQueryStringParameters = extraQueryStringParameters;
     }
 
     /**
@@ -157,21 +120,6 @@ public class AcquireTokenParameters extends TokenParameters {
      */
     public AuthenticationCallback getCallback() {
         return mCallback;
-    }
-
-    /**
-     * The Non-null {@link AuthenticationCallback} to receive the result back.
-     * 1) If user cancels the flow by pressing the device back button, the result will be sent
-     * back via {@link AuthenticationCallback#onCancel()}.
-     * 2) If the sdk successfully receives the token back, result will be sent back via
-     * {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     * 3) All the other errors will be sent back via
-     * {@link AuthenticationCallback#onError(com.microsoft.identity.client.exception.MsalException)}.
-     *
-     * @param callback
-     */
-    public void setCallback(AuthenticationCallback callback) {
-        this.mCallback = callback;
     }
 
     public static class Builder extends TokenParameters.Builder<AcquireTokenParameters.Builder> {

--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenSilentParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenSilentParameters.java
@@ -32,7 +32,7 @@ public class AcquireTokenSilentParameters extends TokenParameters {
         mCallback = builder.mCallback;
     }
 
-    public void setCallback(SilentAuthenticationCallback callback) {
+    void setCallback(SilentAuthenticationCallback callback) {
         mCallback = callback;
     }
 
@@ -49,16 +49,6 @@ public class AcquireTokenSilentParameters extends TokenParameters {
      */
     public SilentAuthenticationCallback getCallback() {
         return mCallback;
-    }
-
-    /**
-     * Boolean.  Indicates whether MSAL should refresh the access token.  Default is false and
-     * unless you have good reason to.  You should not use this parameter.
-     *
-     * @param forceRefresh
-     */
-    public void setForceRefresh(Boolean forceRefresh) {
-        mForceRefresh = forceRefresh;
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationActivity.java
@@ -28,6 +28,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -25,8 +25,8 @@ package com.microsoft.identity.client;
 
 import android.app.Activity;
 import android.content.Context;
+
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.exception.MsalException;

--- a/msal/src/main/java/com/microsoft/identity/client/MsalChromeCustomTabManager.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MsalChromeCustomTabManager.java
@@ -27,6 +27,7 @@ import android.app.Activity;
 import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
+
 import androidx.browser.customtabs.CustomTabsClient;
 import androidx.browser.customtabs.CustomTabsIntent;
 import androidx.browser.customtabs.CustomTabsServiceConnection;

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.client;
 
 import android.app.Activity;
-import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.SerializedName;
@@ -49,15 +50,15 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_USER_AGENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.BROWSER_SAFE_LIST;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CLIENT_ID;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ENVIRONMENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.HTTP;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.LOGGING;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.MULTIPLE_CLOUDS_SUPPORTED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REDIRECT_URI;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.TELEMETRY;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.SHARED_DEVICE_MODE_SUPPORTED;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.USE_BROKER;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ENVIRONMENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REQUIRED_BROKER_PROTOCOL_VERSION;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.SHARED_DEVICE_MODE_SUPPORTED;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.TELEMETRY;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.USE_BROKER;
 
 public class PublicClientApplicationConfiguration {
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -31,7 +31,6 @@ import androidx.annotation.VisibleForTesting;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.client.internal.configuration.LogLevelDeserializer;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AuthorityDeserializer;

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -75,7 +75,7 @@ abstract class TokenParameters {
      *
      * @param account
      */
-    public void setAccount(IAccount account) {
+    void setAccount(IAccount account) {
         this.mAccount = account;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -60,16 +60,6 @@ abstract class TokenParameters {
     }
 
     /**
-     * The non-null array of scopes to be requested for the access token.
-     * MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     *
-     * @param scopes
-     */
-    public void setScopes(List<String> scopes) {
-        this.mScopes = scopes;
-    }
-
-    /**
      * Optional. If provided, will be used to force the session continuation.  If user tries to sign in with a different account, error
      * will be returned.
      *
@@ -104,7 +94,7 @@ abstract class TokenParameters {
      *
      * @param authority
      */
-    public void setAuthority(String authority) {
+    void setAuthority(String authority) {
         this.mAuthority = authority;
     }
 
@@ -115,15 +105,6 @@ abstract class TokenParameters {
      */
     public ClaimsRequest getClaimsRequest() {
         return mClaimsRequest;
-    }
-
-    /**
-     * Optional. Can be passed into request specific claims in the id_token and access_token
-     *
-     * @param claimsRequest
-     */
-    public void setClaimsRequest(ClaimsRequest claimsRequest) {
-        this.mClaimsRequest = claimsRequest;
     }
 
     void setAccountRecord(AccountRecord record) {
@@ -195,6 +176,5 @@ abstract class TokenParameters {
         public abstract B self();
 
         public abstract TokenParameters build();
-
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -31,6 +31,7 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.client.internal.controllers;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.RemoteException;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
@@ -34,6 +34,7 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
+
 import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -23,9 +23,10 @@
 package com.microsoft.identity.client.internal.controllers;
 
 import android.content.Intent;
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
-import android.text.TextUtils;
 
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.exception.ArgumentException;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -28,6 +28,7 @@ import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.PowerManager;
+
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;


### PR DESCRIPTION
Remove [public] setters on fully-constructed AT/ATS params.

Also runs a formatter to optimize imports.