### PR TITLE
Disable shared device flag in config

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -349,6 +349,7 @@ public class PublicClientApplicationConfiguration {
 
         // Multiple is the default mode.
         this.mAccountMode = config.mAccountMode != AccountMode.MULTIPLE ? config.mAccountMode : this.mAccountMode;
+        this.mSharedDeviceModeSupported = config.mSharedDeviceModeSupported | this.mSharedDeviceModeSupported;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -116,7 +116,7 @@ public class PublicClientApplicationConfiguration {
     TelemetryConfiguration mTelemetryConfiguration;
 
     @SerializedName(SHARED_DEVICE_MODE_SUPPORTED)
-    Boolean mSharedDeviceModeSupported;
+    boolean mSharedDeviceModeSupported;
 
     @SerializedName(ACCOUNT_MODE)
     AccountMode mAccountMode;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -353,11 +353,6 @@ public class BrokerMsalController extends BaseController {
                                     final PublicClientApplication.BrokerDeviceModeCallback callback) {
         final String methodName = ":getBrokerDeviceMode";
 
-        if (!configuration.getSharedDeviceModeSupported()) {
-            callback.onGetMode(false);
-            return;
-        }
-
         try {
             if (!MSALControllerFactory.brokerEligible(
                     configuration.getAppContext(),

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -121,6 +121,7 @@ public class MSALControllerFactory {
                                          @NonNull Authority authority,
                                          @NonNull PublicClientApplicationConfiguration applicationConfiguration) throws MsalClientException {
         final String methodName = ":brokerEligible";
+
         //If app has asked for Broker or if the authority is not AAD return false
         if (!applicationConfiguration.getUseBroker() || !(authority instanceof AzureActiveDirectoryAuthority)) {
             Logger.verbose(TAG + methodName, "Eligible to call broker? [false]");

--- a/testapps/testapp/src/main/res/raw/msal_arlington_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_arlington_config.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msalcb7faed4-b8c0-49ee-b421-f5ed16894c83://auth",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
+  "shared_device_mode_supported": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
+  "shared_device_mode_supported": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -4,6 +4,7 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
+  "shared_device_mode_supported": true,
   "minimum.required.broker.protocol.version":"2.0",
   "authorities" : [
     {


### PR DESCRIPTION
Disable this for now, as we can't promise that MSAL would work as expected for apps that sets this to false. (i.e. we prevent addAccount flow from signing in with another account, for example).

 Need to think through what the right behavior should be.

