### PR TITLE
Merge the provided authority/clientid with the config object. Add redirectUri as part of PCA factory overload.

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -76,7 +76,7 @@ public final class PublicClientApplicationTest {
     private Context mAppContext;
     private static final String CLIENT_ID = "client-id";
     private static final String[] SCOPE = {"scope1", "scope2"};
-    public static final String TEST_AUTHORITY = "msauth://com.microsoft.identity.client.sample.local/signature";
+    public static final String TEST_REDIRECT_URI = "msauth://com.microsoft.identity.client.sample.local/signature";
 
     @Before
     public void setUp() {
@@ -225,8 +225,9 @@ public final class PublicClientApplicationTest {
         mockPackageManagerWithDefaultFlag(context);
 
         final PublicClientApplicationConfiguration config = PublicClientApplicationConfigurationFactory.initializeConfiguration(context);
-        config.mRedirectUri = TEST_AUTHORITY;
-        final PublicClientApplication application = new PublicClientApplication(config, CLIENT_ID, null);
+        config.setRedirectUri(TEST_REDIRECT_URI);
+        config.setClientId(CLIENT_ID);
+        final PublicClientApplication application = new PublicClientApplication(config);
         application.acquireToken(getActivity(context), SCOPE, null);
     }
 
@@ -242,10 +243,10 @@ public final class PublicClientApplicationTest {
                 Mockito.refEq(mAppContext.getPackageName()))).thenReturn(PackageManager.PERMISSION_DENIED);
 
         PublicClientApplicationConfiguration config = PublicClientApplicationConfigurationFactory.initializeConfiguration(context);
-        config.mTelemetryConfiguration = null;
-        config.mRedirectUri = TEST_AUTHORITY;
+        config.setRedirectUri(TEST_REDIRECT_URI);
+        config.setClientId(CLIENT_ID);
 
-        new PublicClientApplication(config, CLIENT_ID, null);
+        new PublicClientApplication(config);
     }
 
     @Test
@@ -307,8 +308,9 @@ public final class PublicClientApplicationTest {
         mockPackageManagerWithDefaultFlag(context);
 
         final PublicClientApplicationConfiguration config = PublicClientApplicationConfigurationFactory.initializeConfiguration(context);
-        config.mRedirectUri = TEST_AUTHORITY;
-        final PublicClientApplication pca = new PublicClientApplication(config, CLIENT_ID, null);
+        config.setRedirectUri(TEST_REDIRECT_URI);
+        config.setClientId(CLIENT_ID);
+        final PublicClientApplication pca = new PublicClientApplication(config);
         final PublicClientApplicationConfiguration appConfig = pca.getConfiguration();
 
         SecretKeyFactory keyFactory = SecretKeyFactory

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
@@ -84,9 +84,9 @@ public class PublicClientConfigurationTest {
     @Test
     public void testDefaultConfigurationLoads() {
         assertNotNull(mDefaultConfig);
-        assertNotNull(mDefaultConfig.mAuthorities);
-        assertNotNull(mDefaultConfig.mAuthorizationAgent);
-        assertNotNull(mDefaultConfig.mHttpConfiguration);
+        assertNotNull(mDefaultConfig.getAuthorities());
+        assertNotNull(mDefaultConfig.getAuthorizationAgent());
+        assertNotNull(mDefaultConfig.getHttpConfiguration());
     }
 
     /**
@@ -94,8 +94,8 @@ public class PublicClientConfigurationTest {
      */
     @Test
     public void testDefaultConfigurationLoadsWithHttpConfig() {
-        assertNotNull(mDefaultConfig.mHttpConfiguration);
-        final HttpConfiguration httpConfiguration = mDefaultConfig.mHttpConfiguration;
+        assertNotNull(mDefaultConfig.getHttpConfiguration());
+        final HttpConfiguration httpConfiguration = mDefaultConfig.getHttpConfiguration();
         assertTrue(httpConfiguration.getConnectTimeout() >= 1);
         assertTrue(httpConfiguration.getReadTimeout() >= 1);
     }
@@ -106,8 +106,8 @@ public class PublicClientConfigurationTest {
     @Test
     public void testMinimumConfigurationLoads() {
         final PublicClientApplicationConfiguration minConfig = loadConfig(R.raw.test_pcaconfig_min);
-        assertNotNull(minConfig.mClientId);
-        assertNotNull(minConfig.mRedirectUri);
+        assertNotNull(minConfig.getClientId());
+        assertNotNull(minConfig.getRedirectUri());
     }
 
     /**
@@ -119,19 +119,19 @@ public class PublicClientConfigurationTest {
      */
     private void testMinimumValidConfigurationMerge(PublicClientApplicationConfiguration minConfig) {
         // Record the values of the default config to verify the merge action
-        final List<Authority> authorities = mDefaultConfig.mAuthorities;
-        final AuthorizationAgent agent = mDefaultConfig.mAuthorizationAgent;
-        final HttpConfiguration httpConfiguration = mDefaultConfig.mHttpConfiguration;
+        final List<Authority> authorities = mDefaultConfig.getAuthorities();
+        final AuthorizationAgent agent = mDefaultConfig.getAuthorizationAgent();
+        final HttpConfiguration httpConfiguration = mDefaultConfig.getHttpConfiguration();
 
         // Merge it
         mDefaultConfig.mergeConfiguration(minConfig);
 
         // Assert that the values have merged successfully
-        assertEquals(authorities, mDefaultConfig.mAuthorities);
-        assertEquals(agent, mDefaultConfig.mAuthorizationAgent);
-        assertEquals(httpConfiguration, mDefaultConfig.mHttpConfiguration);
-        assertEquals(minConfig.mClientId, mDefaultConfig.mClientId);
-        assertEquals(minConfig.mRedirectUri, mDefaultConfig.mRedirectUri);
+        assertEquals(authorities, mDefaultConfig.getAuthorities());
+        assertEquals(agent, mDefaultConfig.getAuthorizationAgent());
+        assertEquals(httpConfiguration, mDefaultConfig.getHttpConfiguration());
+        assertEquals(minConfig.getClientId(), mDefaultConfig.getClientId());
+        assertEquals(minConfig.getRedirectUri(), mDefaultConfig.getRedirectUri());
     }
 
     @Test
@@ -150,13 +150,13 @@ public class PublicClientConfigurationTest {
      */
     private void testB2CAuthorityValidConfiguration(PublicClientApplicationConfiguration b2cConfig) {
         assertNotNull(b2cConfig);
-        assertNotNull(b2cConfig.mClientId);
-        assertNotNull(b2cConfig.mRedirectUri);
-        assertNotNull(b2cConfig.mAuthorities);
-        assertEquals(1, b2cConfig.mAuthorities.size());
+        assertNotNull(b2cConfig.getClientId());
+        assertNotNull(b2cConfig.getRedirectUri());
+        assertNotNull(b2cConfig.getAuthorities());
+        assertEquals(1, b2cConfig.getAuthorities().size());
 
         // Grab the Authority from the config
-        final Authority config = b2cConfig.mAuthorities.get(0);
+        final Authority config = b2cConfig.getAuthorities().get(0);
 
         // Test that it is a B2C Authority.
         assertTrue(config instanceof AzureActiveDirectoryB2CAuthority);
@@ -183,13 +183,13 @@ public class PublicClientConfigurationTest {
     public void testADFSAuthorityValidConfiguration() {
         final PublicClientApplicationConfiguration adfsConfig = loadConfig(R.raw.test_pcaconfig_adfs);
         assertNotNull(adfsConfig);
-        assertNotNull(adfsConfig.mClientId);
-        assertNotNull(adfsConfig.mRedirectUri);
-        assertNotNull(adfsConfig.mAuthorities);
-        assertEquals(1, adfsConfig.mAuthorities.size());
+        assertNotNull(adfsConfig.getClientId());
+        assertNotNull(adfsConfig.getRedirectUri());
+        assertNotNull(adfsConfig.getAuthorities());
+        assertEquals(1, adfsConfig.getAuthorities().size());
 
         // Grab the Authority from the config
-        final Authority config = adfsConfig.mAuthorities.get(0);
+        final Authority config = adfsConfig.getAuthorities().get(0);
 
         // Test that it is a B2C Authority.
         assertTrue(config instanceof ActiveDirectoryFederationServicesAuthority);
@@ -203,8 +203,8 @@ public class PublicClientConfigurationTest {
     public void testAudienceAccountsInOneOrganziation() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_aud_accountsinoneorg);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         assertTrue(authority instanceof AzureActiveDirectoryAuthority);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertTrue(azureActiveDirectoryAuthority.mAudience instanceof AccountsInOneOrganization);
@@ -217,8 +217,8 @@ public class PublicClientConfigurationTest {
     public void testAudienceAnyOrganizationAccount() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_aud_anyorg);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         assertTrue(authority instanceof AzureActiveDirectoryAuthority);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertTrue(azureActiveDirectoryAuthority.mAudience instanceof AnyOrganizationalAccount);
@@ -231,8 +231,8 @@ public class PublicClientConfigurationTest {
     public void testAudienceAllAccounts() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_aud_allaccts);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         assertTrue(authority instanceof AzureActiveDirectoryAuthority);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertTrue(azureActiveDirectoryAuthority.mAudience instanceof AllAccounts);
@@ -245,8 +245,8 @@ public class PublicClientConfigurationTest {
     public void testAudienceAnyPersonalAccount() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_aud_anypersonal);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         assertTrue(authority instanceof AzureActiveDirectoryAuthority);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertTrue(azureActiveDirectoryAuthority.mAudience instanceof AnyPersonalAccount);
@@ -259,8 +259,8 @@ public class PublicClientConfigurationTest {
     public void testSliceParametersSet() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_with_slice);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertNotNull(azureActiveDirectoryAuthority.mSlice.getDC());
         assertNotNull(azureActiveDirectoryAuthority.mSlice.getSlice());
@@ -273,8 +273,8 @@ public class PublicClientConfigurationTest {
     public void testFlightParametersSet() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_with_flight);
         assertNotNull(config);
-        assertEquals(1, config.mAuthorities.size());
-        final Authority authority = config.mAuthorities.get(0);
+        assertEquals(1, config.getAuthorities().size());
+        final Authority authority = config.getAuthorities().get(0);
         final AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
         assertFalse(azureActiveDirectoryAuthority.mFlightParameters.isEmpty());
     }
@@ -296,9 +296,9 @@ public class PublicClientConfigurationTest {
     public void testUnknownAudienceException() {
         final PublicClientApplicationConfiguration configWithInvalidAudience = loadConfig(R.raw.test_pcaconfig_unknown_audience);
         assertNotNull(configWithInvalidAudience);
-        assertFalse(configWithInvalidAudience.mAuthorities.isEmpty());
+        assertFalse(configWithInvalidAudience.getAuthorities().isEmpty());
 
-        final Authority authorityWithInvalidAudience = configWithInvalidAudience.mAuthorities.get(0);
+        final Authority authorityWithInvalidAudience = configWithInvalidAudience.getAuthorities().get(0);
         assertNotNull(authorityWithInvalidAudience);
         assertTrue(authorityWithInvalidAudience instanceof AzureActiveDirectoryAuthority);
         configWithInvalidAudience.validateConfiguration();
@@ -329,8 +329,8 @@ public class PublicClientConfigurationTest {
     public void testVerboseLogLevel() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_verbose);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertEquals(Logger.LogLevel.VERBOSE, config.mLoggerConfiguration.getLogLevel());
+        assertNotNull(config.getLoggerConfiguration());
+        assertEquals(Logger.LogLevel.VERBOSE, config.getLoggerConfiguration().getLogLevel());
     }
 
     /**
@@ -340,8 +340,8 @@ public class PublicClientConfigurationTest {
     public void testInfoLogLevel() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_info);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertEquals(Logger.LogLevel.INFO, config.mLoggerConfiguration.getLogLevel());
+        assertNotNull(config.getLoggerConfiguration());
+        assertEquals(Logger.LogLevel.INFO, config.getLoggerConfiguration().getLogLevel());
     }
 
     /**
@@ -351,8 +351,8 @@ public class PublicClientConfigurationTest {
     public void testWarningLogLevel() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_warning);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertEquals(Logger.LogLevel.WARNING, config.mLoggerConfiguration.getLogLevel());
+        assertNotNull(config.getLoggerConfiguration());
+        assertEquals(Logger.LogLevel.WARNING, config.getLoggerConfiguration().getLogLevel());
     }
 
     /**
@@ -362,8 +362,8 @@ public class PublicClientConfigurationTest {
     public void testErrorLogLevel() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_error);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertEquals(Logger.LogLevel.ERROR, config.mLoggerConfiguration.getLogLevel());
+        assertNotNull(config.getLoggerConfiguration());
+        assertEquals(Logger.LogLevel.ERROR, config.getLoggerConfiguration().getLogLevel());
     }
 
     /**
@@ -373,8 +373,8 @@ public class PublicClientConfigurationTest {
     public void testPiiOn() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_info);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertTrue(config.mLoggerConfiguration.isPiiEnabled());
+        assertNotNull(config.getLoggerConfiguration());
+        assertTrue(config.getLoggerConfiguration().isPiiEnabled());
     }
 
     /**
@@ -384,8 +384,8 @@ public class PublicClientConfigurationTest {
     public void testPiiOff() {
         final PublicClientApplicationConfiguration config = loadConfig(R.raw.test_pcaconfig_log_error);
         assertNotNull(config);
-        assertNotNull(config.mLoggerConfiguration);
-        assertFalse(config.mLoggerConfiguration.isPiiEnabled());
+        assertNotNull(config.getLoggerConfiguration());
+        assertFalse(config.getLoggerConfiguration().isPiiEnabled());
     }
 
     private PublicClientApplicationConfiguration loadConfig(final int resourceId) {

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -67,10 +67,8 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         implements IMultipleAccountPublicClientApplication {
     private static final String TAG = MultipleAccountPublicClientApplication.class.getSimpleName();
 
-    protected MultipleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config,
-                                                     @Nullable final String clientId,
-                                                     @Nullable final String authority) throws MsalClientException {
-        super(config, clientId, authority);
+    protected MultipleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config) throws MsalClientException {
+        super(config);
     }
 
     @Override
@@ -145,8 +143,8 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
             final Map<String, String> redirects = new HashMap<>();
             redirects.put(
-                    mPublicClientConfiguration.mClientId, // Our client id
-                    mPublicClientConfiguration.mRedirectUri // Our redirect uri
+                    mPublicClientConfiguration.getClientId(), // Our client id
+                    mPublicClientConfiguration.getRedirectUri() // Our redirect uri
             );
 
             new TokenMigrationUtility<MicrosoftAccount, MicrosoftRefreshToken>()._import(

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -183,6 +183,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         static final String CALLBACK = "callback";
         static final String CLIENT_ID = "client_id";
         static final String AUTHORITY = "authority";
+        static final String REDIRECT_URI = "redirect_uri";
         static final String CONFIG_FILE = "config_file";
         static final String ACTIVITY = "activity";
         static final String SCOPES = "scopes";
@@ -233,8 +234,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      * @param listener             a callback to be invoked when the object is successfully created.
      *                             Cannot be null.
      * @see PublicClientApplication#create(Context, File, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)
+     * @see PublicClientApplication#create(Context, String, String, String, ApplicationCreatedListener)
      * @see PublicClientApplication#create(Context, int)
      */
     public static void create(@NonNull final Context context,
@@ -247,6 +247,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 initializeConfiguration(context, configFileResourceId),
                 null, // client id
                 null, // authority
+                null,
                 listener
         );
     }
@@ -272,8 +273,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      *                   </p>
      * @param listener   a callback to be invoked when the object is successfully created. Cannot be null.
      * @see PublicClientApplication#create(Context, int, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)
+     * @see PublicClientApplication#create(Context, String, String, String, ApplicationCreatedListener)
      * @see PublicClientApplication#create(Context, int)
      */
     public static void create(@NonNull final Context context,
@@ -285,44 +285,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         create(
                 initializeConfiguration(context, configFile),
                 null, // client id
-                null, // authority
-                listener
-        );
-    }
-
-    /**
-     * {@link PublicClientApplication#create(Context, String, ApplicationCreatedListener)} allows
-     * the client id to be passed instead of providing through the AndroidManifest metadata.
-     * If this constructor is called, the default authority https://login.microsoftonline.com/common
-     * will be used.
-     *
-     * @param context  Application's {@link Context}. The sdk requires the application context to
-     *                 be passed in {@link PublicClientApplication}. Cannot be null.
-     *                 <p>
-     *                 Note: The {@link Context} should be the application context instead of the
-     *                 running activity's context, which could potentially make the sdk hold a
-     *                 strong reference to the activity, thus preventing correct garbage collection
-     *                 and causing bugs.
-     *                 </p>
-     * @param clientId The application's client id. Cannot be null.
-     * @param listener a callback to be invoked when the object is successfully created.
-     *                 Cannot be null.
-     * @see PublicClientApplication#create(Context, int, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, File, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, int)
-     */
-    public static void create(@NonNull final Context context,
-                              @NonNull final String clientId,
-                              @NonNull final ApplicationCreatedListener listener) {
-        validateNonNullArgument(context, NONNULL_CONSTANTS.CONTEXT);
-        validateNonNullArgument(clientId, NONNULL_CONSTANTS.CLIENT_ID);
-        validateNonNullArgument(listener, NONNULL_CONSTANTS.LISTENER);
-
-        create(
-                initializeConfiguration(context),
-                clientId,
-                null, // authority
+                null, // authority,
+                null,
                 listener
         );
     }
@@ -331,37 +295,39 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      * {@link PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)}
      * allows the client id and authority to be passed instead of providing them through metadata.
      *
-     * @param context   Application's {@link Context}. The sdk requires the application context to
-     *                  be passed in
-     *                  {@link PublicClientApplication}. Cannot be null.
-     *                  <p>
-     *                  Note: The {@link Context} should be the application context instead of
-     *                  an running activity's context, which could potentially make the sdk hold a
-     *                  strong reference to the activity, thus preventing correct garbage
-     *                  collection and causing bugs.
-     *                  </p>
-     * @param clientId  The application client id. Cannot be null.
-     * @param authority The default authority to be used for the authority. Cannot be null.
-     * @param listener  a callback to be invoked when the object is successfully created.
-     *                  Cannot be null.
+     * @param context     Application's {@link Context}. The sdk requires the application context to
+     *                    be passed in
+     *                    {@link PublicClientApplication}. Cannot be null.
+     *                    <p>
+     *                    Note: The {@link Context} should be the application context instead of
+     *                    an running activity's context, which could potentially make the sdk hold a
+     *                    strong reference to the activity, thus preventing correct garbage
+     *                    collection and causing bugs.
+     *                    </p>
+     * @param clientId    The application client id. Cannot be null.
+     * @param authority   The default authority to be used for the authority. If this is null, the default authority will be used.
+     * @param redirectUri The redirect URI of the application.
+     * @param listener    a callback to be invoked when the object is successfully created.
+     *                    Cannot be null.
      * @see PublicClientApplication#create(Context, int, ApplicationCreatedListener)
      * @see PublicClientApplication#create(Context, File, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, ApplicationCreatedListener)
      * @see PublicClientApplication#create(Context, int)
      */
     public static void create(@NonNull final Context context,
                               @NonNull final String clientId,
-                              @NonNull final String authority,
+                              @Nullable final String authority,
+                              @NonNull final String redirectUri,
                               @NonNull final ApplicationCreatedListener listener) {
         validateNonNullArgument(context, NONNULL_CONSTANTS.CONTEXT);
         validateNonNullArgument(clientId, NONNULL_CONSTANTS.CLIENT_ID);
-        validateNonNullArgument(authority, NONNULL_CONSTANTS.AUTHORITY);
+        validateNonNullArgument(redirectUri, NONNULL_CONSTANTS.REDIRECT_URI);
         validateNonNullArgument(listener, NONNULL_CONSTANTS.LISTENER);
 
         create(
                 initializeConfiguration(context),
                 clientId,
                 authority,
+                redirectUri,
                 listener
         );
     }
@@ -392,8 +358,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      * @throws IllegalStateException if this function is invoked on the main thread.
      * @see PublicClientApplication#create(Context, int, ApplicationCreatedListener)
      * @see PublicClientApplication#create(Context, File, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, ApplicationCreatedListener)
-     * @see PublicClientApplication#create(Context, String, String, ApplicationCreatedListener)
+     * @see PublicClientApplication#create(Context, String, String, String, ApplicationCreatedListener)
      */
     @WorkerThread
     @NonNull
@@ -768,6 +733,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final ResultFuture<AsyncResult<IPublicClientApplication>> future = new ResultFuture<>();
         create(configuration,
                 null, // client id
+                null,
                 null, // authority
                 new ApplicationCreatedListener() {
                     @Override
@@ -798,7 +764,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     private static IMultipleAccountPublicClientApplication createMultipleAccountPublicClientApplication(
             @NonNull final PublicClientApplicationConfiguration configuration)
             throws InterruptedException, MsalException {
-        if (configuration.mAccountMode != AccountMode.MULTIPLE) {
+        if (configuration.getAccountMode() != AccountMode.MULTIPLE) {
             throw new MsalClientException(
                     MULTIPLE_ACCOUNT_PCA_INIT_FAIL_ACCOUNT_MODE_ERROR_CODE,
                     MULTIPLE_ACCOUNT_PCA_INIT_FAIL_ACCOUNT_MODE_ERROR_MESSAGE
@@ -810,7 +776,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         if (application instanceof IMultipleAccountPublicClientApplication) {
             return (IMultipleAccountPublicClientApplication) application;
         } else {
-            if (configuration.mAccountMode == AccountMode.MULTIPLE && application.isSharedDevice()) {
+            if (configuration.getAccountMode() == AccountMode.MULTIPLE && application.isSharedDevice()) {
                 throw new MsalClientException(
                         MULTIPLE_ACCOUNT_PCA_INIT_FAIL_ON_SHARED_DEVICE_ERROR_CODE,
                         MULTIPLE_ACCOUNT_PCA_INIT_FAIL_ON_SHARED_DEVICE_ERROR_MESSAGE
@@ -833,7 +799,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         if (application instanceof ISingleAccountPublicClientApplication) {
             return (ISingleAccountPublicClientApplication) application;
         } else {
-            if (configuration.mAccountMode != AccountMode.SINGLE) {
+            if (configuration.getAccountMode() != AccountMode.SINGLE) {
                 throw new MsalClientException(
                         SINGLE_ACCOUNT_PCA_INIT_FAIL_ACCOUNT_MODE_ERROR_CODE,
                         SINGLE_ACCOUNT_PCA_INIT_FAIL_ACCOUNT_MODE_ERROR_MESSAGE
@@ -849,8 +815,23 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     private static void create(@NonNull final PublicClientApplicationConfiguration config,
                                @Nullable final String clientId,
                                @Nullable final String authority,
+                               @Nullable final String redirectUri,
                                @NonNull final ApplicationCreatedListener listener) {
+        if (clientId != null) {
+            config.setClientId(clientId);
+        }
 
+        if (authority != null) {
+            config.getAuthorities().clear();
+
+            final Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
+            authorityObject.setDefault(true);
+            config.getAuthorities().add(authorityObject);
+        }
+
+        if (redirectUri != null) {
+            config.setRedirectUri(redirectUri);
+        }
 
         final OperationParameters params = OperationParametersAdapter.createOperationParameters(config, config.getOAuth2TokenCache());
 
@@ -880,21 +861,9 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
                         try {
                             if (config.getAccountMode() == AccountMode.SINGLE || isSharedDevice) {
-                                listener.onCreated(
-                                        new SingleAccountPublicClientApplication(
-                                                config,
-                                                clientId,
-                                                authority
-                                        )
-                                );
+                                listener.onCreated(new SingleAccountPublicClientApplication(config));
                             } else {
-                                listener.onCreated(
-                                        new MultipleAccountPublicClientApplication(
-                                                config,
-                                                clientId,
-                                                authority
-                                        )
-                                );
+                                listener.onCreated(new MultipleAccountPublicClientApplication(config));
                             }
                         } catch (final MsalClientException e) {
                             listener.onError(e);
@@ -915,15 +884,16 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             @NonNull final PublicClientApplicationConfiguration configuration,
             @NonNull final IMultipleAccountApplicationCreatedListener listener) {
         create(configuration,
-                null,
-                null,
+                null, // client id
+                null, // authority
+                null, // redirect uri
                 new ApplicationCreatedListener() {
                     @Override
                     public void onCreated(@NonNull final IPublicClientApplication application) {
                         if (application instanceof IMultipleAccountPublicClientApplication) {
                             listener.onCreated((IMultipleAccountPublicClientApplication) application);
                         } else {
-                            if (application.getConfiguration().mAccountMode == AccountMode.MULTIPLE
+                            if (application.getConfiguration().getAccountMode() == AccountMode.MULTIPLE
                                     && application.isSharedDevice()) {
                                 listener.onError(
                                         new MsalClientException(
@@ -957,13 +927,14 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 configuration,
                 null, // client id
                 null, // authority
+                null, // redirect uri
                 new ApplicationCreatedListener() {
                     @Override
                     public void onCreated(final IPublicClientApplication application) {
                         if (application instanceof ISingleAccountPublicClientApplication) {
                             listener.onCreated((ISingleAccountPublicClientApplication) application);
                         } else {
-                            if (application.getConfiguration().mAccountMode != AccountMode.SINGLE) {
+                            if (application.getConfiguration().getAccountMode() != AccountMode.SINGLE) {
                                 listener.onError(
                                         new MsalClientException(
                                                 SINGLE_ACCOUNT_PCA_INIT_FAIL_ACCOUNT_MODE_ERROR_CODE,
@@ -990,24 +961,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     }
     //endregion
 
-    protected PublicClientApplication(@NonNull final PublicClientApplicationConfiguration configFile,
-                                      @Nullable final String clientId,
-                                      @Nullable final String authority) throws MsalClientException {
-
+    protected PublicClientApplication(@NonNull final PublicClientApplicationConfiguration configFile) throws MsalClientException {
         mPublicClientConfiguration = configFile;
-
-        if (clientId != null) {
-            mPublicClientConfiguration.mClientId = clientId;
-        }
-
-        if (authority != null) {
-            mPublicClientConfiguration.getAuthorities().clear();
-
-            Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
-            authorityObject.setDefault(true);
-            mPublicClientConfiguration.getAuthorities().add(authorityObject);
-        }
-
         initializeApplication();
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -247,7 +247,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 initializeConfiguration(context, configFileResourceId),
                 null, // client id
                 null, // authority
-                null,
+                null, // redirect uri
                 listener
         );
     }
@@ -285,8 +285,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         create(
                 initializeConfiguration(context, configFile),
                 null, // client id
-                null, // authority,
-                null,
+                null, // authority
+                null, // redirect uri
                 listener
         );
     }
@@ -733,8 +733,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final ResultFuture<AsyncResult<IPublicClientApplication>> future = new ResultFuture<>();
         create(configuration,
                 null, // client id
-                null,
                 null, // authority
+                null, // redirectUri
                 new ApplicationCreatedListener() {
                     @Override
                     public void onCreated(final IPublicClientApplication application) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -93,46 +93,46 @@ public class PublicClientApplicationConfiguration {
     }
 
     @SerializedName(CLIENT_ID)
-    String mClientId;
+    private String mClientId;
 
     @SerializedName(REDIRECT_URI)
-    String mRedirectUri;
+    private String mRedirectUri;
 
     @SerializedName(AUTHORITIES)
-    List<Authority> mAuthorities;
+    private List<Authority> mAuthorities;
 
     @SerializedName(AUTHORIZATION_USER_AGENT)
-    AuthorizationAgent mAuthorizationAgent;
+    private AuthorizationAgent mAuthorizationAgent;
 
     @SerializedName(HTTP)
-    HttpConfiguration mHttpConfiguration;
+    private HttpConfiguration mHttpConfiguration;
 
     @SerializedName(LOGGING)
-    LoggerConfiguration mLoggerConfiguration;
+    private LoggerConfiguration mLoggerConfiguration;
 
     @SerializedName(MULTIPLE_CLOUDS_SUPPORTED)
-    Boolean mMultipleCloudsSupported;
+    private Boolean mMultipleCloudsSupported;
 
     @SerializedName(USE_BROKER)
-    Boolean mUseBroker;
+    private Boolean mUseBroker;
 
     @SerializedName(ENVIRONMENT)
-    Environment mEnvironment;
+    private Environment mEnvironment;
 
     @SerializedName(REQUIRED_BROKER_PROTOCOL_VERSION)
-    String mRequiredBrokerProtocolVersion;
+    private String mRequiredBrokerProtocolVersion;
 
     @SerializedName(BROWSER_SAFE_LIST)
-    List<BrowserDescriptor> mBrowserSafeList;
+    private List<BrowserDescriptor> mBrowserSafeList;
 
     @SerializedName(TELEMETRY)
-    TelemetryConfiguration mTelemetryConfiguration;
+    private TelemetryConfiguration mTelemetryConfiguration;
 
     @SerializedName(ACCOUNT_MODE)
-    AccountMode mAccountMode;
+    private AccountMode mAccountMode;
 
     @SerializedName(CLIENT_CAPABILITIES)
-    String mClientCapabilities;
+    private String mClientCapabilities;
 
     transient private OAuth2TokenCache mOAuth2TokenCache;
 
@@ -167,6 +167,15 @@ public class PublicClientApplicationConfiguration {
      */
     public String getClientId() {
         return mClientId;
+    }
+
+    /**
+     * Sets the configured client id for the PublicClientApplication.
+     *
+     * @@param  The configured clientId.
+     */
+    public void setClientId(final String clientId){
+        mClientId = clientId;
     }
 
     /**
@@ -222,6 +231,15 @@ public class PublicClientApplicationConfiguration {
      */
     public String getRedirectUri() {
         return this.mRedirectUri;
+    }
+
+    /**
+     * Sets the configured redirect uri for the PublicClientApplication.
+     *
+     * @param redirectUri The redirectUri to use.
+     */
+    public void setRedirectUri(@NonNull final String redirectUri) {
+        this.mRedirectUri = redirectUri;
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -74,10 +74,8 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     private SharedPreferencesFileManager sharedPreferencesFileManager;
 
-    protected SingleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config,
-                                                   @Nullable final String clientId,
-                                                   @Nullable final String authority) throws MsalClientException {
-        super(config, clientId, authority);
+    protected SingleAccountPublicClientApplication(@NonNull PublicClientApplicationConfiguration config) throws MsalClientException {
+        super(config);
         initializeSharedPreferenceFileManager(config.getAppContext());
     }
 


### PR DESCRIPTION
Fix #890 

Two issues here.
1. PCA is not honoring authority/clientID before it makes a call to get device mode. Since no configuration file is passed. clientID will be null and exception is thrown.
2. redirectURI is also not there. Given that there are more than one default redirectURI format (broker Redirect URI was introduced as part of MSAL 1.0), we decided that this should be passed explicitly (instead of trying to prefill it).