### PR TITLE
Set authority from account in silent call

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -203,7 +203,7 @@ public class MsalWrapper {
                                 AcquireTokenSilentParameters acquireTokenSilentParameters =
                                         builder.withResource(requestOptions.getScopes().toLowerCase().trim())
                                                 .forAccount(account)
-                                                .fromAuthority(mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString())
+                                                .fromAuthority(account.getAuthority())
                                                 .forceRefresh(requestOptions.forceRefresh())
                                                 .withCallback(getAuthenticationCallback(notifyCallback))
                                                 .build();
@@ -256,7 +256,7 @@ public class MsalWrapper {
                                 AcquireTokenSilentParameters parameters = new AcquireTokenSilentParameters.Builder()
                                         .withScopes(Arrays.asList(requestOptions.getScopes().toLowerCase().split(" ")))
                                         .forAccount(account)
-                                        .fromAuthority(mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString())
+                                        .fromAuthority(account.getAuthority())
                                         .forceRefresh(requestOptions.forceRefresh())
                                         .withCallback(getAuthenticationCallback(notifyCallback))
                                         .build();


### PR DESCRIPTION
- Currently we get an exception that authority doesnt match with account's for Sov clouds