### PR TITLE
Use Argument Exception when validating non-null as we use it to parse…

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -49,6 +49,7 @@ import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
 import com.microsoft.identity.common.adal.internal.tokensharing.TokenShareUtility;
+import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.authorities.Authority;
@@ -1250,7 +1251,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         acquireToken(acquireTokenParameters);
     }
 
-    protected void validateAcquireTokenParameters(AcquireTokenParameters parameters) throws MsalArgumentException {
+    protected void validateAcquireTokenParameters(AcquireTokenParameters parameters) throws ArgumentException {
         final Activity activity = parameters.getActivity();
         final List scopes = parameters.getScopes();
         final AuthenticationCallback callback = parameters.getCallback();
@@ -1260,7 +1261,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         validateNonNullArg(callback, NONNULL_CONSTANTS.CALLBACK);
     }
 
-    protected void validateAcquireTokenSilentParameters(AcquireTokenSilentParameters parameters) throws MsalArgumentException {
+    protected void validateAcquireTokenSilentParameters(AcquireTokenSilentParameters parameters) throws ArgumentException {
         final String authority = parameters.getAuthority();
         final IAccount account = parameters.getAccount();
         final List scopes = parameters.getScopes();

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -42,6 +42,7 @@ import androidx.browser.customtabs.CustomTabsService;
 
 import com.microsoft.identity.client.BrowserTabActivity;
 import com.microsoft.identity.client.exception.MsalArgumentException;
+import com.microsoft.identity.common.exception.ArgumentException;
 
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -122,17 +123,17 @@ public final class MsalUtils {
     }
 
     /**
-     * Throws MsalArgumentException if the argument is null or empty
+     * Throws ArgumentException if the argument is null or empty
      * @param o
      * @param argName
-     * @throws MsalArgumentException
+     * @throws ArgumentException
      */
     public static void validateNonNullArg(@Nullable final Object o,
-                                          @NonNull final String argName) throws MsalArgumentException {
+                                          @NonNull final String argName) throws ArgumentException {
         if (null == o
                 || (o instanceof CharSequence) && TextUtils.isEmpty((CharSequence) o)
                 || (o instanceof List) && ((List) o).isEmpty()) {
-            throw new MsalArgumentException(argName, argName + " cannot be null or empty");
+            throw new ArgumentException(argName, argName + " cannot be null or empty");
         }
     }
 


### PR DESCRIPTION
… error code

Logic to validate non-null was added in #743 and we were throwing the MsalArgumentException if an argument was null, however, MsalArgumentException always provides us with the `unknown_error` error code because our existing exception adapter logic cannot parse it from an Msal Exception and can only parse it from a corresponding internal Exception that is located in common. For a complete understanding, please see [MsalExceptionAdapter.java](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java)

I've modified the validateNonNullArg method to instead throw an ArgumentException which can be parsed by the ExceptionAdapter.

