### PR TITLE
Add support to silently acquire token for a another tenant for an already authorized user for different tenant

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1540,7 +1540,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                     }
                 }
             }
-            // We should never hit this flow as IAccount should home profile or atleast one tenant profile on it.
+            // We should never hit this flow as IAccount should always have a home profile or at least one tenant profile on it.
             if(accountForRequest ==  null){
                 Logger.warnPII(TAG,
                         "No account record found for IAccount with request tenantId: " + tenantId

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -94,7 +94,7 @@ import static com.microsoft.identity.client.internal.MsalUtils.validateNonNullAr
 import static com.microsoft.identity.client.internal.MsalUtils.validateNonNullArgument;
 import static com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter.msalExceptionFromBaseException;
 import static com.microsoft.identity.client.internal.controllers.OperationParametersAdapter.isAccountHomeTenant;
-import static com.microsoft.identity.client.internal.controllers.OperationParametersAdapter.isHomeTenantEquivalent;
+import static com.microsoft.identity.client.internal.controllers.OperationParametersAdapter.isHomeTenantAlias;
 import static com.microsoft.identity.common.exception.ClientException.TOKEN_CACHE_ITEM_NOT_FOUND;
 import static com.microsoft.identity.common.exception.ClientException.TOKEN_SHARING_DESERIALIZATION_ERROR;
 import static com.microsoft.identity.common.exception.ClientException.TOKEN_SHARING_MSA_PERSISTENCE_ERROR;
@@ -1507,13 +1507,13 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
             final boolean isUuid = isUuid(tenantId);
 
-            if (!isUuid && !isHomeTenantEquivalent(tenantId)) {
+            if (!isUuid && !isHomeTenantAlias(tenantId)) {
                 tenantId = ((AzureActiveDirectoryAuthority) authority).getAudience().getTenantUuidForAlias();
             }
 
             IAccount accountForRequest;
 
-            if (isHomeTenantEquivalent(tenantId)
+            if (isHomeTenantAlias(tenantId)
                     || isAccountHomeTenant(multiTenantAccount.getClaims(), tenantId)) {
                 accountForRequest = multiTenantAccount;
             } else {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/LocalMSALController.java
@@ -31,6 +31,7 @@ import androidx.annotation.WorkerThread;
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import com.microsoft.identity.common.exception.ArgumentException;
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.exception.ServiceException;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.controllers.BaseController;
@@ -212,7 +213,7 @@ public class LocalMSALController extends BaseController {
     @Override
     public AcquireTokenResult acquireTokenSilent(
             @NonNull final AcquireTokenSilentOperationParameters parameters)
-            throws IOException, ClientException, ArgumentException {
+            throws IOException, ClientException, ArgumentException, ServiceException {
         final String methodName = ":acquireTokenSilent";
         Logger.verbose(
                 TAG + methodName,
@@ -253,7 +254,8 @@ public class LocalMSALController extends BaseController {
 
         if (accessTokenIsNull(fullCacheRecord)
                 || refreshTokenIsNull(fullCacheRecord)
-                || parameters.getForceRefresh()) {
+                || parameters.getForceRefresh()
+                || !isRequestAuthorityRealmSameAsATRealm(parameters.getAuthority(), fullCacheRecord.getAccessToken())) {
             if (!refreshTokenIsNull(fullCacheRecord)) {
                 // No AT found, but the RT checks out, so we'll use it
                 Logger.verbose(

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/OperationParametersAdapter.java
@@ -346,7 +346,7 @@ public class OperationParametersAdapter {
         return isAccountHomeTenant;
     }
 
-    public static boolean isHomeTenantEquivalent(@NonNull final String tenantId) {
+    public static boolean isHomeTenantAlias(@NonNull final String tenantId) {
         return tenantId.equalsIgnoreCase(ALL_ACCOUNTS_TENANT_ID)
                 || tenantId.equalsIgnoreCase(ANY_PERSONAL_ACCOUNT_TENANT_ID)
                 || tenantId.equalsIgnoreCase(ORGANIZATIONS);

--- a/msal/src/test/java/com/microsoft/identity/client/RoboTestCacheHelper.java
+++ b/msal/src/test/java/com/microsoft/identity/client/RoboTestCacheHelper.java
@@ -22,7 +22,9 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import com.microsoft.identity.client.e2e.utils.TestConstants;
 import com.microsoft.identity.common.exception.ClientException;
+import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -41,7 +43,10 @@ public class RoboTestCacheHelper {
     public static ICacheRecord saveTokens(TokenResponse tokenResponse, IPublicClientApplication application) throws ClientException {
         final OAuth2TokenCache tokenCache = application.getConfiguration().getOAuth2TokenCache();
         final String clientId = application.getConfiguration().getClientId();
-        final Authority authority = new MockAuthority();
+        final Authority authority = new MockAuthority(new AccountsInOneOrganization(
+                TestConstants.Authorities.AAD_MOCK_AUTHORITY,
+                TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT)
+        );
         final OAuth2Strategy strategy = authority.createOAuth2Strategy();
         final MicrosoftStsAuthorizationRequest mockAuthRequest = Mockito.mock(MicrosoftStsAuthorizationRequest.class);
         Mockito.when(mockAuthRequest.getAuthority()).thenReturn(authority.getAuthorityURL());

--- a/msal/src/test/java/com/microsoft/identity/client/RoboTestCacheHelper.java
+++ b/msal/src/test/java/com/microsoft/identity/client/RoboTestCacheHelper.java
@@ -22,9 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
-import com.microsoft.identity.client.e2e.utils.TestConstants;
 import com.microsoft.identity.common.exception.ClientException;
-import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.providers.microsoft.microsoftsts.MicrosoftStsAuthorizationRequest;
@@ -43,10 +41,7 @@ public class RoboTestCacheHelper {
     public static ICacheRecord saveTokens(TokenResponse tokenResponse, IPublicClientApplication application) throws ClientException {
         final OAuth2TokenCache tokenCache = application.getConfiguration().getOAuth2TokenCache();
         final String clientId = application.getConfiguration().getClientId();
-        final Authority authority = new MockAuthority(new AccountsInOneOrganization(
-                TestConstants.Authorities.AAD_MOCK_AUTHORITY,
-                TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT)
-        );
+        final Authority authority = new MockAuthority();
         final OAuth2Strategy strategy = authority.createOAuth2Strategy();
         final MicrosoftStsAuthorizationRequest mockAuthRequest = Mockito.mock(MicrosoftStsAuthorizationRequest.class);
         Mockito.when(mockAuthRequest.getAuthority()).thenReturn(authority.getAuthorityURL());

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.client.e2e.shadows;
 
 import android.net.Uri;
 
+import com.microsoft.identity.client.e2e.utils.TestConstants;
+import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
 import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
@@ -86,7 +88,10 @@ public class ShadowAuthority {
             // more cases can be added here in the future
             case AAD_MOCK_PATH_SEGMENT:
                 //Return new AAD MOCK Authority
-                authority = new MockAuthority();
+                authority = new MockAuthority(new AccountsInOneOrganization(
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY,
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT)
+                );
                 break;
             case AAD_MOCK_DELAYED_PATH_SEGMENT:
                 authority = new MockDelayedResponseAuthority();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -24,8 +24,6 @@ package com.microsoft.identity.client.e2e.shadows;
 
 import android.net.Uri;
 
-import com.microsoft.identity.client.e2e.utils.TestConstants;
-import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
 import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
@@ -49,7 +47,7 @@ public class ShadowAuthority {
 
     private static final String TAG = ShadowAuthority.class.getSimpleName();
 
-    private static final String AAD_MOCK_PATH_SEGMENT = TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT;
+    private static final String AAD_MOCK_PATH_SEGMENT = "mock";
     private static final String B2C_TEST_PATH_SEGMENT = "tfp";
     private static final String AAD_MOCK_DELAYED_PATH_SEGMENT = "mock_with_delays";
 
@@ -88,11 +86,7 @@ public class ShadowAuthority {
             // more cases can be added here in the future
             case AAD_MOCK_PATH_SEGMENT:
                 //Return new AAD MOCK Authority
-                authority = new MockAuthority(new AccountsInOneOrganization(
-                        TestConstants.Authorities.AAD_MOCK_AUTHORITY,
-                        TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT
-                )
-                );
+                authority = new MockAuthority();
                 break;
             case AAD_MOCK_DELAYED_PATH_SEGMENT:
                 authority = new MockDelayedResponseAuthority();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.client.e2e.shadows;
 
 import android.net.Uri;
 
+import com.microsoft.identity.client.e2e.utils.TestConstants;
+import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
 import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
@@ -47,7 +49,7 @@ public class ShadowAuthority {
 
     private static final String TAG = ShadowAuthority.class.getSimpleName();
 
-    private static final String AAD_MOCK_PATH_SEGMENT = "mock";
+    private static final String AAD_MOCK_PATH_SEGMENT = TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT;
     private static final String B2C_TEST_PATH_SEGMENT = "tfp";
     private static final String AAD_MOCK_DELAYED_PATH_SEGMENT = "mock_with_delays";
 
@@ -86,7 +88,11 @@ public class ShadowAuthority {
             // more cases can be added here in the future
             case AAD_MOCK_PATH_SEGMENT:
                 //Return new AAD MOCK Authority
-                authority = new MockAuthority();
+                authority = new MockAuthority(new AccountsInOneOrganization(
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY,
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT
+                )
+                );
                 break;
             case AAD_MOCK_DELAYED_PATH_SEGMENT:
                 authority = new MockDelayedResponseAuthority();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowMockAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowMockAuthority.java
@@ -1,0 +1,118 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.client.e2e.shadows;
+
+import android.net.Uri;
+
+import com.microsoft.identity.client.e2e.utils.TestConstants;
+import com.microsoft.identity.common.internal.authorities.AccountsInOneOrganization;
+import com.microsoft.identity.common.internal.authorities.Authority;
+import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
+import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
+import com.microsoft.identity.internal.testutils.authorities.B2CTestAuthority;
+import com.microsoft.identity.internal.testutils.authorities.MockAuthority;
+import com.microsoft.identity.internal.testutils.authorities.MockDelayedResponseAuthority;
+
+import org.robolectric.annotation.Implements;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+// A Shadow is Robolectric's way of mocking code
+// A shadow works in a similar way to method overriding
+// Implementing a shadow for a class does not mean that we are shadowing the entire class,
+// instead we are only shadowing the particular method that is implemented in the shadow
+// so in this case, the only thing that we are shadowing is the getAuthorityFromAuthorityUrl method in the Authority class
+@Implements(Authority.class)
+public class ShadowMockAuthority {
+
+    private static final String TAG = ShadowMockAuthority.class.getSimpleName();
+
+    private static final String AAD_MOCK_PATH_SEGMENT = TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT;
+    private static final String B2C_TEST_PATH_SEGMENT = "tfp";
+    private static final String AAD_MOCK_DELAYED_PATH_SEGMENT = "mock_with_delays";
+
+    /**
+     * Returns an Authority based on an authority url.  This method works in similar way to the actual
+     * method in the Authority class, except that over here we create and return test versions of the Authorities
+     *
+     * @param authorityUrl
+     * @return
+     * @throws MalformedURLException
+     */
+    public static Authority getAuthorityFromAuthorityUrl(String authorityUrl) {
+        final String methodName = ":getAuthorityFromAuthorityUrl";
+        URL authUrl;
+
+        try {
+            authUrl = new URL(authorityUrl);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid authority URL");
+        }
+
+        final Uri authorityUri = Uri.parse(authUrl.toString());
+        final List<String> pathSegments = authorityUri.getPathSegments();
+
+        if (pathSegments.size() == 0) {
+            return new UnknownAuthority();
+        }
+
+        Authority authority = null; // Our result object...
+
+        String authorityType = pathSegments.get(0);
+
+        switch (authorityType.toLowerCase()) {
+            // For our test environment, authority could be a AAD, B2C or a mocked authority
+            // For AAD and B2C, we create a test version of that authority that supports ROPC
+            // more cases can be added here in the future
+            case AAD_MOCK_PATH_SEGMENT:
+                //Return new AAD MOCK Authority
+                authority = new MockAuthority(new AccountsInOneOrganization(
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY,
+                        TestConstants.Authorities.AAD_MOCK_AUTHORITY_TENANT
+                )
+                );
+                break;
+            case AAD_MOCK_DELAYED_PATH_SEGMENT:
+                authority = new MockDelayedResponseAuthority();
+                break;
+            case B2C_TEST_PATH_SEGMENT:
+                //Return new B2C TEST Authority
+                authority = new B2CTestAuthority(authorityUrl);
+                break;
+            default:
+                // return new AAD Test Authority
+                authority = new AADTestAuthority();
+                break;
+        }
+
+        return authority;
+    }
+
+    public static boolean isKnownAuthority(Authority authority) {
+        return true;
+    }
+
+
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
@@ -28,8 +28,8 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.RoboTestCacheHelper;
-import com.microsoft.identity.client.e2e.shadows.ShadowAuthority;
 import com.microsoft.identity.client.e2e.shadows.ShadowHttpRequest;
+import com.microsoft.identity.client.e2e.shadows.ShadowMockAuthority;
 import com.microsoft.identity.client.e2e.shadows.ShadowMsalUtils;
 import com.microsoft.identity.client.e2e.shadows.ShadowStorageHelper;
 import com.microsoft.identity.client.e2e.shadows.ShadowStrategyResultServerError;
@@ -56,7 +56,7 @@ import static com.microsoft.identity.client.e2e.utils.TestConstants.Authorities.
 import static org.junit.Assert.fail;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(shadows = {ShadowStorageHelper.class, ShadowAuthority.class, ShadowHttpRequest.class, ShadowMsalUtils.class})
+@Config(shadows = {ShadowStorageHelper.class, ShadowMockAuthority.class, ShadowHttpRequest.class, ShadowMsalUtils.class})
 public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
 
     @Override

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
@@ -39,7 +39,8 @@ public class TestConstants {
     }
 
     public static class Authorities {
-        public static final String AAD_MOCK_AUTHORITY = "https://test.authority/mock";
+        public static final String AAD_MOCK_AUTHORITY_TENANT = "61137f02-8854-4e46-8813-664098dc9f91";
+        public static final String AAD_MOCK_AUTHORITY = "https://login.microsoftonline.com/" + AAD_MOCK_AUTHORITY_TENANT ;
         public static final String AAD_MOCK_DELAYED_RESPONSE_AUTHORITY = "https://test.authority/mock_with_delays";
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
@@ -39,7 +39,8 @@ public class TestConstants {
     }
 
     public static class Authorities {
-        public static final String AAD_MOCK_AUTHORITY = "https://test.authority/mock";
+        public static final String AAD_MOCK_AUTHORITY_TENANT = "61137f02-8854-4e46-8813-664098dc9f91";
+        public static final String AAD_MOCK_AUTHORITY = "https://test.authority/" + AAD_MOCK_AUTHORITY_TENANT ;
         public static final String AAD_MOCK_DELAYED_RESPONSE_AUTHORITY = "https://test.authority/mock_with_delays";
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/TestConstants.java
@@ -39,8 +39,7 @@ public class TestConstants {
     }
 
     public static class Authorities {
-        public static final String AAD_MOCK_AUTHORITY_TENANT = "61137f02-8854-4e46-8813-664098dc9f91";
-        public static final String AAD_MOCK_AUTHORITY = "https://test.authority/" + AAD_MOCK_AUTHORITY_TENANT ;
+        public static final String AAD_MOCK_AUTHORITY = "https://test.authority/mock";
         public static final String AAD_MOCK_DELAYED_RESPONSE_AUTHORITY = "https://test.authority/mock_with_delays";
     }
 


### PR DESCRIPTION
- Also fixed test app to get the correct username to display from `IAccount`