### PR TITLE
[TestApp] Use same redirect uri for both AAD and B2C msal config

### DIFF
--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -28,7 +28,7 @@ apply plugin: 'com.android.application'
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "com.microsoft.identity.client.sample"
+        applicationId "com.msft.identity.client.sample"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
                 <!-- To Test PPE:  msal7cc2dd84-bb0f-4711-8fca-4c7d01249f56 -->
                 <!-- To Test Sovereign: msalcb7faed4-b8c0-49ee-b421-f5ed16894c83 -->
                 <data android:scheme="msauth"
-                    android:host="com.microsoft.identity.client.sample.local"
+                    android:host="${applicationId}"
                     android:path="/1wIqXSqBj7w+h11ZifsnqwgyKrY="/>
             </intent-filter>
         </activity>

--- a/testapps/testapp/src/main/res/raw/msal_b2c_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_b2c_config.json
@@ -1,6 +1,6 @@
 {
   "client_id" : "e3b9ad76-9763-4827-b088-80c7a7888f79",
-  "redirect_uri" : "msale3b9ad76-9763-4827-b088-80c7a7888f79://auth",
+  "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "authorities" : [
     {
       "type": "B2C",

--- a/testapps/testapp/src/main/res/raw/msal_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_config.json
@@ -8,7 +8,7 @@
     {
       "type": "AAD",
       "audience": {
-        "type": "AzureADandPersonalMicrosoftAccount"
+        "type": "AzureADMultipleOrgs"
       }
     }
   ],

--- a/testapps/testapp/src/main/res/raw/msal_msa_config.json
+++ b/testapps/testapp/src/main/res/raw/msal_msa_config.json
@@ -1,5 +1,5 @@
 {
-  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "client_id" : "9668f2bd-6103-4292-9024-84fa2d1b6fb2",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "multiple_clouds_supported":true,


### PR DESCRIPTION
The word "microsoft" is not allowed in a redirect_uri for an app that supports personal MSA accounts.