### PR TITLE
Add signing config for release APK to testapp

### DIFF
--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -41,9 +41,17 @@ android {
             keyAlias 'androiddebugkey'
             keyPassword 'android'
         }
+
+        release {
+            storeFile file("./debug.keystore")
+            storePassword 'android'
+            keyAlias 'androiddebugkey'
+            keyPassword 'android'
+        }
     }
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }


### PR DESCRIPTION
This is done to make it easier to create release builds for MSAL Test App when we do our bug bashes. Right now the behavior is different in Mac and Windows I believe, where on Windows I had to do these changes to build the release version with the same keystore file that we use for debug builds. Don't want us to manually make these changes locally before every release