### PR TITLE
Parse MsalException from MsalException in MsalExceptionAdapter

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
@@ -42,7 +42,9 @@ public class MsalExceptionAdapter {
     public static MsalException msalExceptionFromBaseException(final BaseException e) {
         MsalException msalException = null;
 
-        if (e instanceof ClientException) {
+        if (e instanceof MsalException) {
+            msalException = (MsalException) e;
+        } else if (e instanceof ClientException) {
             final ClientException clientException = ((ClientException) e);
             msalException = new MsalClientException(
                     clientException.getErrorCode(),
@@ -60,11 +62,11 @@ public class MsalExceptionAdapter {
         } else if (e instanceof UiRequiredException) {
             final UiRequiredException uiRequiredException = ((UiRequiredException) e);
             msalException = new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
-        } else if (e instanceof IntuneAppProtectionPolicyRequiredException){
+        } else if (e instanceof IntuneAppProtectionPolicyRequiredException) {
             msalException = new MsalIntuneAppProtectionPolicyRequiredException(
-                    (IntuneAppProtectionPolicyRequiredException)e
+                    (IntuneAppProtectionPolicyRequiredException) e
             );
-        }else if (e instanceof ServiceException) {
+        } else if (e instanceof ServiceException) {
             final ServiceException serviceException = ((ServiceException) e);
             msalException = new MsalServiceException(
                     serviceException.getErrorCode(),
@@ -75,6 +77,7 @@ public class MsalExceptionAdapter {
         } else if (e instanceof UserCancelException) {
             msalException = new MsalUserCancelException();
         }
+
         if (msalException == null) {
             msalException = new MsalClientException(MsalClientException.UNKNOWN_ERROR, e.getMessage(), e);
         }


### PR DESCRIPTION
Logic to validate non-null was added in #743 and we were throwing the MsalArgumentException if an argument was null, however, MsalArgumentException always provides us with the `unknown_error` error code because our existing exception adapter logic cannot parse it from an Msal Exception and can only parse it from a corresponding internal Exception that is located in common. For a complete understanding, please see [MsalExceptionAdapter.java](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/dev/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java)

To fix this, I've added a block that checks if the exception we have is already an instance of an MsalException and if it is, then we just cast to that and return that exception.