### PR TITLE
Enable logcat by default

### DIFF
--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -20,7 +20,7 @@
   "logging": {
     "pii_enabled": false,
     "log_level": "WARNING",
-    "logcat_enabled": false
+    "logcat_enabled": true
   },
   "shared_device_mode_supported": false,
   "account_mode": "MULTIPLE",


### PR DESCRIPTION
See diff. Enables MSAL output to logcat by default