### PR TITLE
Refactor E2E Network tests to use the new Lab Api

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkAADTest.java
@@ -22,7 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests.network;
 
-import com.microsoft.identity.internal.testutils.labutils.TestConfigurationQuery;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import static com.microsoft.identity.client.e2e.utils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
 import static com.microsoft.identity.client.e2e.utils.TestConstants.Scopes.USER_READ_SCOPE;
@@ -33,15 +34,6 @@ import static com.microsoft.identity.client.e2e.utils.TestConstants.Scopes.USER_
 public class AcquireTokenNetworkAADTest extends AcquireTokenNetworkTest {
 
     @Override
-    public TestConfigurationQuery getTestConfigurationQuery() {
-        final TestConfigurationQuery query = new TestConfigurationQuery();
-        query.userType = "Member";
-        query.isFederated = false;
-        query.federationProvider = "ADFSv4";
-        return query;
-    }
-
-    @Override
     public String getConfigFilePath() {
         return MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
     }
@@ -49,5 +41,12 @@ public class AcquireTokenNetworkAADTest extends AcquireTokenNetworkTest {
     @Override
     public String[] getScopes() {
         return USER_READ_SCOPE;
+    }
+
+    @Override
+    public LabUserQuery getLabUserQuery() {
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.CLOUD;
+        return query;
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkB2CTest.java
@@ -22,7 +22,8 @@
 // THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests.network;
 
-import com.microsoft.identity.internal.testutils.labutils.TestConfigurationQuery;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import static com.microsoft.identity.client.e2e.utils.TestConstants.Configurations.B2C_CONFIG_FILE_PATH;
 import static com.microsoft.identity.client.e2e.utils.TestConstants.Scopes.B2C_SCOPE;
@@ -33,9 +34,10 @@ import static com.microsoft.identity.client.e2e.utils.TestConstants.Scopes.B2C_S
 public class AcquireTokenNetworkB2CTest extends AcquireTokenNetworkTest {
 
     @Override
-    public TestConfigurationQuery getTestConfigurationQuery() {
-        final TestConfigurationQuery query = new TestConfigurationQuery();
-        query.b2cProvider = "Local";
+    public LabUserQuery getLabUserQuery() {
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.B2C;
+        query.b2cProvider = LabConstants.B2CProvider.LOCAL;
         return query;
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
@@ -31,8 +31,8 @@ import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.client.e2e.utils.ErrorCodes;
 import com.microsoft.identity.client.e2e.utils.RoboTestUtils;
-import com.microsoft.identity.internal.testutils.labutils.TestConfigurationHelper;
-import com.microsoft.identity.internal.testutils.labutils.TestConfigurationQuery;
+import com.microsoft.identity.internal.testutils.labutils.LabUserHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import org.junit.After;
 import org.junit.Before;
@@ -57,8 +57,8 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     @Before
     public void setup() {
         AcquireTokenTestHelper.setAccount(null);
-        final TestConfigurationQuery query = getTestConfigurationQuery();
-        mUsername = TestConfigurationHelper.getUpnForTest(query);
+        final LabUserQuery query = getLabUserQuery();
+        mUsername = LabUserHelper.getUpnForTest(query);
         super.setup();
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/IAcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/IAcquireTokenNetworkTest.java
@@ -23,11 +23,11 @@
 package com.microsoft.identity.client.e2e.tests.network;
 
 import com.microsoft.identity.client.e2e.tests.IAcquireTokenTest;
-import com.microsoft.identity.internal.testutils.labutils.TestConfigurationQuery;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 public interface IAcquireTokenNetworkTest extends IAcquireTokenTest {
 
-    TestConfigurationQuery getTestConfigurationQuery();
+    LabUserQuery getLabUserQuery();
 
 }
 


### PR DESCRIPTION
This PR depends on this common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/708