### PR TITLE
Fix MSAL issue #779

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -184,6 +184,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         private static final String ACTIVITY = "activity";
         private static final String SCOPES = "scopes";
         private static final String ACCOUNT = "account";
+
+        private static final String NULL_ERROR_SUFFIX = " cannot be null or empty";
     }
 
 
@@ -1623,7 +1625,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             public void onError(BaseException exception) {
                 MsalException msalException = msalExceptionFromBaseException(exception);
                 if (authenticationCallback == null) {
-                    throw new IllegalStateException("Callback cannot be null or empty");
+                    throw new IllegalStateException(NONNULL_CONSTANTS.CALLBACK + NONNULL_CONSTANTS.NULL_ERROR_SUFFIX);
                 } else {
                     authenticationCallback.onError(msalException);
                 }
@@ -1648,7 +1650,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                                   @NonNull final SilentAuthenticationCallback authenticationCallback){
 
         if (authenticationCallback == null) {
-            throw new IllegalStateException("Callback cannot be null or empty");
+            throw new IllegalStateException(NONNULL_CONSTANTS.CALLBACK + NONNULL_CONSTANTS.NULL_ERROR_SUFFIX);
         }
 
         // Check if any of the requested scopes are declined by the server, if yes throw a MsalDeclinedScope exception

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1622,7 +1622,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             @Override
             public void onError(BaseException exception) {
                 MsalException msalException = msalExceptionFromBaseException(exception);
-                authenticationCallback.onError(msalException);
+                if (authenticationCallback == null) {
+                    throw new IllegalStateException("Callback cannot be null or empty");
+                } else {
+                    authenticationCallback.onError(msalException);
+                }
             }
 
             @Override
@@ -1642,6 +1646,10 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     protected void postAuthResult(@NonNull final ILocalAuthenticationResult localAuthenticationResult,
                                   @NonNull final TokenParameters requestParameters,
                                   @NonNull final SilentAuthenticationCallback authenticationCallback){
+
+        if (authenticationCallback == null) {
+            throw new IllegalStateException("Callback cannot be null or empty");
+        }
 
         // Check if any of the requested scopes are declined by the server, if yes throw a MsalDeclinedScope exception
         final List<String> declinedScopes = AuthenticationResultAdapter.getDeclinedScopes(


### PR DESCRIPTION
In this PR I've fixed MSAL issue #779 
See #779 

To fix this issue, I check if callback is null before we call any onSuccess or onError methods on it and then we throw an IllegalStateException if the callback is null

