### PR TITLE
Throw MsalClientException when redirect URI validation fails

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -172,9 +172,9 @@ public class PublicClientApplicationConfiguration {
     /**
      * Sets the configured client id for the PublicClientApplication.
      *
-     * @@param  The configured clientId.
+     * @@param The configured clientId.
      */
-    public void setClientId(final String clientId){
+    public void setClientId(final String clientId) {
         mClientId = clientId;
     }
 
@@ -445,7 +445,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     // Verifies broker redirect URI against the app's signature, to make sure that this is legit.
-    private void verifyRedirectUriWithAppSignature() {
+    private void verifyRedirectUriWithAppSignature() throws MsalClientException {
         final String packageName = mAppContext.getPackageName();
         try {
             final PackageInfo info = mAppContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_SIGNATURES);
@@ -469,8 +469,10 @@ public class PublicClientApplicationConfiguration {
             Logger.error(TAG, "Unexpected error in verifyRedirectUriWithAppSignature()", e);
         }
 
-        throw new IllegalStateException("The redirect URI in the configuration file doesn't match with the one " +
-                "generated with package name and signature hash. Please verify the uri in the config file and your app registration in Azure portal.");
+        throw new MsalClientException(
+                MsalClientException.REDIRECT_URI_VALIDATION_ERROR,
+                "The redirect URI in the configuration file doesn't match with the one " +
+                        "generated with package name and signature hash. Please verify the uri in the config file and your app registration in Azure portal.");
     }
 
     @SuppressWarnings("PMD")

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -186,6 +186,11 @@ public final class MsalClientException extends MsalException {
     public static final String APP_MANIFEST_VALIDATION_ERROR = "app_manifest_validation_error";
 
     /**
+     * Developer error. The redirect URI in the configuration file doesn't match with the one generated with package name and signature hash.
+     */
+    public static final String REDIRECT_URI_VALIDATION_ERROR = "redirect_uri_validation_error";
+
+    /**
      * Temporary non-exposed error code to indicate that ADFS authority validation fails. ADFS as authority is not supported
      * for preview.
      */


### PR DESCRIPTION
Closing the gap in #879 