### PR TITLE
Use a configured Gson instance for AbstractAuthenticationScheme serialization

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerBaseStrategy.java
@@ -28,7 +28,6 @@ import android.os.Looper;
 
 import androidx.annotation.NonNull;
 
-import com.google.gson.Gson;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.internal.broker.BrokerRequest;
@@ -41,6 +40,8 @@ import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import com.microsoft.identity.common.internal.result.MsalBrokerResultAdapter;
 
 import java.util.List;
+
+import static com.microsoft.identity.common.internal.request.MsalBrokerRequestAdapter.sRequestAdapterGsonInstance;
 
 abstract class BrokerBaseStrategy {
     protected final MsalBrokerRequestAdapter mRequestAdapter = new MsalBrokerRequestAdapter();
@@ -57,7 +58,7 @@ abstract class BrokerBaseStrategy {
 
     abstract void removeBrokerAccount(@NonNull final OperationParameters parameters) throws BaseException;
 
-    abstract boolean getDeviceMode(@NonNull final OperationParameters parameters)throws BaseException;
+    abstract boolean getDeviceMode(@NonNull final OperationParameters parameters) throws BaseException;
 
     abstract List<ICacheRecord> getCurrentAccountInSharedDevice(@NonNull final OperationParameters parameters) throws BaseException;
 
@@ -72,12 +73,13 @@ abstract class BrokerBaseStrategy {
     }
 
     protected Intent completeInteractiveRequestIntent(@NonNull final Intent interactiveRequestIntent,
-                                                      @NonNull final AcquireTokenOperationParameters parameters){
+                                                      @NonNull final AcquireTokenOperationParameters parameters) {
         interactiveRequestIntent.putExtra(
                 AuthenticationConstants.Broker.BROKER_REQUEST_V2,
-                new Gson().toJson(
+                sRequestAdapterGsonInstance.toJson(
                         mRequestAdapter.brokerRequestFromAcquireTokenParameters(parameters),
-                        BrokerRequest.class)
+                        BrokerRequest.class
+                )
         );
 
         return interactiveRequestIntent;


### PR DESCRIPTION
Bugfix for using a Gson instance that has not been provided the necessary type adapter

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.azure.authenticator/com.azure.authenticator.ui.AccountChooserActivity}: java.lang.RuntimeException: Unable to invoke no-args constructor for class com.microsoft.identity.common.internal.authscheme.AbstractAuthenticationScheme. Registering an InstanceCreator with Gson for this type may fix this problem.
```