### PR TITLE
Only catch unknown errors + common update

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
@@ -26,10 +26,7 @@ package com.microsoft.identity.client;
 import android.app.Activity;
 import android.os.Bundle;
 
-import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
-import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity;
-import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationFragment;
-import com.microsoft.identity.common.internal.providers.oauth2.AuthorizationStrategy;
+import com.microsoft.identity.common.internal.providers.oauth2.BrowserAuthorizationFragment;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
 /**
@@ -64,21 +61,8 @@ public final class BrowserTabActivity extends Activity {
         if (savedInstanceState == null
                 && getIntent() != null
                 && !StringUtil.isEmpty(getIntent().getDataString())) {
-            startActivity(AuthorizationFragment.createCustomTabResponseIntent(this, getIntent().getDataString()));
+            startActivity(BrowserAuthorizationFragment.createCustomTabResponseIntent(this, getIntent().getDataString()));
             finish();
         }
-    }
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        if (getIntent() != null
-                && getIntent().hasExtra(AuthorizationStrategy.RESULT_CODE)) {
-            CommandDispatcher.completeInteractive(
-                    getIntent().getIntExtra(AuthorizationStrategy.REQUEST_CODE, 0),
-                    getIntent().getIntExtra(AuthorizationStrategy.RESULT_CODE, 0),
-                    getIntent());
-        }
-        finish();
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerActivity.java
@@ -26,9 +26,14 @@ import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
 
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
-import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.logging.Logger;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.RETURN_INTERACTIVE_REQUEST_RESULT;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.REQUEST_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentKey.RESULT_CODE;
 
 public final class BrokerActivity extends Activity {
 
@@ -101,7 +106,12 @@ public final class BrokerActivity extends Activity {
                 || resultCode == AuthenticationConstants.UIResponse.BROWSER_CODE_ERROR) {
 
             Logger.verbose(TAG + methodName, "Completing interactive request ");
-            CommandDispatcher.completeInteractive(requestCode, resultCode, data);
+
+            data.setAction(RETURN_INTERACTIVE_REQUEST_RESULT);
+            data.putExtra(REQUEST_CODE, AuthenticationConstants.UIRequest.BROWSER_FLOW);
+            data.putExtra(RESULT_CODE, resultCode);
+
+            LocalBroadcastManager.getInstance(getApplicationContext()).sendBroadcast(data);
         }
         finish();
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -198,12 +198,10 @@ public class BrokerMsalController extends BaseController {
                 if (result != null) {
                     break;
                 }
+            } catch (final BrokerCommunicationException communicationException) {
+                // These are known MSAL-Broker communication exception. Continue.
+                lastCaughtException = communicationException;
             } catch (final BaseException exception) {
-                if (exception instanceof  BrokerCommunicationException) {
-                    lastCaughtException = exception;
-                    continue;
-                }
-
                 // MSAL is aware of these exceptions. throw.
                 if (strategyTask.getTelemetryApiId() != null) {
                     Telemetry.emit(

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -200,6 +200,7 @@ public class BrokerMsalController extends BaseController {
                 }
             } catch (final BaseException exception) {
                 if (exception instanceof  BrokerCommunicationException) {
+                    lastCaughtException = exception;
                     continue;
                 }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -198,7 +198,21 @@ public class BrokerMsalController extends BaseController {
                 if (result != null) {
                     break;
                 }
-            } catch (final Exception exception){
+            } catch (final BaseException exception) {
+                if (exception instanceof  BrokerCommunicationException) {
+                    continue;
+                }
+
+                // MSAL is aware of these exceptions. Continue.
+                if (strategyTask.getTelemetryApiId() != null) {
+                    Telemetry.emit(
+                            new ApiEndEvent()
+                                    .putException(exception)
+                                    .putApiId(strategyTask.getTelemetryApiId())
+                    );
+                }
+                throw exception;
+            } catch (final Exception exception) {
                 // We know for a fact that in some OEM, bind service might throw a runtime exception.
                 // Given that the type of exception here could be unpredictable,
                 // it is better to catch 'every' exception so that we could try the next strategy - which could work.

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -203,7 +203,7 @@ public class BrokerMsalController extends BaseController {
                     continue;
                 }
 
-                // MSAL is aware of these exceptions. Continue.
+                // MSAL is aware of these exceptions. throw.
                 if (strategyTask.getTelemetryApiId() != null) {
                     Telemetry.emit(
                             new ApiEndEvent()


### PR DESCRIPTION
This is a fix on top of #900 

If there is a 'known' MSAL error, we will just throw it.

Also update the code to accommodate the latest common.