### PR TITLE
Optionally allow the caller to provide a nonce for AT/PoP calls

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PoPAuthenticationScheme.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PoPAuthenticationScheme.java
@@ -28,7 +28,6 @@ import com.microsoft.identity.common.internal.authscheme.IPoPAuthenticationSchem
 import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
 
 import java.net.URL;
-import java.util.UUID;
 
 public class PoPAuthenticationScheme
         extends AuthenticationScheme
@@ -39,11 +38,12 @@ public class PoPAuthenticationScheme
     private final String mNonce;
 
     private PoPAuthenticationScheme(@NonNull final HttpMethod method,
-                                    @NonNull final URL url) {
+                                    @NonNull final URL url,
+                                    @NonNull final String nonce) {
         super(PopAuthenticationSchemeInternal.SCHEME_POP);
         mHttpMethod = method;
         mUrl = url;
-        mNonce = UUID.randomUUID().toString();
+        mNonce = nonce;
     }
 
     public static Builder builder() {
@@ -69,6 +69,7 @@ public class PoPAuthenticationScheme
 
         private URL mUrl;
         private HttpMethod mHttpMethod;
+        private String mNonce;
 
         private Builder() {
             // Intentionally blank
@@ -84,6 +85,11 @@ public class PoPAuthenticationScheme
             return this;
         }
 
+        public Builder withNonce(@NonNull final String nonce) {
+            mNonce = nonce;
+            return this;
+        }
+
         public PoPAuthenticationScheme build() {
             String errMsg = "PoP authentication scheme param must not be null: ";
 
@@ -95,7 +101,11 @@ public class PoPAuthenticationScheme
                 throw new IllegalArgumentException(errMsg + "HTTP Method");
             }
 
-            return new PoPAuthenticationScheme(mHttpMethod, mUrl);
+            if (null == mNonce) {
+                throw new IllegalArgumentException(errMsg + "nonce");
+            }
+
+            return new PoPAuthenticationScheme(mHttpMethod, mUrl, mNonce);
         }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PoPAuthenticationScheme.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PoPAuthenticationScheme.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.internal.authscheme.IPoPAuthenticationSchemeParams;
 import com.microsoft.identity.common.internal.authscheme.PopAuthenticationSchemeInternal;
@@ -39,7 +40,7 @@ public class PoPAuthenticationScheme
 
     private PoPAuthenticationScheme(@NonNull final HttpMethod method,
                                     @NonNull final URL url,
-                                    @NonNull final String nonce) {
+                                    @Nullable final String nonce) {
         super(PopAuthenticationSchemeInternal.SCHEME_POP);
         mHttpMethod = method;
         mUrl = url;
@@ -85,7 +86,7 @@ public class PoPAuthenticationScheme
             return this;
         }
 
-        public Builder withNonce(@NonNull final String nonce) {
+        public Builder withNonce(@Nullable final String nonce) {
             mNonce = nonce;
             return this;
         }
@@ -99,10 +100,6 @@ public class PoPAuthenticationScheme
 
             if (null == mHttpMethod) {
                 throw new IllegalArgumentException(errMsg + "HTTP Method");
-            }
-
-            if (null == mNonce) {
-                throw new IllegalArgumentException(errMsg + "nonce");
             }
 
             return new PoPAuthenticationScheme(mHttpMethod, mUrl, mNonce);


### PR DESCRIPTION
Builds on:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/822

Per internal thread, RPs want to supply client with a nonce value to submit in these requests.

Edit:
- Nonce is optional
- If no nonce is provided, resulting SHR will contain no nonce claim