### PR TITLE
Add end-to-end tests for guest accounts

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
@@ -22,11 +22,21 @@
 // THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests;
 
+import com.microsoft.identity.client.AcquireTokenParameters;
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
+import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.internal.testutils.TestUtils;
 
 import org.junit.After;
 import org.junit.Before;
+
+import java.util.Arrays;
+
+import static com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper.getAccount;
+import static com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper.successfulInteractiveCallback;
+import static com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper.successfulSilentCallback;
+import static com.microsoft.identity.client.e2e.utils.RoboTestUtils.flushScheduler;
 
 public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAbstractTest implements IAcquireTokenTest {
 
@@ -43,5 +53,71 @@ public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAb
         AcquireTokenTestHelper.setAccount(null);
         // remove everything from cache after test ends
         TestUtils.clearCache(SHARED_PREFERENCES_NAME);
+    }
+
+    public void performInteractiveAcquireTokenCall(final String username) {
+        final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withLoginHint(username)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(successfulInteractiveCallback())
+                .build();
+
+
+        mApplication.acquireToken(parameters);
+        flushScheduler();
+    }
+
+    public void performInteractiveAcquireTokenCall(final String username, final String authority) {
+        final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withLoginHint(username)
+                .withScopes(Arrays.asList(mScopes))
+                .fromAuthority(authority)
+                .withCallback(successfulInteractiveCallback())
+                .build();
+
+
+        mApplication.acquireToken(parameters);
+        flushScheduler();
+    }
+
+    public void performSilentAcquireTokenCall(final String[] scopes) {
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .forAccount(getAccount())
+                .fromAuthority(getAuthority())
+                .withScopes(Arrays.asList(scopes))
+                .forceRefresh(false)
+                .withCallback(successfulSilentCallback())
+                .build();
+
+        mApplication.acquireTokenSilentAsync(silentParameters);
+        flushScheduler();
+    }
+
+    public void performSilentAcquireTokenCall(final IAccount account) {
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .forAccount(account)
+                .fromAuthority(account.getAuthority())
+                .withScopes(Arrays.asList(mScopes))
+                .forceRefresh(false)
+                .withCallback(successfulSilentCallback())
+                .build();
+
+        mApplication.acquireTokenSilentAsync(silentParameters);
+        flushScheduler();
+    }
+
+    public void performSilentAcquireTokenCall(final IAccount account, final String authority) {
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .forAccount(account)
+                .fromAuthority(authority)
+                .withScopes(Arrays.asList(mScopes))
+                .forceRefresh(false)
+                .withCallback(successfulSilentCallback())
+                .build();
+
+        mApplication.acquireTokenSilentAsync(silentParameters);
+        flushScheduler();
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
@@ -1,0 +1,131 @@
+package com.microsoft.identity.client.e2e.tests.network;
+
+import com.microsoft.identity.client.MultiTenantAccount;
+import com.microsoft.identity.client.e2e.shadows.ShadowAuthority;
+import com.microsoft.identity.client.e2e.shadows.ShadowMsalUtils;
+import com.microsoft.identity.client.e2e.shadows.ShadowStorageHelper;
+import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
+import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+import com.microsoft.identity.internal.testutils.labutils.LabGuest;
+import com.microsoft.identity.internal.testutils.labutils.LabGuestAccountHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper.getAccount;
+import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
+import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.USER_READ_SCOPE;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {ShadowStorageHelper.class, ShadowAuthority.class, ShadowMsalUtils.class})
+public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTest {
+    @Override
+    public String[] getScopes() {
+        return USER_READ_SCOPE;
+    }
+
+    @Override
+    public String getAuthority() {
+        return AcquireTokenTestHelper.getAccount().getAuthority();
+    }
+
+    @Override
+    public String getConfigFilePath() {
+        return MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
+    }
+
+    @Test // test that we can use mrrt to get a token silently for guest accounts
+    public void testGetTokenSilentlyForEachGuestTenantSuccess() {
+        final String authorityPrefix = "https://login.microsoftonline.com/";
+
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.GUEST;
+        query.guestHomedIn = LabConstants.GuestHomedIn.HOST_AZURE_AD;
+
+        final LabGuest labGuest = LabGuestAccountHelper.loadGuestAccountFromLab(query);
+
+        // sanity check - make sure that lab api provided a guest account that is part of at least
+        // one guest tenant
+        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+
+        // get a token interactively for home tenant
+        performInteractiveAcquireTokenCall(labGuest.getHomeUpn());
+
+        // get token silently for home tenant
+        performSilentAcquireTokenCall(getAccount(), authorityPrefix + labGuest.getHomeTenantId());
+
+        Assert.assertTrue(labGuest.getGuestLabTenants() != null && labGuest.getGuestLabTenants().size() > 0);
+
+        // get a token silently for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            // just making sure that it is indeed guest tenant by comparing against home tenant
+            Assert.assertNotSame(labGuest.getHomeTenantId(), guestLabTenant.getTenantId());
+            // create authority from guest tenant id and use to obtain a token silently for guest tenant
+            performSilentAcquireTokenCall(getAccount(), authorityPrefix + guestLabTenant.getTenantId());
+        }
+
+        Assert.assertTrue(getAccount() instanceof MultiTenantAccount);
+
+        final MultiTenantAccount multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should have as many tenant profiles as the amount of guest tenants we requested tokens for
+        Assert.assertSame(labGuest.getGuestLabTenants().size(), multiTenantAccount.getTenantProfiles().size());
+
+        // make sure that we have a tenant profile for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            Assert.assertTrue(multiTenantAccount.getTenantProfiles().containsKey(guestLabTenant.getTenantId()));
+        }
+    }
+
+    @Test
+    public void testGuestSignInDirectlyIntoGuestTenantSuccess() {
+        final String authorityPrefix = "https://login.microsoftonline.com/";
+
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.GUEST;
+        query.guestHomedIn = LabConstants.GuestHomedIn.HOST_AZURE_AD;
+
+        final LabGuest labGuest = LabGuestAccountHelper.loadGuestAccountFromLab(query);
+
+        // sanity check - make sure that lab api provided a guest account that is part of at least
+        // one guest tenant
+        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+
+        // get a token interactively for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            // just making sure that it is indeed guest tenant by comparing against home tenant
+            Assert.assertNotSame(labGuest.getHomeTenantId(), guestLabTenant.getTenantId());
+            // create authority from guest tenant id and use to obtain a token interactively for guest tenant
+            performInteractiveAcquireTokenCall(labGuest.getHomeUpn(), authorityPrefix + guestLabTenant.getTenantId());
+        }
+
+        Assert.assertTrue(getAccount() instanceof MultiTenantAccount);
+
+        MultiTenantAccount multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should not have claims for root account as we didn't acquire a token for it
+        Assert.assertNull(multiTenantAccount.getClaims());
+
+        // we should have as many tenant profiles as the amount of guest tenants we requested tokens for
+        Assert.assertSame(labGuest.getGuestLabTenants().size(), multiTenantAccount.getTenantProfiles().size());
+
+        // make sure that we have a tenant profile for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            Assert.assertTrue(multiTenantAccount.getTenantProfiles().containsKey(guestLabTenant.getTenantId()));
+        }
+
+        // now get a token silently for home tenant
+        performSilentAcquireTokenCall(multiTenantAccount, authorityPrefix + labGuest.getHomeTenantId());
+
+        multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should now have claims for root account as we just acquired a token for it
+        Assert.assertNotNull(multiTenantAccount.getClaims());
+
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
@@ -51,15 +51,13 @@ public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTe
 
         // sanity check - make sure that lab api provided a guest account that is part of at least
         // one guest tenant
-        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+        Assert.assertTrue(labGuest.getGuestLabTenants() != null && labGuest.getGuestLabTenants().size() > 0);
 
         // get a token interactively for home tenant
         performInteractiveAcquireTokenCall(labGuest.getHomeUpn());
 
         // get token silently for home tenant
         performSilentAcquireTokenCall(getAccount(), authorityPrefix + labGuest.getHomeTenantId());
-
-        Assert.assertTrue(labGuest.getGuestLabTenants() != null && labGuest.getGuestLabTenants().size() > 0);
 
         // get a token silently for each guest tenant
         for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
@@ -94,7 +92,7 @@ public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTe
 
         // sanity check - make sure that lab api provided a guest account that is part of at least
         // one guest tenant
-        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+        Assert.assertTrue(labGuest.getGuestLabTenants() != null && labGuest.getGuestLabTenants().size() > 0);
 
         // get a token interactively for each guest tenant
         for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
@@ -108,7 +106,7 @@ public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTe
 
         MultiTenantAccount multiTenantAccount = (MultiTenantAccount) getAccount();
 
-        // we should not have claims for root account as we didn't acquire a token for it
+        // we should NOT have claims for root account as we didn't acquire a token for it
         Assert.assertNull(multiTenantAccount.getClaims());
 
         // we should have as many tenant profiles as the amount of guest tenants we requested tokens for

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
@@ -25,14 +25,21 @@ package com.microsoft.identity.client.e2e.tests.network;
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.MultiTenantAccount;
 import com.microsoft.identity.client.e2e.shadows.ShadowAuthority;
 import com.microsoft.identity.client.e2e.shadows.ShadowMsalUtils;
 import com.microsoft.identity.client.e2e.shadows.ShadowStorageHelper;
 import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabConfig;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+import com.microsoft.identity.internal.testutils.labutils.LabGuest;
+import com.microsoft.identity.internal.testutils.labutils.LabGuestAccountHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabUserHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -60,7 +67,7 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
 
     @Override
     public String getAuthority() {
-        return (String) AcquireTokenTestHelper.getAccount().getClaims().get("iss");
+        return (String) AcquireTokenTestHelper.getAccount().getAuthority();
     }
 
     @Override
@@ -81,10 +88,37 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
         flushScheduler();
     }
 
-    public void performSilentAcquireTokenCall(final IAccount account, final String authority) {
+    public void performInteractiveAcquireTokenCall(final String username, final String authority) {
+        final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withLoginHint(username)
+                .withScopes(Arrays.asList(mScopes))
+                .fromAuthority(authority)
+                .withCallback(successfulInteractiveCallback())
+                .build();
+
+
+        mApplication.acquireToken(parameters);
+        flushScheduler();
+    }
+
+    public void performSilentAcquireTokenCall(final String[] scopes) {
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .forAccount(getAccount())
+                .fromAuthority(getAuthority())
+                .withScopes(Arrays.asList(scopes))
+                .forceRefresh(false)
+                .withCallback(successfulSilentCallback())
+                .build();
+
+        mApplication.acquireTokenSilentAsync(silentParameters);
+        flushScheduler();
+    }
+
+    public void performSilentAcquireTokenCall(final IAccount account) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(account)
-                .fromAuthority(authority)
+                .fromAuthority(account.getAuthority())
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
                 .withCallback(successfulSilentCallback())
@@ -94,11 +128,11 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
         flushScheduler();
     }
 
-    public void performSilentAcquireTokenCall(final String[] scopes) {
+    public void performSilentAcquireTokenCall(final IAccount account, final String authority) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-                .forAccount(getAccount())
-                .fromAuthority(getAuthority())
-                .withScopes(Arrays.asList(scopes))
+                .forAccount(account)
+                .fromAuthority(authority)
+                .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
                 .withCallback(successfulSilentCallback())
                 .build();
@@ -126,8 +160,7 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
 
         // perform silent call for each account
         for (final IAccount account : accounts) {
-            final String authority = (String) account.getClaims().get("iss");
-            performSilentAcquireTokenCall(account, authority);
+            performSilentAcquireTokenCall(account);
         }
     }
 
@@ -151,6 +184,96 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
         performSilentAcquireTokenCall(MS_GRAPH_USER_READ_SCOPE);
         performSilentAcquireTokenCall(OFFICE_USER_READ_SCOPE);
         performSilentAcquireTokenCall(AD_GRAPH_USER_READ_SCOPE);
+    }
+
+    @Test // test that we can use mrrt to get a token silently for guest accounts
+    public void testGetTokenSilentlyForEachGuestTenantSuccess() {
+        final String authorityPrefix = "https://login.microsoftonline.com/";
+
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.GUEST;
+        query.guestHomedIn = LabConstants.GuestHomedIn.HOST_AZURE_AD;
+
+        final LabGuest labGuest = LabGuestAccountHelper.loadGuestAccountFromLab(query);
+
+        // sanity check - make sure that lab api provided a guest account that is part of at least
+        // one guest tenant
+        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+
+        // get a token interactively for home tenant
+        performInteractiveAcquireTokenCall(labGuest.getHomeUpn());
+
+        // get token silently for home tenant
+        performSilentAcquireTokenCall(getAccount(), authorityPrefix + labGuest.getHomeTenantId());
+
+        Assert.assertTrue(labGuest.getGuestLabTenants() != null && labGuest.getGuestLabTenants().size() > 0);
+
+        // get a token silently for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            // just making sure that it is indeed guest tenant by comparing against home tenant
+            Assert.assertNotSame(labGuest.getHomeTenantId(), guestLabTenant.getTenantId());
+            // create authority from guest tenant id and use to obtain a token silently for guest tenant
+            performSilentAcquireTokenCall(getAccount(), authorityPrefix + guestLabTenant.getTenantId());
+        }
+
+        Assert.assertTrue(getAccount() instanceof MultiTenantAccount);
+
+        final MultiTenantAccount multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should have as many tenant profiles as the amount of guest tenants we requested tokens for
+        Assert.assertSame(labGuest.getGuestLabTenants().size(), multiTenantAccount.getTenantProfiles().size());
+
+        // make sure that we have a tenant profile for each guest tenant
+        for(LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            Assert.assertTrue(multiTenantAccount.getTenantProfiles().containsKey(guestLabTenant.getTenantId()));
+        }
+    }
+
+    @Test
+    public void testGuestSignInDirectlyIntoGuestTenantSuccess() {
+        final String authorityPrefix = "https://login.microsoftonline.com/";
+
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.GUEST;
+        query.guestHomedIn = LabConstants.GuestHomedIn.HOST_AZURE_AD;
+
+        final LabGuest labGuest = LabGuestAccountHelper.loadGuestAccountFromLab(query);
+
+        // sanity check - make sure that lab api provided a guest account that is part of at least
+        // one guest tenant
+        Assert.assertTrue(labGuest.getGuestLabTenants().size() > 0);
+        
+        // get a token interactively for each guest tenant
+        for (LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            // just making sure that it is indeed guest tenant by comparing against home tenant
+            Assert.assertNotSame(labGuest.getHomeTenantId(), guestLabTenant.getTenantId());
+            // create authority from guest tenant id and use to obtain a token interactively for guest tenant
+            performInteractiveAcquireTokenCall(labGuest.getHomeUpn(), authorityPrefix + guestLabTenant.getTenantId());
+        }
+
+        Assert.assertTrue(getAccount() instanceof MultiTenantAccount);
+
+        MultiTenantAccount multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should not have claims for root account as we didn't acquire a token for it
+        Assert.assertNull(multiTenantAccount.getClaims());
+
+        // we should have as many tenant profiles as the amount of guest tenants we requested tokens for
+        Assert.assertSame(labGuest.getGuestLabTenants().size(), multiTenantAccount.getTenantProfiles().size());
+
+        // make sure that we have a tenant profile for each guest tenant
+        for(LabGuest.GuestLabTenant guestLabTenant : labGuest.getGuestLabTenants()) {
+            Assert.assertTrue(multiTenantAccount.getTenantProfiles().containsKey(guestLabTenant.getTenantId()));
+        }
+
+        // now get a token silently for home tenant
+        performSilentAcquireTokenCall(multiTenantAccount, authorityPrefix + labGuest.getHomeTenantId());
+
+        multiTenantAccount = (MultiTenantAccount) getAccount();
+
+        // we should now have claims for root account as we just acquired a token for it
+        Assert.assertNotNull(multiTenantAccount.getClaims());
+
     }
 
 }


### PR DESCRIPTION
Added end-to-end tests for guest accounts.

This PR depends on [common PR 760](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/760)