### PR TITLE
Return MSAL config error in onError() instead of throwing a runtime exception

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -37,6 +37,7 @@ import android.os.Bundle;
 import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
@@ -217,7 +218,7 @@ public final class PublicClientApplicationTest {
      * Verify correct exception is thrown if callback is not provided.
      */
     @Test(expected = IllegalArgumentException.class)
-    public void testCallBackEmpty() throws PackageManager.NameNotFoundException {
+    public void testCallBackEmpty() throws PackageManager.NameNotFoundException, MsalClientException {
         final Context context = new MockContext(mAppContext);
         mockPackageManagerWithClientId(context, null, CLIENT_ID);
         mockHasCustomTabRedirect(context);
@@ -230,7 +231,7 @@ public final class PublicClientApplicationTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testInternetPermissionMissing() throws PackageManager.NameNotFoundException {
+    public void testInternetPermissionMissing() throws PackageManager.NameNotFoundException, MsalClientException {
         final Context context = new MockContext(mAppContext);
         final PackageManager packageManager = context.getPackageManager();
         mockPackageManagerWithClientId(context, null, CLIENT_ID);
@@ -300,7 +301,7 @@ public final class PublicClientApplicationTest {
     }
 
     @Test
-    public void testSecretKeysAreSet() throws NoSuchAlgorithmException, InvalidKeySpecException {
+    public void testSecretKeysAreSet() throws NoSuchAlgorithmException, InvalidKeySpecException, MsalClientException {
         final Context context = new MockContext(mAppContext);
         mockHasCustomTabRedirect(context);
         mockPackageManagerWithDefaultFlag(context);

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -69,7 +69,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
     protected MultipleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config,
                                                      @Nullable final String clientId,
-                                                     @Nullable final String authority) {
+                                                     @Nullable final String authority) throws MsalClientException {
         super(config, clientId, authority);
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -878,22 +878,26 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                     public void onTaskCompleted(Boolean isSharedDevice) {
                         config.setIsSharedDevice(isSharedDevice);
 
-                        if (config.getAccountMode() == AccountMode.SINGLE || isSharedDevice) {
-                            listener.onCreated(
-                                    new SingleAccountPublicClientApplication(
-                                            config,
-                                            clientId,
-                                            authority
-                                    )
-                            );
-                        } else {
-                            listener.onCreated(
-                                    new MultipleAccountPublicClientApplication(
-                                            config,
-                                            clientId,
-                                            authority
-                                    )
-                            );
+                        try {
+                            if (config.getAccountMode() == AccountMode.SINGLE || isSharedDevice) {
+                                listener.onCreated(
+                                        new SingleAccountPublicClientApplication(
+                                                config,
+                                                clientId,
+                                                authority
+                                        )
+                                );
+                            } else {
+                                listener.onCreated(
+                                        new MultipleAccountPublicClientApplication(
+                                                config,
+                                                clientId,
+                                                authority
+                                        )
+                                );
+                            }
+                        } catch (final MsalClientException e) {
+                            listener.onError(e);
                         }
                     }
 
@@ -988,7 +992,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
     protected PublicClientApplication(@NonNull final PublicClientApplicationConfiguration configFile,
                                       @Nullable final String clientId,
-                                      @Nullable final String authority) {
+                                      @Nullable final String authority) throws MsalClientException {
 
         mPublicClientConfiguration = configFile;
 
@@ -1007,7 +1011,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         initializeApplication();
     }
 
-    private void initializeApplication() {
+    private void initializeApplication() throws MsalClientException {
         final String methodName = ":initializeApplication";
 
         final Context context = mPublicClientConfiguration.getAppContext();

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -35,6 +35,7 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.client.configuration.AccountMode;
 import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.internal.authorities.Authority;
@@ -455,7 +456,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     @SuppressWarnings("PMD")
-    public void checkIntentFilterAddedToAppManifestForBrokerFlow() {
+    public void checkIntentFilterAddedToAppManifestForBrokerFlow() throws MsalClientException {
         if (!mUseBroker) {
             return;
         }
@@ -477,7 +478,8 @@ public class PublicClientApplicationConfiguration {
 
         if (!hasCustomTabRedirectActivity) {
             final Uri redirectUri = Uri.parse(mRedirectUri);
-            throw new IllegalStateException(
+            throw new MsalClientException(
+                    MsalClientException.APP_MANIFEST_VALIDATION_ERROR,
                     "Intent filter for: " +
                             BrowserTabActivity.class.getSimpleName() +
                             " is missing. " +

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -76,7 +76,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     protected SingleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config,
                                                    @Nullable final String clientId,
-                                                   @Nullable final String authority) {
+                                                   @Nullable final String authority) throws MsalClientException {
         super(config, clientId, authority);
         initializeSharedPreferenceFileManager(config.getAppContext());
     }

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -181,11 +181,15 @@ public final class MsalClientException extends MsalException {
     public static final String DUPLICATE_COMMAND = "duplicate_command";
 
     /**
+     * Developer error. Application manifest is not properly configured to support MSAL.
+     */
+    public static final String APP_MANIFEST_VALIDATION_ERROR = "app_manifest_validation_error";
+
+    /**
      * Temporary non-exposed error code to indicate that ADFS authority validation fails. ADFS as authority is not supported
      * for preview.
      */
     static final String ADFS_AUTHORITY_VALIDATION_FAILED = "adfs_authority_validation_failed";
-
     public MsalClientException(final String errorCode) {
         super(errorCode);
     }


### PR DESCRIPTION
Requested in #879 