### PR TITLE
Throw IllegalStateException if callback is null for single accout pca

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -175,18 +175,18 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     private static final String ACCESS_NETWORK_STATE_PERMISSION = "android.permission.ACCESS_NETWORK_STATE";
     private static final ExecutorService sBackgroundExecutor = Executors.newCachedThreadPool();
 
-    private static class NONNULL_CONSTANTS {
-        private static final String CONTEXT = "context";
-        private static final String LISTENER = "listener";
-        private static final String CALLBACK = "callback";
-        private static final String CLIENT_ID = "client_id";
-        private static final String AUTHORITY = "authority";
-        private static final String CONFIG_FILE = "config_file";
-        private static final String ACTIVITY = "activity";
-        private static final String SCOPES = "scopes";
-        private static final String ACCOUNT = "account";
+    static class NONNULL_CONSTANTS {
+        static final String CONTEXT = "context";
+        static final String LISTENER = "listener";
+        static final String CALLBACK = "callback";
+        static final String CLIENT_ID = "client_id";
+        static final String AUTHORITY = "authority";
+        static final String CONFIG_FILE = "config_file";
+        static final String ACTIVITY = "activity";
+        static final String SCOPES = "scopes";
+        static final String ACCOUNT = "account";
 
-        private static final String NULL_ERROR_SUFFIX = " cannot be null or empty";
+        static final String NULL_ERROR_SUFFIX = " cannot be null or empty";
     }
 
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -251,6 +251,10 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
             @Override
             public void onTaskCompleted(@NonNull final ILocalAuthenticationResult localAuthenticationResult) {
+                if (authenticationCallback == null) {
+                    throw new IllegalStateException(NONNULL_CONSTANTS.CALLBACK + NONNULL_CONSTANTS.NULL_ERROR_SUFFIX);
+                }
+
                 //Get Local Authentication Result then check if the current account is set or not
                 MultiTenantAccount newAccount = getAccountFromICacheRecordList(localAuthenticationResult.getCacheRecordWithTenantProfileData());
 
@@ -272,7 +276,11 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
             @Override
             public void onError(BaseException exception) {
                 MsalException msalException = MsalExceptionAdapter.msalExceptionFromBaseException(exception);
-                authenticationCallback.onError(msalException);
+                if (authenticationCallback == null) {
+                    throw new IllegalStateException(NONNULL_CONSTANTS.CALLBACK + NONNULL_CONSTANTS.NULL_ERROR_SUFFIX);
+                } else {
+                    authenticationCallback.onError(msalException);
+                }
             }
 
             @Override


### PR DESCRIPTION
This was already done for the base class `PublicClientApplication`, but we also need to do it for `SingleAccountPublicClientApplication` as it overrides the `getCommandCallback` method.