### PR TITLE
Do not throw any exception until we've tried all strategies

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
@@ -27,7 +27,7 @@ import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 
 /**
- * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or Account Manager).
+ * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or AccountManager).
  */
 public class BrokerCommunicationException extends BaseException {
 

--- a/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
@@ -1,0 +1,43 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client.exception;
+
+import com.microsoft.identity.common.exception.BaseException;
+import com.microsoft.identity.common.exception.ErrorStrings;
+
+/**
+ * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or Account Manager).
+ */
+public class BrokerCommunicationException extends BaseException {
+
+    /**
+     * Initiates the {@link com.microsoft.identity.common.exception.BrokerCommunicationException} with error message and throwable.
+     *
+     * @param errorMessage The error message contained in the exception.
+     * @param throwable    The {@link Throwable} contains the cause for the exception.
+     */
+    public BrokerCommunicationException(final String errorMessage, final Throwable throwable) {
+        super(ErrorStrings.IO_ERROR, errorMessage, throwable);
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -33,9 +33,9 @@ import android.os.Bundle;
 import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
+import com.microsoft.identity.client.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
-import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.logging.Logger;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -36,7 +36,6 @@ import androidx.annotation.WorkerThread;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.BrokerCommunicationException;
-import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -107,7 +106,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
                             .putErrorCode(ErrorStrings.IO_ERROR)
                             .putErrorDescription(e.getMessage()));
 
-            throw new BrokerCommunicationException("Failed to connect to AccountManager");
+            throw new BrokerCommunicationException("Failed to connect to AccountManager", e);
         } catch (final BaseException e) {
             Logger.error(TAG + methodName, e.getMessage(), e);
             Telemetry.emit(
@@ -135,7 +134,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
             throws BaseException {
 
         if (!BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())) {
-            throw new BrokerCommunicationException("Account manager permissions are not granted");
+            throw new BrokerCommunicationException("Account manager permissions are not granted", null);
         }
 
         invokeBrokerAccountManagerOperation(parameters, new OperationInfo<OperationParameters, Void>() {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -56,7 +56,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
 
     public interface OperationInfo<T extends OperationParameters, U> {
         /**
-         * Performs this account manager operation in this method with the given IMicrosoftAuthService.
+         * Performs this AccountManager operation in this method with the given IMicrosoftAuthService.
          */
         Bundle getRequestBundle(T parameters);
 
@@ -134,7 +134,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
             throws BaseException {
 
         if (!BrokerMsalController.isAccountManagerPermissionsGranted(parameters.getAppContext())) {
-            throw new BrokerCommunicationException("Account manager permissions are not granted", null);
+            throw new BrokerCommunicationException("AccountManager permissions are not granted", null);
         }
 
         invokeBrokerAccountManagerOperation(parameters, new OperationInfo<OperationParameters, Void>() {
@@ -168,7 +168,7 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @WorkerThread
     Intent getBrokerAuthorizationIntent(@NonNull final AcquireTokenOperationParameters parameters) throws BaseException {
         final String methodName = ":getBrokerAuthorizationIntent";
-        Logger.verbose(TAG + methodName, "Get the broker authorization intent from Account Manager.");
+        Logger.verbose(TAG + methodName, "Get the broker authorization intent from AccountManager.");
 
         return invokeBrokerAccountManagerOperation(parameters,
                 new OperationInfo<AcquireTokenOperationParameters, Intent>() {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -133,7 +133,7 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
                             .putErrorCode(ErrorStrings.IO_ERROR)
                             .putErrorDescription(e.getMessage()));
 
-            throw new BrokerCommunicationException(errorDescription);
+            throw new BrokerCommunicationException(errorDescription, e);
         } catch (final BaseException e) {
             Logger.error(TAG + methodName, e.getMessage(), e);
             Telemetry.emit(
@@ -142,7 +142,6 @@ public class BrokerAuthServiceStrategy extends BrokerBaseStrategy {
                             .isSuccessful(false)
                             .putErrorCode(e.getErrorCode())
                             .putErrorDescription(e.getMessage()));
-
             throw e;
         } finally {
             client.disconnect();

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -31,8 +31,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.IMicrosoftAuthService;
+import com.microsoft.identity.client.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.BaseException;
-import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.internal.broker.MicrosoftAuthClient;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -36,9 +36,9 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.google.gson.GsonBuilder;
+import com.microsoft.identity.client.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
-import com.microsoft.identity.common.exception.BrokerCommunicationException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;
 import com.microsoft.identity.common.exception.ServiceException;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -183,6 +183,7 @@ public class BrokerMsalController extends BaseController {
         final List<BrokerBaseStrategy> strategies = getStrategies();
 
         U result = null;
+        Exception lastCaughtException = null;
         for (int ii = 0; ii < strategies.size(); ii++) {
             final BrokerBaseStrategy strategy = strategies.get(ii);
             try {
@@ -197,23 +198,20 @@ public class BrokerMsalController extends BaseController {
                 if (result != null) {
                     break;
                 }
-            } catch (final BrokerCommunicationException exception){
-                // continue
             } catch (final Exception exception){
-                if (strategyTask.getTelemetryApiId() != null) {
-                    Telemetry.emit(
-                            new ApiEndEvent()
-                                    .putException(exception)
-                                    .putApiId(strategyTask.getTelemetryApiId())
-                    );
-                }
-                throw exception;
+                // We know for a fact that in some OEM, bind service might throw a runtime exception.
+                // Given that the type of exception here could be unpredictable,
+                // it is better to catch 'every' exception so that we could try the next strategy - which could work.
+                lastCaughtException = exception;
             }
         }
 
         // This means that we've tried every strategies...
         if (result == null) {
-            final BrokerCommunicationException exception = new BrokerCommunicationException("MSAL failed to communicate to Broker.");
+            final BrokerCommunicationException exception = new BrokerCommunicationException(
+                    "MSAL failed to communicate to Broker.",
+                    lastCaughtException);
+
             if (strategyTask.getTelemetryApiId() != null) {
                 Telemetry.emit(
                         new ApiEndEvent()
@@ -221,6 +219,7 @@ public class BrokerMsalController extends BaseController {
                                 .putApiId(strategyTask.getTelemetryApiId())
                 );
             }
+
             throw exception;
         }
 


### PR DESCRIPTION
I found out today that we cannot be so sure what kind of exception would be thrown when bind service fails (i.e. in a variant of Samsung S8, NullPointerException is thrown).

For that particular device, AccountManager method would work (forced through android debugger), but the current code will never trigger that as an exception will be thrown before it tries the next strategy.

The fix here is to try every strategy, and then only throw if all strategies fail.