### PR TITLE
Fix null pointer exception in BrokerMsalStrategies

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -24,6 +24,8 @@ package com.microsoft.identity.client.internal.controllers;
 
 import android.accounts.AccountManager;
 import android.accounts.AccountManagerFuture;
+import android.accounts.AuthenticatorException;
+import android.accounts.OperationCanceledException;
 import android.annotation.SuppressLint;
 import android.content.Intent;
 import android.os.Bundle;
@@ -33,21 +35,21 @@ import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
-import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
 import com.microsoft.identity.common.internal.request.OperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
-import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
 import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.internal.telemetry.events.BrokerEndEvent;
 import com.microsoft.identity.common.internal.telemetry.events.BrokerStartEvent;
 
+import java.io.IOException;
 import java.util.List;
 
 public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
@@ -96,23 +98,26 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
 
             Logger.verbose(TAG + methodName, "Received result from broker");
             result = operationInfo.getResultFromBundle(resultBundle.getResult());
-        } catch (final Exception e) {
-            final BaseException baseException = getBaseExceptionFromException(e);
-
-            Logger.error(
-                    TAG + methodName,
-                    e.getMessage(),
-                    e
-            );
-
+        } catch (final AuthenticatorException | IOException | OperationCanceledException e) {
+            Logger.error(TAG + methodName, e.getMessage(), e);
             Telemetry.emit(
                     new BrokerEndEvent()
                             .putAction(methodName)
                             .isSuccessful(false)
-                            .putErrorCode(baseException.getErrorCode())
-                            .putErrorDescription(baseException.getMessage()));
+                            .putErrorCode(ErrorStrings.IO_ERROR)
+                            .putErrorDescription(e.getMessage()));
 
-            throw baseException;
+            throw new BrokerCommunicationException("Failed to connect to AccountManager");
+        } catch (final BaseException e) {
+            Logger.error(TAG + methodName, e.getMessage(), e);
+            Telemetry.emit(
+                    new BrokerEndEvent()
+                            .putAction(methodName)
+                            .isSuccessful(false)
+                            .putErrorCode(e.getErrorCode())
+                            .putErrorDescription(e.getMessage()));
+
+            throw e;
         }
 
         Telemetry.emit(
@@ -124,29 +129,16 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
         return result;
     }
 
-    private static BaseException getBaseExceptionFromException(final Exception e) {
-        if (e instanceof BaseException) {
-            return (BaseException) e;
-        }
-
-        return new ClientException(
-                ErrorStrings.BROKER_REQUEST_CANCELLED,
-                e.getClass().getSimpleName() + " thrown when talking to account manager.",
-                e
-        );
-    }
-
     @WorkerThread
     @SuppressLint("MissingPermission")
-    boolean hello(@NonNull final OperationParameters parameters)
+    void hello(@NonNull final OperationParameters parameters)
             throws BaseException {
 
         if (!BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())) {
-            //If the account manager permissions are not granted, return false.
-            return false;
+            throw new BrokerCommunicationException("Account manager permissions are not granted");
         }
 
-        return invokeBrokerAccountManagerOperation(parameters, new OperationInfo<OperationParameters, Boolean>() {
+        invokeBrokerAccountManagerOperation(parameters, new OperationInfo<OperationParameters, Void>() {
             @Override
             public Bundle getRequestBundle(OperationParameters parameters) {
                 final Bundle requestBundle = mRequestAdapter.getRequestBundleForHello(parameters);
@@ -161,8 +153,9 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
             }
 
             @Override
-            public Boolean getResultFromBundle(Bundle bundle) throws BaseException {
-                return mResultAdapter.getHelloFromResultBundle(bundle);
+            public Void getResultFromBundle(Bundle bundle) throws BaseException {
+                mResultAdapter.verifyHelloFromResultBundle(bundle);
+                return null;
             }
         });
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
@@ -25,7 +25,6 @@ package com.microsoft.identity.client.internal.controllers;
 import android.accounts.AuthenticatorException;
 import android.accounts.OperationCanceledException;
 import android.content.Intent;
-import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.RemoteException;
@@ -34,55 +33,40 @@ import androidx.annotation.NonNull;
 
 import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.adal.internal.util.JsonExtensions;
 import com.microsoft.identity.common.exception.BaseException;
-import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
-import com.microsoft.identity.common.internal.broker.BrokerResult;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
-import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.request.AcquireTokenOperationParameters;
 import com.microsoft.identity.common.internal.request.AcquireTokenSilentOperationParameters;
 import com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter;
 import com.microsoft.identity.common.internal.request.OperationParameters;
 import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
-import com.microsoft.identity.common.internal.ui.browser.Browser;
-import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
-import com.microsoft.identity.common.internal.util.StringUtil;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_CLIENTID_KEY;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_HOME_ACCOUNT_ID;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ACCOUNT_REDIRECT;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_ACCOUNTS;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.BROKER_DEVICE_MODE;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.DEFAULT_BROWSER_PACKAGE_NAME;
-import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.ENVIRONMENT;
 
 abstract class BrokerBaseStrategy {
     protected final MsalBrokerRequestAdapter mRequestAdapter = new MsalBrokerRequestAdapter();
 
     protected final MsalBrokerResultAdapter mResultAdapter = new MsalBrokerResultAdapter();
 
-    abstract boolean hello(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract void hello(@NonNull final OperationParameters parameters) throws BaseException;
 
-    abstract Intent getBrokerAuthorizationIntent(@NonNull AcquireTokenOperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract Intent getBrokerAuthorizationIntent(@NonNull AcquireTokenOperationParameters parameters) throws BaseException;
 
-    abstract AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract AcquireTokenResult acquireTokenSilent(AcquireTokenSilentOperationParameters parameters) throws BaseException;
 
-    abstract List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters) throws InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException, BaseException;
+    abstract List<ICacheRecord> getBrokerAccounts(@NonNull final OperationParameters parameters) throws BaseException;
 
-    abstract void removeBrokerAccount(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract void removeBrokerAccount(@NonNull final OperationParameters parameters) throws BaseException;
 
-    abstract boolean getDeviceMode(@NonNull final OperationParameters parameters)throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract boolean getDeviceMode(@NonNull final OperationParameters parameters)throws BaseException;
 
-    abstract List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final OperationParameters parameters) throws InterruptedException, ExecutionException, RemoteException, OperationCanceledException, IOException, AuthenticatorException, BaseException;
+    abstract List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final OperationParameters parameters) throws BaseException;
 
-    abstract void signOutFromSharedDevice(@NonNull final OperationParameters parameters) throws BaseException, InterruptedException, ExecutionException, RemoteException;
+    abstract void signOutFromSharedDevice(@NonNull final OperationParameters parameters) throws BaseException;
 
     Handler getPreferredHandler() {
         if (null != Looper.myLooper() && Looper.getMainLooper() != Looper.myLooper()) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -155,7 +155,7 @@ public class BrokerMsalController extends BaseController {
          * If this value returns null, no telemetry event will be emitted.
          */
         @Nullable
-        String getTelemetryApiName();
+        String getTelemetryApiId();
 
         /**
          * A method that will be invoked before the success event is emitted.
@@ -172,11 +172,11 @@ public class BrokerMsalController extends BaseController {
                                                                        @NonNull final BrokerOperationInfo<T, U> strategyTask)
             throws Exception {
 
-        if (strategyTask.getTelemetryApiName() != null) {
+        if (strategyTask.getTelemetryApiId() != null) {
             Telemetry.emit(
                     new ApiStartEvent()
                             .putProperties(parameters)
-                            .putApiId(strategyTask.getTelemetryApiName())
+                            .putApiId(strategyTask.getTelemetryApiId())
             );
         }
 
@@ -200,11 +200,11 @@ public class BrokerMsalController extends BaseController {
             } catch (final BrokerCommunicationException exception){
                 // continue
             } catch (final Exception exception){
-                if (strategyTask.getTelemetryApiName() != null) {
+                if (strategyTask.getTelemetryApiId() != null) {
                     Telemetry.emit(
                             new ApiEndEvent()
                                     .putException(exception)
-                                    .putApiId(strategyTask.getTelemetryApiName())
+                                    .putApiId(strategyTask.getTelemetryApiId())
                     );
                 }
                 throw exception;
@@ -214,19 +214,19 @@ public class BrokerMsalController extends BaseController {
         // This means that we've tried every strategies...
         if (result == null) {
             final BrokerCommunicationException exception = new BrokerCommunicationException("MSAL failed to communicate to Broker.");
-            if (strategyTask.getTelemetryApiName() != null) {
+            if (strategyTask.getTelemetryApiId() != null) {
                 Telemetry.emit(
                         new ApiEndEvent()
                                 .putException(exception)
-                                .putApiId(strategyTask.getTelemetryApiName())
+                                .putApiId(strategyTask.getTelemetryApiId())
                 );
             }
             throw exception;
         }
 
-        if (strategyTask.getTelemetryApiName() != null) {
+        if (strategyTask.getTelemetryApiId() != null) {
             final ApiEndEvent successEvent = new ApiEndEvent()
-                    .putApiId(strategyTask.getTelemetryApiName())
+                    .putApiId(strategyTask.getTelemetryApiId())
                     .isApiCallSuccessful(Boolean.TRUE);
             strategyTask.putValueInSuccessEvent(successEvent, result);
             Telemetry.emit(successEvent);
@@ -266,7 +266,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return null;
                     }
 
@@ -320,7 +320,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.BROKER_ACQUIRE_TOKEN_SILENT;
                     }
 
@@ -355,7 +355,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.BROKER_GET_ACCOUNTS;
                     }
 
@@ -385,7 +385,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT;
                     }
 
@@ -413,7 +413,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.GET_BROKER_DEVICE_MODE;
                     }
 
@@ -448,7 +448,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.BROKER_GET_CURRENT_ACCOUNT;
                     }
 
@@ -494,7 +494,7 @@ public class BrokerMsalController extends BaseController {
 
                     @Nullable
                     @Override
-                    public String getTelemetryApiName() {
+                    public String getTelemetryApiId() {
                         return TelemetryEventStrings.Api.BROKER_REMOVE_ACCOUNT_FROM_SHARED_DEVICE;
                     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -151,7 +151,7 @@ public class BrokerMsalController extends BaseController {
         String getMethodName();
 
         /**
-         * Name of the telemetry API event associated to this strategy task.
+         * ID of the telemetry API event associated to this strategy task.
          * If this value returns null, no telemetry event will be emitted.
          */
         @Nullable


### PR DESCRIPTION
Related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/772

This fixes AzureAD/microsoft-authentication-library-common-for-android#770

Root cause:
- verifyHelloFromResultBundle returned boolean.
- In BrokerMsalController, since it returned boolean, exception is never thrown for that strategy.
- if hello failed twice - for BindService and AccountManager, then we'll end up with result = null.

Fix:
1. verifyHelloFromResultBundle() now throw an exception, if it gets an unexpected result bundle (i.e. Broker doesn't support hello in the calling strategy, which could be BindService or AccountManager).
 
2. Also introduce BrokerCommunicationException, which is thrown when
 - We ran into bind service errors in BrokerAuthServiceStrategy
 - We ran into AccountManager error in BrokerAccountManagerStrategy

3. In BrokerMsalController
 - When we loop through strategies, if BrokerCommunicationException is thrown, we continue, otherwise we throw an exception right away.
 - After the loop is done, if result = null, it means we got BrokerCommunicationException for EVERY strategies we iterated through. In this case, we throw BrokerCommunicationException. 