### PR TITLE
Refactor E2E network tests to run individually, & also as a Suite

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
@@ -1,0 +1,9 @@
+package com.microsoft.identity.client.robolectric.tests.network;
+
+public class AcquireTokenNetworkAADTest extends AcquireTokenNetworkTest {
+
+    public AcquireTokenNetworkAADTest() {
+        this.mAuthorityType = AAD_AUTHORITY_TYPE_STRING;
+        this.mScopes = AAD_SCOPES;
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.client.robolectric.tests.network;
 
 /**

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkAADTest.java
@@ -1,5 +1,8 @@
 package com.microsoft.identity.client.robolectric.tests.network;
 
+/**
+ * Run all tests in the {@link AcquireTokenNetworkTest} class using AAD
+ */
 public class AcquireTokenNetworkAADTest extends AcquireTokenNetworkTest {
 
     public AcquireTokenNetworkAADTest() {

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.client.robolectric.tests.network;
 
 /**

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
@@ -1,5 +1,8 @@
 package com.microsoft.identity.client.robolectric.tests.network;
 
+/**
+ * Run all tests in the {@link AcquireTokenNetworkTest} class using B2C
+ */
 public class AcquireTokenNetworkB2CTest extends AcquireTokenNetworkTest {
 
     public AcquireTokenNetworkB2CTest() {

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkB2CTest.java
@@ -1,0 +1,9 @@
+package com.microsoft.identity.client.robolectric.tests.network;
+
+public class AcquireTokenNetworkB2CTest extends AcquireTokenNetworkTest {
+
+    public AcquireTokenNetworkB2CTest() {
+        this.mAuthorityType = B2C_AUTHORITY_TYPE_STRING;
+        this.mScopes = B2C_SCOPES;
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTest.java
@@ -33,55 +33,45 @@ import com.microsoft.identity.client.robolectric.shadows.ShadowStorageHelper;
 import com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.client.robolectric.utils.ErrorCodes;
 import com.microsoft.identity.client.robolectric.utils.RoboTestUtils;
+import com.microsoft.identity.common.internal.logging.Logger;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Arrays;
-import java.util.Collection;
 
 import static com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHelper.failureSilentCallback;
 import static com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHelper.getAccount;
 import static com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHelper.successfulInteractiveCallback;
 import static com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHelper.successfulSilentCallback;
 
-@RunWith(ParameterizedRobolectricTestRunner.class)
+@RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowStorageHelper.class, ShadowAuthority.class, ShadowMsalUtils.class})
 /**
  * This class contains PublicClientApplication acquire token tests that hit the network and
  * try to acquire a token. These test are parameterized and cannot be run individually,
  * the entire class must be run together for them to work.
  */
-public final class AcquireTokenNetworkTest {
+public class AcquireTokenNetworkTest {
 
-    private static final String[] AAD_SCOPES = {"user.read"};
-    private static final String[] B2C_SCOPES = {"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read"};
+    static final String TAG = AcquireTokenNetworkTest.class.getSimpleName();
 
-    private static final String AAD_AUTHORITY_TYPE_STRING = "AAD";
-    private static final String B2C_AUTHORITY_TYPE_STRING = "B2C";
+    static final String[] AAD_SCOPES = {"user.read"};
+    static final String[] B2C_SCOPES = {"https://msidlabb2c.onmicrosoft.com/msidlabb2capi/read"};
 
-    private String mAuthorityType;
-    private String[] mScopes;
+    static final String AAD_AUTHORITY_TYPE_STRING = "AAD";
+    static final String B2C_AUTHORITY_TYPE_STRING = "B2C";
 
-    public AcquireTokenNetworkTest(String authorityType, String[] scopes) {
-        mAuthorityType = authorityType;
-        mScopes = scopes;
-    }
-
-    @ParameterizedRobolectricTestRunner.Parameters(name = "Authority Type = {0}")
-    public static Collection data() {
-        return Arrays.asList(new Object[][]{
-                {AAD_AUTHORITY_TYPE_STRING, AAD_SCOPES},
-                {B2C_AUTHORITY_TYPE_STRING, B2C_SCOPES}
-        });
-    }
+    String mAuthorityType = B2C_AUTHORITY_TYPE_STRING; //default
+    String[] mScopes = B2C_SCOPES; //default
 
     @Before
     public void setup() {
+        Logger.info(TAG, "Authority type = " + mAuthorityType);
         AcquireTokenTestHelper.setAccount(null);
     }
 
@@ -224,7 +214,7 @@ public final class AcquireTokenNetworkTest {
     }
 
     @Test
-    public void testAcquireTokenSilentSuccessEmptyCache() {
+    public void testAcquireTokenSilentSuccessCacheWithNoAccessToken() {
         new AcquireTokenNetworkBaseTest() {
 
             @Override

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTest.java
@@ -53,8 +53,11 @@ import static com.microsoft.identity.client.robolectric.utils.AcquireTokenTestHe
 @Config(shadows = {ShadowStorageHelper.class, ShadowAuthority.class, ShadowMsalUtils.class})
 /**
  * This class contains PublicClientApplication acquire token tests that hit the network and
- * try to acquire a token. These test are parameterized and cannot be run individually,
- * the entire class must be run together for them to work.
+ * try to acquire a token. These tests will operate by being passed an authority and scopes parameters.
+ * These parameters will change based on whether we want run test that use AAD or B2C.
+ * To run all of these test using AAD see {@link AcquireTokenNetworkAADTest}
+ * To run all of these test using B2C see {@link AcquireTokenNetworkB2CTest}
+ * To run all of these test using both AAD & B2C, see {@link AcquireTokenNetworkTestSuite}
  */
 public class AcquireTokenNetworkTest {
 
@@ -66,6 +69,9 @@ public class AcquireTokenNetworkTest {
     static final String AAD_AUTHORITY_TYPE_STRING = "AAD";
     static final String B2C_AUTHORITY_TYPE_STRING = "B2C";
 
+    // The tests need to passed an authority (could be AAD or B2C)
+    // The tests also need scopes
+    // These are the default authorities and scopes and can be changed if needed
     String mAuthorityType = B2C_AUTHORITY_TYPE_STRING; //default
     String[] mScopes = B2C_SCOPES; //default
 

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
@@ -8,5 +8,9 @@ import org.junit.runners.Suite;
         AcquireTokenNetworkAADTest.class,
         AcquireTokenNetworkB2CTest.class
 })
+/**
+ * This class runs all tests in the {@link AcquireTokenNetworkTest} class,
+ * using both AAD and B2C
+ */
 public class AcquireTokenNetworkTestSuite {
 }

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
@@ -1,0 +1,12 @@
+package com.microsoft.identity.client.robolectric.tests.network;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+        AcquireTokenNetworkAADTest.class,
+        AcquireTokenNetworkB2CTest.class
+})
+public class AcquireTokenNetworkTestSuite {
+}

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/network/AcquireTokenNetworkTestSuite.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.client.robolectric.tests.network;
 
 import org.junit.runner.RunWith;


### PR DESCRIPTION
In this PR, I've refactored robolectric network tests to allow running as a suite as well as individually.

The acquire token network tests were originally written using the `ParameterizedRobolectricTestRunner` because it allowed us to get rid of duplicated tests as the tests for both AAD and B2C are the same and the only difference lied in the json configuration file (or the authority in that file) passed when creating the PublicClientApplication.

However, parameterized tests cannot be run individually, and this is a problem because it stops us from being able to debug a specific test. We would would have to run all tests in the class even if we wanted to debug / run a specific test.

To solve this problem, I've replaced the parameterized runner with regular `RobolectricTestRunner`, and I've introduced a couple more test classes using java inheritance that still allows us to avoid duplicating tests while still being able to run them individually as well as a suite.