### PR TITLE
Enable broker by default

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -216,20 +216,6 @@ public final class PublicClientApplicationTest {
     }
 
     /**
-     * Verify correct exception is thrown if {@link BrowserTabActivity} does not have the correct intent-filer.
-     */
-    @Test(expected = IllegalStateException.class)
-    public void testNoCustomTabSchemeConfigured() throws PackageManager.NameNotFoundException {
-        final Context context = new MockContext(mAppContext);
-        mockPackageManagerWithClientId(context, null, CLIENT_ID);
-        mockPackageManagerWithDefaultFlag(context);
-
-        final PublicClientApplicationConfiguration config = PublicClientApplicationConfigurationFactory.initializeConfiguration(context);
-        config.mRedirectUri = "msauth://com.microsoft.identity.msal.test/123456";
-        new PublicClientApplication(config, CLIENT_ID, null);
-    }
-
-    /**
      * Verify correct exception is thrown if callback is not provided.
      */
     @Test(expected = IllegalArgumentException.class)

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -225,7 +225,7 @@ public final class PublicClientApplicationTest {
         mockPackageManagerWithDefaultFlag(context);
 
         final PublicClientApplicationConfiguration config = PublicClientApplicationConfigurationFactory.initializeConfiguration(context);
-        config.mRedirectUri = "msal123456://auth";
+        config.mRedirectUri = "msauth://com.microsoft.identity.msal.test/123456";
         new PublicClientApplication(config, CLIENT_ID, null);
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -992,8 +992,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 )
         );
 
-        checkIntentFilterAddedToAppManifest();
-
         // Since network request is sent from the sdk, if calling app doesn't declare the internet
         // permission in the manifest, we cannot make the network call.
         checkInternetPermission();
@@ -1625,23 +1623,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             return result.getResult();
         } else {
             throw result.getException();
-        }
-    }
-
-    private void checkIntentFilterAddedToAppManifest() {
-        final boolean hasCustomTabRedirectActivity = MsalUtils.hasCustomTabRedirectActivity(
-                mPublicClientConfiguration.getAppContext(),
-                mPublicClientConfiguration.getRedirectUri()
-        );
-
-        if (!hasCustomTabRedirectActivity) {
-            throw new IllegalStateException(
-                    "Intent filter for: "
-                            + BrowserTabActivity.class.getSimpleName()
-                            + " is missing. Please verify that the registered redirect URI in AndroidManifest.xml is valid. "
-                            + "Please note that the leading /'//' is required for android:path. "
-                            + "For more information, please refer to the MSAL readme and https://developer.android.com/training/app-links/deep-linking."
-            );
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -992,6 +992,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 )
         );
 
+        mPublicClientConfiguration.checkIntentFilterAddedToAppManifestForBrokerFlow();
+
         // Since network request is sent from the sdk, if calling app doesn't declare the internet
         // permission in the manifest, we cannot make the network call.
         checkInternetPermission();

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -48,8 +48,6 @@ import com.microsoft.identity.common.internal.telemetry.TelemetryConfiguration;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
 
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -394,7 +392,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     private boolean isBrokerRedirectUri() {
-        final String BROKER_REDIRECT_URI_REGEX = "msauth://"+ mAppContext.getPackageName() + "/.*";
+        final String BROKER_REDIRECT_URI_REGEX = "msauth://" + mAppContext.getPackageName() + "/.*";
         final Pattern pairRegex = Pattern.compile(BROKER_REDIRECT_URI_REGEX);
         final Matcher matcher = pairRegex.matcher(mRedirectUri);
         return matcher.matches();
@@ -404,26 +402,25 @@ public class PublicClientApplicationConfiguration {
     private void verifyRedirectUriWithAppSignature() {
         final String packageName = mAppContext.getPackageName();
         try {
-            PackageInfo info = mAppContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_SIGNATURES);
-            for (final Signature signature: info.signatures) {
-                final Uri.Builder builder = new Uri.Builder();
-
+            final PackageInfo info = mAppContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_SIGNATURES);
+            for (final Signature signature : info.signatures) {
                 final MessageDigest messageDigest = MessageDigest.getInstance("SHA");
                 messageDigest.update(signature.toByteArray());
                 final String signatureHash = Base64.encodeToString(messageDigest.digest(), Base64.NO_WRAP);
 
-                Uri uri = builder.scheme("msauth")
-                            .authority(packageName)
-                            .appendPath(signatureHash)
-                            .build();
+                final Uri.Builder builder = new Uri.Builder();
+                final Uri uri = builder.scheme("msauth")
+                        .authority(packageName)
+                        .appendPath(signatureHash)
+                        .build();
 
-                if (mRedirectUri.equalsIgnoreCase(uri.toString())){
+                if (mRedirectUri.equalsIgnoreCase(uri.toString())) {
                     // Life is good.
                     return;
                 }
             }
         } catch (PackageManager.NameNotFoundException | NoSuchAlgorithmException e) {
-            Logger.error(TAG, "Unexpected error",e);
+            Logger.error(TAG, "Unexpected error in verifyRedirectUriWithAppSignature()", e);
         }
 
         throw new IllegalStateException("The redirect URI in the configuration file doesn't match with the one " +

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -23,7 +23,6 @@
 package com.microsoft.identity.client;
 
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -61,7 +60,6 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.MULTIPLE_CLOUDS_SUPPORTED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REDIRECT_URI;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REQUIRED_BROKER_PROTOCOL_VERSION;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.SHARED_DEVICE_MODE_SUPPORTED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.TELEMETRY;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.USE_BROKER;
 
@@ -81,7 +79,6 @@ public class PublicClientApplicationConfiguration {
         static final String REQUIRED_BROKER_PROTOCOL_VERSION = "minimum_required_broker_protocol_version";
         static final String TELEMETRY = "telemetry";
         static final String BROWSER_SAFE_LIST = "browser_safelist";
-        static final String SHARED_DEVICE_MODE_SUPPORTED = "shared_device_mode_supported";
         static final String ACCOUNT_MODE = "account_mode";
     }
 
@@ -120,9 +117,6 @@ public class PublicClientApplicationConfiguration {
 
     @SerializedName(TELEMETRY)
     TelemetryConfiguration mTelemetryConfiguration;
-
-    @SerializedName(SHARED_DEVICE_MODE_SUPPORTED)
-    Boolean mSharedDeviceModeSupported;
 
     @SerializedName(ACCOUNT_MODE)
     AccountMode mAccountMode;
@@ -246,18 +240,6 @@ public class PublicClientApplicationConfiguration {
     }
 
     /**
-     * Indicates whether or not the public client application supports shared device mode
-     * <p>
-     * Shared device mode is enabled by the Administrators of devices using the Microsoft Authenticator app or via
-     * provisioning via a mobile device management solution.
-     *
-     * @return The boolean indicator of whether shared device mode is supported by this app.
-     */
-    public Boolean getSharedDeviceModeSupported() {
-        return mSharedDeviceModeSupported;
-    }
-
-    /**
      * Gets the currently configured {@link AccountMode} for the PublicClientApplication.
      *
      * @return The AccountMode supported by this application.
@@ -357,7 +339,6 @@ public class PublicClientApplicationConfiguration {
 
         // Multiple is the default mode.
         this.mAccountMode = config.mAccountMode != AccountMode.MULTIPLE ? config.mAccountMode : this.mAccountMode;
-        this.mSharedDeviceModeSupported = config.mSharedDeviceModeSupported == null ? this.mSharedDeviceModeSupported : config.mSharedDeviceModeSupported;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -364,7 +364,6 @@ public class PublicClientApplicationConfiguration {
         nullConfigurationCheck(REDIRECT_URI, mRedirectUri);
         nullConfigurationCheck(CLIENT_ID, mClientId);
         checkDefaultAuthoritySpecified();
-        checkIntentFilterAddedToAppManifestForBrokerFlow();
 
         // Only validate the browser safe list configuration
         // when the authorization agent is set either DEFAULT or BROWSER.
@@ -404,20 +403,20 @@ public class PublicClientApplicationConfiguration {
         }
     }
 
-    private boolean isLegacyLocalMsalRedirectUri() {
-        final String LEGACY_LOCAL_MSAL_REDIRECT_URI_REGEX = "msal[0-9a-f]{8}\\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\\b[0-9a-f]{12}\\b://auth";
-        Pattern pairRegex = Pattern.compile(LEGACY_LOCAL_MSAL_REDIRECT_URI_REGEX);
-        Matcher matcher = pairRegex.matcher(mRedirectUri);
+    private boolean isBrokerRedirectUri() {
+        final String BROKER_REDIRECT_URI_REGEX = "msauth://"+ mAppContext.getPackageName() + "/.*";
+        final Pattern pairRegex = Pattern.compile(BROKER_REDIRECT_URI_REGEX);
+        final Matcher matcher = pairRegex.matcher(mRedirectUri);
         return matcher.matches();
     }
 
-    private void checkIntentFilterAddedToAppManifestForBrokerFlow() {
+    public void checkIntentFilterAddedToAppManifestForBrokerFlow() {
         if (!mUseBroker) {
             return;
         }
 
-        if (isLegacyLocalMsalRedirectUri()) {
-            // This means that the app is still using the legacy local-MSAL Redirect uri (already removed from the new portal).
+        if (!isBrokerRedirectUri()) {
+            // This means that the app is still using the legacy local-only MSAL Redirect uri (already removed from the new portal).
             // If this is the case, we can assume that the user doesn't need Broker support.
             Logger.info(TAG, "The app is still using legacy MSAL redirect uri. Switch to MSAL local auth.");
             mUseBroker = false;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -83,10 +83,9 @@ public class PublicClientApplicationConfigurationFactory {
         final PublicClientApplicationConfiguration config = loadDefaultConfiguration(context);
         if (developerConfig != null) {
             config.mergeConfiguration(developerConfig);
-            config.validateConfiguration();
         }
 
-        config.setAppContext(context);
+        config.validateConfiguration();
         config.setOAuth2TokenCache(MsalOAuth2TokenCache.create(context));
         return config;
     }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -97,7 +97,10 @@ public class PublicClientApplicationConfigurationFactory {
                 TAG + methodName,
                 "Loading default configuration"
         );
-        return loadConfiguration(context, R.raw.msal_default_config);
+        final PublicClientApplicationConfiguration config = loadConfiguration(context, R.raw.msal_default_config);
+        config.setAppContext(context);
+
+        return config;
     }
 
     @VisibleForTesting

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -83,9 +83,9 @@ public class PublicClientApplicationConfigurationFactory {
         final PublicClientApplicationConfiguration config = loadDefaultConfiguration(context);
         if (developerConfig != null) {
             config.mergeConfiguration(developerConfig);
+            config.validateConfiguration();
         }
 
-        config.validateConfiguration();
         config.setOAuth2TokenCache(MsalOAuth2TokenCache.create(context));
         return config;
     }

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -22,7 +22,6 @@
     "log_level": "WARNING",
     "logcat_enabled": true
   },
-  "shared_device_mode_supported": false,
   "account_mode": "MULTIPLE",
   "browser_safelist": [
     {

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -11,7 +11,7 @@
   "authorization_user_agent": "DEFAULT",
   "minimum_required_broker_protocol_version": "3.0",
   "multiple_clouds_supported": false,
-  "broker_redirect_uri_registered": false,
+  "broker_redirect_uri_registered": true,
   "environment": "Production",
   "http": {
     "connect_timeout": 10000,

--- a/testapps/testapp/src/main/res/raw/msal_arlington_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_arlington_config.json
@@ -4,7 +4,6 @@
   "redirect_uri" : "msalcb7faed4-b8c0-49ee-b421-f5ed16894c83://auth",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
-  "shared_device_mode_supported": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -3,8 +3,6 @@
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
-  "broker_redirect_uri_registered": true,
-  "shared_device_mode_supported": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -4,7 +4,6 @@
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
-  "shared_device_mode_supported": true,
   "minimum.required.broker.protocol.version":"2.0",
   "authorities" : [
     {


### PR DESCRIPTION
Also, if the redirectURI in the config is set to Broker's, we verify the AppManifest.
Otherwise, let it go and set mUseBroker to false (for backward compatibility).