### PR TITLE
Migrate FLW operations to command + Refactoring.

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -42,12 +42,10 @@ import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.IShareSingleSignOnState;
 import com.microsoft.identity.common.internal.cache.ISharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
-import com.microsoft.identity.common.internal.controllers.Command;
 import com.microsoft.identity.common.internal.controllers.CommandCallback;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.controllers.LoadAccountCommand;
 import com.microsoft.identity.common.internal.controllers.RemoveAccountCommand;
-import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.migration.AdalMigrationAdapter;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
@@ -167,10 +165,10 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         }
 
         try {
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
+            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
             final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                     params,
-                    MSALControllerFactory.getAcquireTokenSilentControllers(
+                    MSALControllerFactory.getAllControllers(
                             mPublicClientConfiguration.getAppContext(),
                             params.getAuthority(),
                             mPublicClientConfiguration
@@ -236,10 +234,10 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         );
 
         try {
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
+            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
             final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                     params,
-                    MSALControllerFactory.getAcquireTokenSilentControllers(
+                    MSALControllerFactory.getAllControllers(
                             mPublicClientConfiguration.getAppContext(),
                             params.getAuthority(),
                             mPublicClientConfiguration
@@ -358,7 +356,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             return;
         }
 
-        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
 
         // TODO Clean this up, only the cache should make these records...
         // The broker strips these properties out of this object to hit the cache
@@ -371,7 +369,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         try {
             final RemoveAccountCommand removeAccountCommand = new RemoveAccountCommand(
                     params,
-                    MSALControllerFactory.getAcquireTokenSilentControllers(
+                    MSALControllerFactory.getAllControllers(
                             mPublicClientConfiguration.getAppContext(),
                             params.getAuthority(),
                             mPublicClientConfiguration

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -165,7 +165,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         }
 
         try {
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
             final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                     params,
                     MSALControllerFactory.getAllControllers(
@@ -234,7 +234,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         );
 
         try {
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
             final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                     params,
                     MSALControllerFactory.getAllControllers(
@@ -356,7 +356,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
             return;
         }
 
-        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
 
         // TODO Clean this up, only the cache should make these records...
         // The broker strips these properties out of this object to hit the cache

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -853,7 +853,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                                @NonNull final ApplicationCreatedListener listener) {
 
 
-        final OperationParameters params = OperationParametersAdapter.createOperationParameters(config);
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(config, config.getOAuth2TokenCache());
 
         final BaseController controller;
         try {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -133,9 +133,11 @@ public class PublicClientApplicationConfiguration {
     @SerializedName(CLIENT_CAPABILITIES)
     String mClientCapabilities;
 
-    transient OAuth2TokenCache mOAuth2TokenCache;
+    transient private OAuth2TokenCache mOAuth2TokenCache;
 
-    transient Context mAppContext;
+    transient private Context mAppContext;
+
+    transient private boolean mIsSharedDevice = false;
 
     /**
      * Sets the secret key bytes to use when encrypting/decrypting cache entries.
@@ -286,12 +288,20 @@ public class PublicClientApplicationConfiguration {
         mAppContext = applicationContext;
     }
 
-    OAuth2TokenCache getOAuth2TokenCache() {
+    public OAuth2TokenCache getOAuth2TokenCache() {
         return mOAuth2TokenCache;
     }
 
     void setOAuth2TokenCache(OAuth2TokenCache tokenCache) {
         mOAuth2TokenCache = tokenCache;
+    }
+
+    public boolean getIsSharedDevice() {
+        return mIsSharedDevice;
+    }
+
+    void setIsSharedDevice(boolean isSharedDevice) {
+        mIsSharedDevice = isSharedDevice;
     }
 
     public Authority getDefaultAuthority() {
@@ -361,6 +371,7 @@ public class PublicClientApplicationConfiguration {
         // Multiple is the default mode.
         this.mAccountMode = config.mAccountMode != AccountMode.MULTIPLE ? config.mAccountMode : this.mAccountMode;
         this.mClientCapabilities = config.mClientCapabilities == null ? this.mClientCapabilities : config.mClientCapabilities;
+        this.mIsSharedDevice = config.mIsSharedDevice == true ? this.mIsSharedDevice : config.mIsSharedDevice;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -288,7 +288,7 @@ public class PublicClientApplicationConfiguration {
         mAppContext = applicationContext;
     }
 
-    public OAuth2TokenCache getOAuth2TokenCache() {
+    OAuth2TokenCache getOAuth2TokenCache() {
         return mOAuth2TokenCache;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.CommandCallback;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
+import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.internal.controllers.GetCurrentAccountCommand;
 import com.microsoft.identity.common.internal.controllers.RemoveCurrentAccountCommand;
@@ -275,6 +276,11 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         }
 
         final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
+        final AccountRecord requestAccountRecord = new AccountRecord();
+        requestAccountRecord.setEnvironment(persistedCurrentAccount.getEnvironment());
+        requestAccountRecord.setHomeAccountId(persistedCurrentAccount.getHomeAccountId());
+        params.setAccount(requestAccountRecord);
+
         final BaseController controller;
         try {
             controller = MSALControllerFactory.getDefaultController(

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -88,7 +88,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public void getCurrentAccountAsync(@NonNull final CurrentAccountCallback callback) {
-        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
         final BaseController controller;
         try {
             controller = MSALControllerFactory.getDefaultController(
@@ -259,7 +259,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
             return;
         }
 
-        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
         final BaseController controller;
         try {
             controller = MSALControllerFactory.getDefaultController(

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -32,7 +32,6 @@ import androidx.annotation.WorkerThread;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.internal.AsyncResult;
-import com.microsoft.identity.client.internal.controllers.BrokerMsalController;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
 import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
@@ -40,13 +39,12 @@ import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
+import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.CommandCallback;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
-import com.microsoft.identity.common.internal.controllers.LoadAccountCommand;
-import com.microsoft.identity.common.internal.controllers.RemoveAccountCommand;
-import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
-import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.eststelemetry.PublicApiId;
+import com.microsoft.identity.common.internal.controllers.GetCurrentAccountCommand;
+import com.microsoft.identity.common.internal.controllers.RemoveCurrentAccountCommand;
 import com.microsoft.identity.common.internal.request.OperationParameters;
 import com.microsoft.identity.common.internal.result.ILocalAuthenticationResult;
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
@@ -76,11 +74,9 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     protected SingleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config,
                                                    @Nullable final String clientId,
-                                                   @Nullable final String authority,
-                                                   @NonNull final Boolean isSharedDevice) {
+                                                   @Nullable final String authority) {
         super(config, clientId, authority);
         initializeSharedPreferenceFileManager(config.getAppContext());
-        mIsSharedDevice = isSharedDevice;
     }
 
     private void initializeSharedPreferenceFileManager(@NonNull final Context context) {
@@ -92,63 +88,43 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public void getCurrentAccountAsync(@NonNull final CurrentAccountCallback callback) {
-        final String methodName = ":getCurrentAccount";
-        final PublicClientApplicationConfiguration configuration = getConfiguration();
-
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+        final BaseController controller;
         try {
-            if (mIsSharedDevice) {
-                getCurrentAccountFromSharedDevice(callback, configuration);
-                return;
-            }
+            controller = MSALControllerFactory.getDefaultController(
+                    mPublicClientConfiguration.getAppContext(),
+                    params.getAuthority(),
+                    mPublicClientConfiguration);
+        } catch (MsalClientException e) {
+            callback.onError(e);
+            return;
+        }
 
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Getting the current account"
-            );
-
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
-            final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
-                    params,
-                    MSALControllerFactory.getAcquireTokenController(
-                            mPublicClientConfiguration.getAppContext(),
-                            params.getAuthority(),
-                            mPublicClientConfiguration
-                    ),
-                    new CommandCallback<List<ICacheRecord>, BaseException>() {
-                        @Override
-                        public void onTaskCompleted(final List<ICacheRecord> result) {
-                            // To simplify the logic, if more than one account is returned, the first account will be picked.
-                            // We do not support switching from MULTIPLE to SINGLE.
-                            // See getAccountFromICacheRecordList() for more details.
-                            checkCurrentAccountNotifyCallback(callback, result);
-                        }
-
-                        @Override
-                        public void onError(final BaseException exception) {
-                            com.microsoft.identity.common.internal.logging.Logger.error(
-                                    TAG + methodName,
-                                    exception.getMessage(),
-                                    exception
-                            );
-
-                            callback.onError(MsalExceptionAdapter.msalExceptionFromBaseException(exception));
-                        }
-
-                        @Override
-                        public void onCancel() {
-                            //Do nothing
-                        }
+        final GetCurrentAccountCommand command = new GetCurrentAccountCommand(
+                params,
+                controller,
+                new CommandCallback<List<ICacheRecord>, BaseException>() {
+                    @Override
+                    public void onTaskCompleted(final List<ICacheRecord> result) {
+                        // To simplify the logic, if more than one account is returned, the first account will be picked.
+                        // We do not support switching from MULTIPLE to SINGLE.
+                        // See getAccountFromICacheRecordList() for more details.
+                        checkCurrentAccountNotifyCallback(callback, result);
                     }
 
+                    @Override
+                    public void onError(final BaseException exception) {
+                        callback.onError(MsalExceptionAdapter.msalExceptionFromBaseException(exception));
+                    }
 
-            );
+                    @Override
+                    public void onCancel() {
+                        //Do nothing
+                    }
+                });
 
-            loadAccountCommand.setPublicApiId(PublicApiId.GET_CURRENT_ACCOUNT_ASYNC);
-            CommandDispatcher.submitSilent(loadAccountCommand);
-
-        } catch (MsalClientException clientException) {
-            callback.onError(clientException);
-        }
+        command.setPublicApiId(PublicApiId.GET_CURRENT_ACCOUNT_ASYNC);
+        CommandDispatcher.submitSilent(command);
     }
 
     @Override
@@ -183,26 +159,6 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         } else {
             throw result.getException();
         }
-    }
-
-    private void getCurrentAccountFromSharedDevice(@NonNull final CurrentAccountCallback callback,
-                                                   @NonNull final PublicClientApplicationConfiguration configuration) {
-
-        //TODO: migrate to Command.
-        new BrokerMsalController().getCurrentAccount(
-                configuration,
-                configuration.getOAuth2TokenCache(),
-                new TaskCompletedCallbackWithError<List<ICacheRecord>, MsalException>() {
-                    @Override
-                    public void onTaskCompleted(List<ICacheRecord> cacheRecords) {
-                        checkCurrentAccountNotifyCallback(callback, cacheRecords);
-                    }
-
-                    @Override
-                    public void onError(MsalException exception) {
-                        callback.onError(exception);
-                    }
-                });
     }
 
     private void checkCurrentAccountNotifyCallback(@NonNull final CurrentAccountCallback callback,
@@ -297,58 +253,48 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public void signOut(@NonNull final SignOutCallback callback) {
-        final PublicClientApplicationConfiguration configuration = getConfiguration();
-
         final MultiTenantAccount persistedCurrentAccount = getPersistedCurrentAccount();
         if (persistedCurrentAccount == null) {
             callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
             return;
         }
 
-        if (mIsSharedDevice) {
-            //TODO: need to integrate with server-side telemetry here once we refactor it to command
-            removeAccountFromSharedDevice(callback, configuration);
+        final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration);
+        final BaseController controller;
+        try {
+            controller = MSALControllerFactory.getDefaultController(
+                    mPublicClientConfiguration.getAppContext(),
+                    params.getAuthority(),
+                    mPublicClientConfiguration);
+        } catch (MsalClientException e) {
+            callback.onError(e);
             return;
         }
 
-        try {
-            final OperationParameters params = OperationParametersAdapter.createOperationParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
-            final AccountRecord requestAccountRecord = new AccountRecord();
-            requestAccountRecord.setEnvironment(persistedCurrentAccount.getEnvironment());
-            requestAccountRecord.setHomeAccountId(persistedCurrentAccount.getHomeAccountId());
-            params.setAccount(requestAccountRecord);
-
-            final RemoveAccountCommand removeAccountCommand = new RemoveAccountCommand(
-                    params,
-                    MSALControllerFactory.getAcquireTokenController(
-                            mPublicClientConfiguration.getAppContext(),
-                            params.getAuthority(),
-                            mPublicClientConfiguration
-                    ),
-                    new CommandCallback<Boolean, BaseException>() {
-                        @Override
-                        public void onError(BaseException error) {
-                            callback.onError(MsalExceptionAdapter.msalExceptionFromBaseException(error));
-                        }
-
-                        @Override
-                        public void onTaskCompleted(Boolean result) {
-                            persistCurrentAccount(null);
-                            callback.onSignOut();
-                        }
-
-                        @Override
-                        public void onCancel() {
-                            //Do nothing
-                        }
+        final RemoveCurrentAccountCommand command = new RemoveCurrentAccountCommand(
+                params,
+                controller,
+                new CommandCallback<Boolean, BaseException>() {
+                    @Override
+                    public void onError(BaseException error) {
+                        callback.onError(MsalExceptionAdapter.msalExceptionFromBaseException(error));
                     }
-            );
 
-            removeAccountCommand.setPublicApiId(PublicApiId.SIGN_OUT);
-            CommandDispatcher.submitSilent(removeAccountCommand);
-        } catch (final MsalClientException clientException) {
-            callback.onError(clientException);
-        }
+                    @Override
+                    public void onTaskCompleted(Boolean result) {
+                        persistCurrentAccount(null);
+                        callback.onSignOut();
+                    }
+
+                    @Override
+                    public void onCancel() {
+                        //Do nothing
+                    }
+                }
+        );
+
+        command.setPublicApiId(PublicApiId.SIGN_OUT);
+        CommandDispatcher.submitSilent(command);
     }
 
     @Override
@@ -377,26 +323,6 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
         } else {
             throw result.getException();
         }
-    }
-
-    private void removeAccountFromSharedDevice(@NonNull final SignOutCallback callback,
-                                               @NonNull final PublicClientApplicationConfiguration configuration) {
-
-        //TODO: migrate to Command.
-        new BrokerMsalController().removeAccountFromSharedDevice(
-                configuration,
-                new TaskCompletedCallbackWithError<Void, MsalException>() {
-                    @Override
-                    public void onTaskCompleted(Void aVoid) {
-                        persistCurrentAccount(null);
-                        callback.onSignOut();
-                    }
-
-                    @Override
-                    public void onError(MsalException exception) {
-                        callback.onError(exception);
-                    }
-                });
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -31,11 +31,13 @@ import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Binder;
 import android.os.Bundle;
+import android.os.RemoteException;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.google.gson.Gson;
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
@@ -57,6 +59,7 @@ import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
 import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
@@ -321,7 +324,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @SuppressWarnings("PMD")
     @SuppressLint("MissingPermission")
     protected List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters)
-            throws OperationCanceledException, IOException, AuthenticatorException, ClientException {
+            throws OperationCanceledException, IOException, AuthenticatorException, BaseException {
         final String methodName = ":getBrokerAccountsFromAccountManager";
         Telemetry.emit(
                 new BrokerStartEvent()
@@ -384,7 +387,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @WorkerThread
     @SuppressWarnings("PMD")
     @SuppressLint("MissingPermission")
-    protected boolean removeBrokerAccount(@NonNull final OperationParameters parameters) {
+    protected void removeBrokerAccount(@NonNull final OperationParameters parameters) {
         final String methodName = ":removeBrokerAccountFromAccountManager";
         Telemetry.emit(
                 new BrokerStartEvent()
@@ -426,8 +429,24 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
                         .putAction(methodName)
                         .isSuccessful(true)
         );
+    }
 
-        return true;
+    @Override
+    boolean getDeviceMode(@NonNull OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+        // TODO
+        throw new MsalClientException("Not yet implemented");
+    }
+
+    @Override
+    List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull OperationParameters parameters) throws InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException, BaseException {
+        // TODO
+        throw new MsalClientException("Not yet implemented");
+    }
+
+    @Override
+    void signOutFromSharedDevice(@NonNull OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+        // TODO
+        throw new MsalClientException("Not yet implemented");
     }
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -434,19 +434,19 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @Override
     boolean getDeviceMode(@NonNull OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
         // TODO
-        throw new MsalClientException("Not yet implemented");
+        throw new MsalClientException("getDeviceMode() is not yet implemented in BrokerAccountManagerStrategy()");
     }
 
     @Override
     List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull OperationParameters parameters) throws InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException, BaseException {
         // TODO
-        throw new MsalClientException("Not yet implemented");
+        throw new MsalClientException("getCurrentAccountInSharedDevice() is not yet implemented in BrokerAccountManagerStrategy()");
     }
 
     @Override
     void signOutFromSharedDevice(@NonNull OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
         // TODO
-        throw new MsalClientException("Not yet implemented");
+        throw new MsalClientException("signOutFromSharedDevice() is not yet implemented in BrokerAccountManagerStrategy()");
     }
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -99,9 +99,11 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
     public interface AuthServiceOperation<T> {
 
         /**
-         * Performs a task in this function with the given IMicrosoftAuthService.
+         * Performs a task in this method with the given IMicrosoftAuthService.
          * If the operation doesn't return expected value, the implementer MUST thrown an exception.
          * Otherwise, this operation is considered succeeded.
+         *
+         * {@link IMicrosoftAuthService}
          */
         T perform(IMicrosoftAuthService service) throws BaseException, RemoteException;
 
@@ -204,7 +206,7 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
 
                     @Override
                     public String getOperationName() {
-                        return ":getBrokerAuthorizationIntentFromAuthService";
+                        return ":acquireTokenSilentWithAuthService";
                     }
                 });
     }
@@ -242,7 +244,6 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
     @WorkerThread
     protected void removeBrokerAccount(@NonNull final OperationParameters parameters)
             throws BaseException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":removeBrokerAccountWithAuthService";
         performAuthServiceOperation(parameters.getAppContext(),
                 new AuthServiceOperation<Void>() {
                     @Override
@@ -257,7 +258,7 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
 
                     @Override
                     public String getOperationName() {
-                        return methodName;
+                        return ":removeBrokerAccountWithAuthService";
                     }
                 });
     }
@@ -314,7 +315,6 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
 
     @WorkerThread
     protected void signOutFromSharedDevice(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":signOutFromSharedDeviceWithAuthService";
         performAuthServiceOperation(parameters.getAppContext(),
                 new AuthServiceOperation<Void>() {
                     @Override
@@ -329,7 +329,7 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
 
                     @Override
                     public String getOperationName() {
-                        return methodName;
+                        return ":signOutFromSharedDeviceWithAuthService";
                     }
                 });
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -610,8 +610,7 @@ public class BrokerMsalController extends BaseController {
                                 null
                         );
 
-                final BrokerResult brokerResult = MsalBrokerResultAdapter.brokerResultFromBundle(result.getResult());
-                if (result == null || brokerResult == null) {
+                if (result == null) {
                     return false;
                 } else {
                     return MsalBrokerResultAdapter.getHelloResultFromBundle(result.getResult());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -33,19 +33,14 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
-import android.os.Handler;
-import android.os.Looper;
 import android.os.RemoteException;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.google.gson.GsonBuilder;
 import com.microsoft.identity.client.IMicrosoftAuthService;
-import com.microsoft.identity.client.PublicClientApplication;
-import com.microsoft.identity.client.PublicClientApplicationConfiguration;
-import com.microsoft.identity.client.exception.MsalClientException;
-import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
@@ -59,14 +54,11 @@ import com.microsoft.identity.common.internal.broker.MicrosoftAuthServiceFuture;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.controllers.BaseController;
-import com.microsoft.identity.common.internal.controllers.ExceptionAdapter;
-import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.ClientInfo;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAccount;
 import com.microsoft.identity.common.internal.providers.oauth2.IDToken;
-import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
 import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
@@ -77,9 +69,6 @@ import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
 import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
-import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
-import com.microsoft.identity.common.internal.ui.browser.Browser;
-import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.internal.util.ICacheRecordGsonAdapter;
 
 import java.io.IOException;
@@ -90,7 +79,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.microsoft.identity.client.internal.controllers.BrokerBaseStrategy.getAcquireTokenResult;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.DEFAULT_BROWSER_PACKAGE_NAME;
 
 /**
  * The implementation of MSAL Controller for Broker
@@ -99,21 +87,11 @@ public class BrokerMsalController extends BaseController {
 
     private static final String TAG = BrokerMsalController.class.getSimpleName();
 
-    private List<BrokerBaseStrategy> mStrategies = new ArrayList<>();
-
     private static final String MANIFEST_PERMISSION_GET_ACCOUNTS = "android.permission.GET_ACCOUNTS";
     private static final String MANIFEST_PERMISSION_MANAGE_ACCOUNTS = "android.permission.MANAGE_ACCOUNTS";
     private static final String MANIFEST_PERMISSION_USE_CREDENTIALS = "android.permission.USE_CREDENTIALS";
 
     private BrokerResultFuture mBrokerResultFuture;
-
-    List<BrokerBaseStrategy> getStrategies() {
-        return mStrategies;
-    }
-
-    void addBrokerStrategy(@NonNull final BrokerBaseStrategy strategy) {
-        mStrategies.add(strategy);
-    }
 
     /**
      * ExecutorService to handle background computation.
@@ -121,8 +99,7 @@ public class BrokerMsalController extends BaseController {
     private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
 
     @Override
-    public AcquireTokenResult acquireToken(AcquireTokenOperationParameters parameters)
-            throws InterruptedException, BaseException {
+    public AcquireTokenResult acquireToken(AcquireTokenOperationParameters parameters) throws Exception {
         Telemetry.emit(
                 new ApiStartEvent()
                         .putProperties(parameters)
@@ -151,7 +128,18 @@ public class BrokerMsalController extends BaseController {
         // For MSA Accounts Broker doesn't save the accounts, instead it just passes the result along,
         // MSAL needs to save this account locally for future token calls.
         saveMsaAccountToCache(resultBundle, (MsalOAuth2TokenCache) parameters.getTokenCache());
-        final AcquireTokenResult result = getAcquireTokenResult(resultBundle);
+
+        final AcquireTokenResult result;
+        try {
+            result = getAcquireTokenResult(resultBundle);
+        } catch (BaseException e) {
+            Telemetry.emit(
+                    new ApiEndEvent()
+                            .putException(e)
+                            .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_INTERACTIVE)
+            );
+            throw e;
+        }
 
         Telemetry.emit(
                 new ApiEndEvent()
@@ -163,39 +151,122 @@ public class BrokerMsalController extends BaseController {
     }
 
     /**
-     * Get the intent for the broker interactive request
-     *
-     * @param parameters
-     * @return
+     * Info of a broker operation to be performed with available strategies.
      */
-    private Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws ClientException {
-        final String methodName = ":getBrokerAuthorizationIntent";
-        helloBroker(parameters);
+    private interface BrokerOperationInfo<T extends OperationParameters, U> {
+        /**
+         * Performs this broker operation in this function with the given IMicrosoftAuthService.
+         */
+        @Nullable
+        U perform(BrokerBaseStrategy strategy, T parameters) throws Exception;
 
-        Intent interactiveRequestIntent = null;
+        /**
+         * Name of the task (for logging purposes).
+         */
+        String getMethodName();
 
-        for (int ii = 0; ii < getStrategies().size(); ii++) {
-            final BrokerBaseStrategy strategy = getStrategies().get(ii);
+        /**
+         * Name of the telemetry API event associated to this strategy task.
+         * If this value returns null, no telemetry event will be emitted.
+         */
+        @Nullable
+        String getTelemetryApiName();
+
+        /**
+         * A function that will be invoked before the success event is emitted.
+         * If the calling operation wants to put any value in the success event, put it here.
+         */
+        void putValueInSuccessEvent(ApiEndEvent event, U result);
+    }
+
+    /**
+     * A generic function that would initialize and iterate through available strategies.
+     * It will return a result immediately if any of the strategy succeeds, or throw an exception if all of the strategies fails.
+     */
+    private <T extends OperationParameters, U> U performStrategies(@NonNull final T parameters,
+                                                                   @NonNull final BrokerOperationInfo<T, U> strategyTask)
+            throws Exception {
+
+        if (strategyTask.getTelemetryApiName() != null) {
+            Telemetry.emit(
+                    new ApiStartEvent()
+                            .putProperties(parameters)
+                            .putApiId(strategyTask.getTelemetryApiName())
+            );
+        }
+
+        final List<BrokerBaseStrategy> strategies = helloBroker(parameters);
+
+        U result = null;
+        for (int ii = 0; ii < strategies.size(); ii++) {
+            final BrokerBaseStrategy strategy = strategies.get(ii);
             com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
+                    TAG + strategyTask.getMethodName(),
                     "Executing with strategy: "
                             + strategy.getClass().getSimpleName()
             );
 
             try {
-                interactiveRequestIntent = strategy.getBrokerAuthorizationIntent(parameters);
-                if (interactiveRequestIntent != null) {
+                result = strategyTask.perform(strategy, parameters);
+                if (result != null) {
                     break;
                 }
             } catch (final Exception exception) {
-                if (ii == (getStrategies().size() - 1)) {
+                if (ii == (strategies.size() - 1)) {
                     //throw the exception for the last trying of strategies.
+                    if (strategyTask.getTelemetryApiName() != null) {
+                        Telemetry.emit(
+                                new ApiEndEvent()
+                                        .putException(exception)
+                                        .putApiId(strategyTask.getTelemetryApiName())
+                        );
+                    }
                     throw exception;
                 }
             }
         }
 
-        return interactiveRequestIntent;
+        if (strategyTask.getTelemetryApiName() != null) {
+            final ApiEndEvent successEvent = new ApiEndEvent()
+                    .putApiId(strategyTask.getTelemetryApiName())
+                    .isApiCallSuccessful(Boolean.TRUE);
+            strategyTask.putValueInSuccessEvent(successEvent, result);
+            Telemetry.emit(successEvent);
+        }
+
+        return result;
+    }
+
+    /**
+     * Get the intent for the broker interactive request
+     *
+     * @param parameters
+     * @return
+     */
+    private Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws Exception {
+        return performStrategies(parameters,
+                new BrokerOperationInfo<AcquireTokenOperationParameters, Intent>() {
+                    @Nullable
+                    @Override
+                    public Intent perform(BrokerBaseStrategy strategy, AcquireTokenOperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+                        return strategy.getBrokerAuthorizationIntent(parameters);
+                    }
+
+                    @Override
+                    public String getMethodName() {
+                        return ":getBrokerAuthorizationIntent";
+                    }
+
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return null;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Intent result) {
+                    }
+                });
     }
 
     /**
@@ -226,48 +297,32 @@ public class BrokerMsalController extends BaseController {
     }
 
     @Override
-    public AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException {
-        final String methodName = ":acquireTokenSilent";
-        helloBroker(parameters);
+    public AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws Exception {
+        return performStrategies(parameters,
+                new BrokerOperationInfo<AcquireTokenSilentOperationParameters, AcquireTokenResult>() {
+                    @Nullable
+                    @Override
+                    public AcquireTokenResult perform(BrokerBaseStrategy strategy, AcquireTokenSilentOperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException {
+                        return strategy.acquireTokenSilent(parameters);
+                    }
 
-        Telemetry.emit(
-                new ApiStartEvent()
-                        .putProperties(parameters)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT)
-        );
+                    @Override
+                    public String getMethodName() {
+                        return ":acquireTokenSilent";
+                    }
 
-        AcquireTokenResult acquireTokenResult = null;
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT;
+                    }
 
-        for (int ii = 0; ii < getStrategies().size(); ii++) {
-            final BrokerBaseStrategy strategy = getStrategies().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Executing with strategy for silent : "
-                            + strategy.getClass().getSimpleName()
-            );
-
-            try {
-                acquireTokenResult = strategy.acquireTokenSilent(parameters);
-                if (acquireTokenResult != null) {
-                    break;
-                }
-            } catch (final Exception exception) {
-                if (ii == (getStrategies().size() - 1)) {
-                    //throw the exception for the last trying of strategies.
-                    throw exception;
-                }
-            }
-        }
-
-        Telemetry.emit(
-                new ApiEndEvent()
-                        .putResult(acquireTokenResult)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT)
-        );
-
-        return acquireTokenResult;
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, AcquireTokenResult result) {
+                        event.putResult(result);
+                    }
+                });
     }
-
 
     /**
      * Returns list of accounts that has previously been used to acquire token with broker through the calling app.
@@ -277,204 +332,171 @@ public class BrokerMsalController extends BaseController {
      * this needs to be called on background thread.
      */
     @Override
-    public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters)
-            throws ClientException, InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException {
-        final String methodName = ":getBrokerAccounts";
-        Telemetry.emit(
-                new ApiStartEvent()
-                        .putProperties(parameters)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS)
-        );
+    public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters) throws Exception {
+        return performStrategies(parameters,
+                new BrokerOperationInfo<OperationParameters, List<ICacheRecord>>() {
+                    @Nullable
+                    @Override
+                    public List<ICacheRecord> perform(BrokerBaseStrategy strategy, OperationParameters parameters) throws RemoteException, InterruptedException, ExecutionException, AuthenticatorException, IOException, OperationCanceledException, BaseException {
+                        return strategy.getBrokerAccounts(parameters);
+                    }
 
-        helloBroker(parameters);
-        List<ICacheRecord> result = null;
+                    @Override
+                    public String getMethodName() {
+                        return ":getBrokerAccounts";
+                    }
 
-        for (int ii = 0; ii < getStrategies().size(); ii++) {
-            final BrokerBaseStrategy strategy = getStrategies().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Executing with strategy: "
-                            + strategy.getClass().getSimpleName()
-            );
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS;
+                    }
 
-            try {
-                result = strategy.getBrokerAccounts(parameters);
-                if (!result.isEmpty()) {
-                    break;
-                }
-            } catch (final Exception exception) {
-                if (ii == (getStrategies().size() - 1)) {
-                    //throw the exception for the last trying of strategies.
-                    Telemetry.emit(
-                            new ApiEndEvent()
-                                    .putException(exception)
-                                    .putApiId(TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS)
-                    );
-
-                    throw exception;
-                }
-            }
-        }
-
-        Telemetry.emit(
-                new ApiEndEvent()
-                        .put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(result.size()))
-                        .isApiCallSuccessful(Boolean.TRUE)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS)
-        );
-
-        return result;
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, List<ICacheRecord> result) {
+                        event.put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(result.size()));
+                    }
+                });
     }
-
 
     @Override
     @WorkerThread
-    public boolean removeAccount(@NonNull final OperationParameters parameters)
-            throws BaseException, InterruptedException, ExecutionException, RemoteException {
-        final String methodName = ":removeBrokerAccount";
-        Telemetry.emit(
-                new ApiStartEvent()
-                        .putProperties(parameters)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT)
-        );
+    public boolean removeAccount(@NonNull final OperationParameters parameters) throws Exception {
+        performStrategies(parameters,
+                new BrokerOperationInfo<OperationParameters, Void>() {
+                    @Nullable
+                    @Override
+                    public Void perform(BrokerBaseStrategy strategy, OperationParameters parameters) throws InterruptedException, ExecutionException, BaseException, RemoteException {
+                        strategy.removeBrokerAccount(parameters);
+                        return null;
+                    }
 
-        helloBroker(parameters);
-        boolean result = false;
+                    @Override
+                    public String getMethodName() {
+                        return ":removeBrokerAccount";
+                    }
 
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT;
+                    }
 
-        for (int ii = 0; ii < getStrategies().size(); ii++) {
-            final BrokerBaseStrategy strategy = getStrategies().get(ii);
-            com.microsoft.identity.common.internal.logging.Logger.verbose(
-                    TAG + methodName,
-                    "Executing with strategy: "
-                            + strategy.getClass().getSimpleName()
-            );
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Void result) {
+                    }
+                });
 
-            try {
-                result = strategy.removeBrokerAccount(parameters);
-            } catch (final Exception exception) {
-                if (ii == (getStrategies().size() - 1)) {
-                    //throw the exception for the last trying of strategies.
-                    Telemetry.emit(
-                            new ApiEndEvent()
-                                    .putException(exception)
-                                    .putApiId(TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT)
-                    );
-
-                    throw exception;
-                }
-            }
-        }
-
-        Telemetry.emit(
-                new ApiEndEvent()
-                        .isApiCallSuccessful(Boolean.TRUE)
-                        .putApiId(TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT)
-        );
-
-        return result;
+        return true;
     }
 
-    /**
-     * Get device mode from Broker.
-     */
-    public void getBrokerDeviceMode(final PublicClientApplicationConfiguration configuration,
-                                    final PublicClientApplication.BrokerDeviceModeCallback callback) {
-        final String methodName = ":getBrokerDeviceMode";
+    @Override
+    @WorkerThread
+    public boolean getDeviceMode(@NonNull final OperationParameters parameters) throws Exception {
+        return performStrategies(parameters,
+                new BrokerOperationInfo<OperationParameters, Boolean>() {
+                    @Nullable
+                    @Override
+                    public Boolean perform(BrokerBaseStrategy strategy, OperationParameters parameters) throws Exception {
+                        return strategy.getDeviceMode(parameters);
+                    }
 
-        try {
-            if (!MSALControllerFactory.brokerEligible(
-                    configuration.getAppContext(),
-                    configuration.getDefaultAuthority(),
-                    configuration)) {
+                    @Override
+                    public String getMethodName() {
+                        return ":getDeviceMode";
+                    }
 
-                final String errorMessage = "This request is not eligible to use the broker. Do not check sharedDevice mode and return false immediately.";
-                com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
-                callback.onGetMode(false);
-                return;
-            }
-        } catch (MsalClientException e) {
-            com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, e.toString(), null);
-            callback.onGetMode(false);
-            return;
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE;
+                    }
+
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Boolean result) {
+                        event.put(TelemetryEventStrings.Key.IS_DEVICE_SHARED, Boolean.toString(result));
+                    }
+                });
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccount(OperationParameters parameters) throws Exception {
+        final String methodName = ":getCurrentAccount";
+
+        if (!parameters.getIsSharedDevice()) {
+            Logger.verbose(TAG + methodName, "Not a shared device, invoke getAccounts() instead of getCurrentAccount()");
+            return getAccounts(parameters);
         }
 
-        Telemetry.emit(
-                new ApiStartEvent()
-                        .putApiId(TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE)
-        );
+        return performStrategies(parameters,
+                new BrokerOperationInfo<OperationParameters, List<ICacheRecord>>() {
+                    @Nullable
+                    @Override
+                    public List<ICacheRecord> perform(BrokerBaseStrategy strategy, OperationParameters parameters) throws Exception {
+                        return strategy.getCurrentAccountInSharedDevice(parameters);
+                    }
 
-        final Handler handler = new Handler(Looper.getMainLooper());
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
 
-        if (!MSALControllerFactory.brokerInstalled(configuration.getAppContext())) {
-            final String errorMessage = "Broker app is not installed on the device. Shared device mode requires the broker.";
-            com.microsoft.identity.common.internal.logging.Logger.verbose(TAG + methodName, errorMessage, null);
-            callback.onGetMode(false);
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.BROKER_GET_CURRENT_ACCOUNT;
+                    }
 
-            Telemetry.emit(
-                    new ApiEndEvent()
-                            .putApiId(TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE)
-                            .put(TelemetryEventStrings.Key.ERROR_DESCRIPTION, errorMessage)
-                            .isApiCallSuccessful(Boolean.FALSE)
-            );
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, List<ICacheRecord> result) {
+                        event.put(TelemetryEventStrings.Key.ACCOUNTS_NUMBER, Integer.toString(result.size()));
+                    }
+                });
+    }
 
-            return;
+    @Override
+    public boolean removeCurrentAccount(OperationParameters parameters) throws Exception {
+        final String methodName = ":removeCurrentAccount";
+
+        if (!parameters.getIsSharedDevice()) {
+            Logger.verbose(TAG + methodName, "Not a shared device, invoke removeAccount() instead of removeCurrentAccount()");
+            return removeAccount(parameters);
         }
 
-        sBackgroundExecutor.submit(new Runnable() {
-            @Override
-            public void run() {
-                IMicrosoftAuthService service;
-                final MicrosoftAuthClient client = new MicrosoftAuthClient(configuration.getAppContext());
-                try {
-                    final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
+        /**
+         * Given an account, perform a global sign-out from this shared device (End my shift capability).
+         * This will invoke Broker and
+         * 1. Remove account from token cache.
+         * 2. Remove account from AccountManager.
+         * 3. Clear WebView cookies.
+         * 4. Sign out from default browser.
+         */
+        performStrategies(parameters,
+                new BrokerOperationInfo<OperationParameters, Void>() {
+                    @Nullable
+                    @Override
+                    public Void perform(BrokerBaseStrategy strategy, OperationParameters parameters) throws InterruptedException, ExecutionException, BaseException, RemoteException {
+                        strategy.signOutFromSharedDevice(parameters);
+                        return null;
+                    }
 
-                    service = authServiceFuture.get();
+                    @Override
+                    public String getMethodName() {
+                        return methodName;
+                    }
 
-                    final boolean mode =
-                            MsalBrokerResultAdapter
-                                    .deviceModeFromBundle(
-                                            service.getDeviceMode()
-                                    );
+                    @Nullable
+                    @Override
+                    public String getTelemetryApiName() {
+                        return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT_FROM_SHARED_DEVICE;
+                    }
 
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            Telemetry.emit(
-                                    new ApiEndEvent()
-                                            .putApiId(TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE)
-                                            .put(TelemetryEventStrings.Key.IS_DEVICE_SHARED, Boolean.toString(mode))
-                                            .isApiCallSuccessful(Boolean.TRUE)
-                            );
+                    @Override
+                    public void putValueInSuccessEvent(ApiEndEvent event, Void result) {
+                    }
+                });
 
-                            callback.onGetMode(mode);
-                        }
-                    });
-                } catch (final ClientException | InterruptedException | ExecutionException | RemoteException e) {
-                    final String errorMessage = "Exception is thrown when trying to get current mode from Broker";
-                    com.microsoft.identity.common.internal.logging.Logger.error(
-                            TAG + methodName,
-                            errorMessage,
-                            e);
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            Telemetry.emit(
-                                    new ApiEndEvent()
-                                            .putApiId(TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE)
-                                            .put(TelemetryEventStrings.Key.ERROR_CODE, MsalClientException.IO_ERROR)
-                                            .put(TelemetryEventStrings.Key.ERROR_DESCRIPTION, errorMessage)
-                                            .isApiCallSuccessful(Boolean.FALSE)
-                            );
-
-                            callback.onError(new MsalClientException(MsalClientException.IO_ERROR, errorMessage, e));
-                        }
-                    });
-                } finally {
-                    client.disconnect();
-                }
-            }
-        });
+        return true;
     }
 
     /**
@@ -530,162 +552,6 @@ public class BrokerMsalController extends BaseController {
             }
         }
 
-    }
-
-    /**
-     * A broker task to be performed. Use in conjunction with performBrokerTask()
-     */
-    public interface BrokerTask<T> {
-
-        /**
-         * Performs a task in this function with the given IMicrosoftAuthService.
-         */
-        T perform(IMicrosoftAuthService service) throws BaseException, RemoteException;
-
-        /**
-         * Name of the task (for logging purposes).
-         */
-        String getOperationName();
-    }
-
-    /**
-     * Perform an operation with Broker's MicrosoftAuthService on a background thread.
-     *
-     * @param appContext app context.
-     * @param callback   a callback function to be invoked to return result/error of the performed task.
-     * @param brokerTask the task to be performed.
-     */
-    private <T> void performBrokerTask(@NonNull final Context appContext,
-                                       @NonNull final TaskCompletedCallbackWithError<T, MsalException> callback,
-                                       @NonNull final BrokerTask<T> brokerTask) {
-
-        final Handler handler = new Handler(Looper.getMainLooper());
-
-        sBackgroundExecutor.submit(new Runnable() {
-            @Override
-            public void run() {
-                IMicrosoftAuthService service;
-                final MicrosoftAuthClient client = new MicrosoftAuthClient(appContext);
-                try {
-                    final MicrosoftAuthServiceFuture authServiceFuture = client.connect();
-                    service = authServiceFuture.get();
-                    final T result = brokerTask.perform(service);
-
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            callback.onTaskCompleted(result);
-                        }
-                    });
-                } catch (final BaseException | InterruptedException | ExecutionException | RemoteException e) {
-                    com.microsoft.identity.common.internal.logging.Logger.error(
-                            TAG + brokerTask.getOperationName(),
-                            "Exception is thrown when trying to perform a broker operation:"
-                                    + e.getMessage(),
-                            e);
-                    handler.post(new Runnable() {
-                        @Override
-                        public void run() {
-                            BaseException baseException = ExceptionAdapter.baseExceptionFromException(e);
-                            callback.onError(MsalExceptionAdapter.msalExceptionFromBaseException(baseException));
-                        }
-                    });
-                } finally {
-                    client.disconnect();
-                }
-            }
-        });
-    }
-
-    /**
-     * Get the currently signed-in account, if there's any.
-     * This only works when getBrokerAccountMode() is BROKER_ACCOUNT_MODE_SINGLE_ACCOUNT.
-     */
-    public void getCurrentAccount(@NonNull final PublicClientApplicationConfiguration configuration,
-                                  @NonNull final OAuth2TokenCache cache,
-                                  @NonNull final TaskCompletedCallbackWithError<List<ICacheRecord>, MsalException> callback) {
-        final String methodName = ":getCurrentAccount";
-
-        performBrokerTask(
-                configuration.getAppContext(),
-                callback,
-                new BrokerTask<List<ICacheRecord>>() {
-                    @Override
-                    public List<ICacheRecord> perform(IMicrosoftAuthService service) throws ClientException, RemoteException {
-                        return MsalBrokerResultAdapter
-                                .accountsFromBundle(
-                                        service.getCurrentAccount(
-                                                BrokerAuthServiceStrategy.getRequestBundleForGetAccounts(
-                                                        OperationParametersAdapter.createOperationParameters(configuration, cache)
-                                                )
-                                        )
-                                );
-                    }
-
-                    @Override
-                    public String getOperationName() {
-                        return methodName;
-                    }
-                });
-    }
-
-    /**
-     * Given an account, perform a global sign-out from this shared device (End my shift capability).
-     * This will invoke Broker and
-     * 1. Remove account from token cache.
-     * 2. Remove account from AccountManager.
-     * 3. Clear WebView cookies.
-     * 4. Sign out from default browser.
-     */
-    public void removeAccountFromSharedDevice(@NonNull final PublicClientApplicationConfiguration configuration,
-                                              @NonNull final TaskCompletedCallbackWithError<Void, MsalException> callback) {
-        final String methodName = ":removeAccountFromSharedDevice";
-
-        performBrokerTask(
-                configuration.getAppContext(),
-                callback,
-                new BrokerTask<Void>() {
-                    @Override
-                    public Void perform(IMicrosoftAuthService service) throws BaseException, RemoteException {
-                        final Bundle resultBundle = service.removeAccountFromSharedDevice(
-                                getRequestBundleForRemoveAccountFromSharedDevice(configuration)
-                        );
-
-                        if (resultBundle == null) {
-                            return null;
-                        } else {
-                            final BrokerResult brokerResult = MsalBrokerResultAdapter.brokerResultFromBundle(resultBundle);
-                            com.microsoft.identity.common.internal.logging.Logger.error(
-                                    TAG,
-                                    "Failed to perform global sign-out."
-                                            + brokerResult.getErrorMessage(),
-                                    null);
-
-                            throw new MsalClientException(
-                                    MsalClientException.UNKNOWN_ERROR,
-                                    brokerResult.getErrorMessage());
-                        }
-                    }
-
-                    @Override
-                    public String getOperationName() {
-                        return methodName;
-                    }
-                });
-    }
-
-    private Bundle getRequestBundleForRemoveAccountFromSharedDevice(PublicClientApplicationConfiguration configuration) {
-        final Bundle requestBundle = new Bundle();
-
-        try {
-            Browser browser = BrowserSelector.select(configuration.getAppContext(), configuration.getBrowserSafeList());
-            requestBundle.putString(DEFAULT_BROWSER_PACKAGE_NAME, browser.getPackageName());
-        } catch (ClientException e) {
-            // Best effort. If none is passed to broker, then it will let the OS decide.
-            Logger.error(TAG, e.getErrorCode(), e);
-        }
-
-        return requestBundle;
     }
 
     @WorkerThread
@@ -833,30 +699,31 @@ public class BrokerMsalController extends BaseController {
         return isGranted;
     }
 
-    private void helloBroker(@NonNull final OperationParameters parameters)
+    // The order matters. We should always try the most reliable option first.
+    private List<BrokerBaseStrategy> helloBroker(@NonNull final OperationParameters parameters)
             throws ClientException {
         final String methodName = ":helloBroker";
-        if (!getStrategies().isEmpty()) {
-            mStrategies = new ArrayList<>();
+        final List<BrokerBaseStrategy> strategies = new ArrayList<>();
+
+        //check if account manager available
+        if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
+            Logger.verbose(TAG + methodName, "Add the account manager strategy.");
+            strategies.add(new BrokerAccountManagerStrategy());
         }
 
         //check if bound service available
         if (BrokerMsalController.helloWithMicrosoftAuthService(parameters.getAppContext(), parameters)) {
             Logger.verbose(TAG + methodName, "Add the broker AuthService strategy.");
-            this.addBrokerStrategy(new BrokerAuthServiceStrategy());
+            strategies.add(new BrokerAuthServiceStrategy());
         }
 
-        //check if account manager available
-        if (BrokerMsalController.helloWithAccountManager(parameters.getAppContext(), parameters)) {
-            Logger.verbose(TAG + methodName, "Add the account manager strategy.");
-            this.addBrokerStrategy(new BrokerAccountManagerStrategy());
-        }
-
-        if (getStrategies().isEmpty()) {
+        if (strategies.isEmpty()) {
             throw new ClientException(
                     ErrorStrings.UNSUPPORTED_BROKER_VERSION,
                     "The protocol versions between the MSAL client app and broker are not compatible."
             );
         }
+
+        return strategies;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -155,7 +155,7 @@ public class BrokerMsalController extends BaseController {
      */
     private interface BrokerOperationInfo<T extends OperationParameters, U> {
         /**
-         * Performs this broker operation in this function with the given IMicrosoftAuthService.
+         * Performs this broker operation in this method with the given IMicrosoftAuthService.
          */
         @Nullable
         U perform(BrokerBaseStrategy strategy, T parameters) throws Exception;
@@ -173,14 +173,14 @@ public class BrokerMsalController extends BaseController {
         String getTelemetryApiName();
 
         /**
-         * A function that will be invoked before the success event is emitted.
+         * A method that will be invoked before the success event is emitted.
          * If the calling operation wants to put any value in the success event, put it here.
          */
         void putValueInSuccessEvent(ApiEndEvent event, U result);
     }
 
     /**
-     * A generic function that would initialize and iterate through available strategies.
+     * A generic method that would initialize and iterate through available strategies.
      * It will return a result immediately if any of the strategy succeeds, or throw an exception if all of the strategies fails.
      */
     private <T extends OperationParameters, U> U performStrategies(@NonNull final T parameters,

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -183,8 +183,8 @@ public class BrokerMsalController extends BaseController {
      * A generic method that would initialize and iterate through available strategies.
      * It will return a result immediately if any of the strategy succeeds, or throw an exception if all of the strategies fails.
      */
-    private <T extends OperationParameters, U> U performStrategies(@NonNull final T parameters,
-                                                                   @NonNull final BrokerOperationInfo<T, U> strategyTask)
+    private <T extends OperationParameters, U> U invokeBrokerOperation(@NonNull final T parameters,
+                                                                       @NonNull final BrokerOperationInfo<T, U> strategyTask)
             throws Exception {
 
         if (strategyTask.getTelemetryApiName() != null) {
@@ -244,7 +244,7 @@ public class BrokerMsalController extends BaseController {
      * @return
      */
     private Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws Exception {
-        return performStrategies(parameters,
+        return invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<AcquireTokenOperationParameters, Intent>() {
                     @Nullable
                     @Override
@@ -298,7 +298,7 @@ public class BrokerMsalController extends BaseController {
 
     @Override
     public AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws Exception {
-        return performStrategies(parameters,
+        return invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<AcquireTokenSilentOperationParameters, AcquireTokenResult>() {
                     @Nullable
                     @Override
@@ -333,7 +333,7 @@ public class BrokerMsalController extends BaseController {
      */
     @Override
     public List<ICacheRecord> getAccounts(@NonNull final OperationParameters parameters) throws Exception {
-        return performStrategies(parameters,
+        return invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<OperationParameters, List<ICacheRecord>>() {
                     @Nullable
                     @Override
@@ -362,7 +362,7 @@ public class BrokerMsalController extends BaseController {
     @Override
     @WorkerThread
     public boolean removeAccount(@NonNull final OperationParameters parameters) throws Exception {
-        performStrategies(parameters,
+        invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<OperationParameters, Void>() {
                     @Nullable
                     @Override
@@ -393,7 +393,7 @@ public class BrokerMsalController extends BaseController {
     @Override
     @WorkerThread
     public boolean getDeviceMode(@NonNull final OperationParameters parameters) throws Exception {
-        return performStrategies(parameters,
+        return invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<OperationParameters, Boolean>() {
                     @Nullable
                     @Override
@@ -428,7 +428,7 @@ public class BrokerMsalController extends BaseController {
             return getAccounts(parameters);
         }
 
-        return performStrategies(parameters,
+        return invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<OperationParameters, List<ICacheRecord>>() {
                     @Nullable
                     @Override
@@ -471,7 +471,7 @@ public class BrokerMsalController extends BaseController {
          * 3. Clear WebView cookies.
          * 4. Sign out from default browser.
          */
-        performStrategies(parameters,
+        invokeBrokerOperation(parameters,
                 new BrokerOperationInfo<OperationParameters, Void>() {
                     @Nullable
                     @Override

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -387,4 +387,24 @@ public class LocalMSALController extends BaseController {
 
         return localRemoveAccountSuccess;
     }
+
+    @Override
+    public boolean getDeviceMode(OperationParameters parameters) throws Exception {
+        final String methodName = ":getDeviceMode";
+
+        final String errorMessage = "LocalMSALControler is not eligible to use the broker. Do not check sharedDevice mode and return false immediately.";
+        com.microsoft.identity.common.internal.logging.Logger.error(TAG + methodName, errorMessage, null);
+
+        return false;
+    }
+
+    @Override
+    public List<ICacheRecord> getCurrentAccount(OperationParameters parameters) throws Exception {
+        return getAccounts(parameters);
+    }
+
+    @Override
+    public boolean removeCurrentAccount(OperationParameters parameters) throws Exception {
+        return removeAccount(parameters);
+    }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -63,10 +63,9 @@ public class MSALControllerFactory {
      *
      * @return
      */
-
-    public static BaseController getAcquireTokenController(@NonNull final Context applicationContext,
-                                                           @NonNull final Authority authority,
-                                                           @NonNull final PublicClientApplicationConfiguration applicationConfiguration)
+    public static BaseController getDefaultController(@NonNull final Context applicationContext,
+                                                      @NonNull final Authority authority,
+                                                      @NonNull final PublicClientApplicationConfiguration applicationConfiguration)
             throws MsalClientException {
         if (brokerEligible(applicationContext, authority, applicationConfiguration)) {
             return new BrokerMsalController();
@@ -76,7 +75,7 @@ public class MSALControllerFactory {
     }
 
     /**
-     * Returns one or more controllers to address silent requests
+     * Returns one or more controllers to address a given request.
      * <p>
      * The order of the response matters.  The local controller should be returned first in order to
      * ensure that any local refresh tokens are preferred over the use of the broker
@@ -91,9 +90,9 @@ public class MSALControllerFactory {
      *
      * @return
      */
-    public static List<BaseController> getAcquireTokenSilentControllers(@NonNull final Context applicationContext,
-                                                                        @NonNull final Authority authority,
-                                                                        @NonNull final PublicClientApplicationConfiguration applicationConfiguration)
+    public static List<BaseController> getAllControllers(@NonNull final Context applicationContext,
+                                                         @NonNull final Authority authority,
+                                                         @NonNull final PublicClientApplicationConfiguration applicationConfiguration)
             throws MsalClientException {
         List<BaseController> controllers = new ArrayList<>();
         controllers.add(new LocalMSALController());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -70,10 +70,11 @@ public class OperationParametersAdapter {
     public static final String CLIENT_CAPABILITIES_CLAIM = "XMS_CC";
 
     public static OperationParameters createOperationParameters(
-            @NonNull final PublicClientApplicationConfiguration configuration) {
+            @NonNull final PublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache cache) {
         final OperationParameters parameters = new OperationParameters();
         parameters.setAppContext(configuration.getAppContext());
-        parameters.setTokenCache(configuration.getOAuth2TokenCache());
+        parameters.setTokenCache(cache);
         parameters.setBrowserSafeList(configuration.getBrowserSafeList());
         parameters.setIsSharedDevice(configuration.getIsSharedDevice());
         parameters.setClientId(configuration.getClientId());

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -25,7 +25,6 @@ package com.microsoft.identity.client.internal.controllers;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -71,11 +70,12 @@ public class OperationParametersAdapter {
     public static final String CLIENT_CAPABILITIES_CLAIM = "XMS_CC";
 
     public static OperationParameters createOperationParameters(
-            @NonNull final PublicClientApplicationConfiguration configuration,
-            @NonNull final OAuth2TokenCache cache) {
+            @NonNull final PublicClientApplicationConfiguration configuration) {
         final OperationParameters parameters = new OperationParameters();
         parameters.setAppContext(configuration.getAppContext());
-        parameters.setTokenCache(cache);
+        parameters.setTokenCache(configuration.getOAuth2TokenCache());
+        parameters.setBrowserSafeList(configuration.getBrowserSafeList());
+        parameters.setIsSharedDevice(configuration.getIsSharedDevice());
         parameters.setClientId(configuration.getClientId());
         parameters.setRedirectUri(configuration.getRedirectUri());
         parameters.setAuthority(configuration.getDefaultAuthority());

--- a/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/mocked/AcquireTokenMockBaseTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/robolectric/tests/mocked/AcquireTokenMockBaseTest.java
@@ -48,14 +48,12 @@ public abstract class AcquireTokenMockBaseTest {
 
         final File configFile = new File(AAD_CONFIG_FILE_PATH);
 
+        final IPublicClientApplication[] applications = new IPublicClientApplication[1];
+
         PublicClientApplication.create(context, configFile, new PublicClientApplication.ApplicationCreatedListener() {
             @Override
             public void onCreated(IPublicClientApplication application) {
-                try {
-                    makeAcquireTokenCall(application, testActivity);
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
+                applications[0] = application;
             }
 
             @Override
@@ -63,6 +61,16 @@ public abstract class AcquireTokenMockBaseTest {
                 exception.printStackTrace();
             }
         });
+
+        RoboTestUtils.flushScheduler();
+
+        // TODO: This is a temporary change that is needed as create() is now using command.
+        //       Will need a proper refactor at some point.
+        try {
+            makeAcquireTokenCall(applications[0], testActivity);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
 }


### PR DESCRIPTION
- Migrate FLW operations to command. (Now they're only supporting broker IPC, getAuthToken() work will be in the next card).

- In BrokerAuthServiceStrategy and BrokerMsalController, extract duplicate logic into a generic function + callback. This is to make sure we're handling exception, telemetry, etc consistency across all overloads.