### PR TITLE
Fix crash on redirect when no activity available

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/BrowserTabActivity.java
@@ -24,8 +24,11 @@
 package com.microsoft.identity.client;
 
 import android.app.Activity;
+import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Toast;
 
+import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.oauth2.BrowserAuthorizationFragment;
 import com.microsoft.identity.common.internal.util.StringUtil;
 
@@ -53,7 +56,7 @@ import com.microsoft.identity.common.internal.util.StringUtil;
  * </pre>
  */
 public final class BrowserTabActivity extends Activity {
-    //private static final String TAG = BrowserTabActivity.class.getSimpleName();
+    private static final String TAG = BrowserTabActivity.class.getSimpleName();
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -61,7 +64,13 @@ public final class BrowserTabActivity extends Activity {
         if (savedInstanceState == null
                 && getIntent() != null
                 && !StringUtil.isEmpty(getIntent().getDataString())) {
-            startActivity(BrowserAuthorizationFragment.createCustomTabResponseIntent(this, getIntent().getDataString()));
+            final Intent responseIntent = BrowserAuthorizationFragment.createCustomTabResponseIntent(this, getIntent().getDataString());
+            if (responseIntent != null) {
+                startActivity(responseIntent);
+            } else {
+                Logger.warn(TAG, "Received NULL response intent. Unable to complete authorization.");
+                Toast.makeText(getApplicationContext(), "Unable to complete authorization as there is no interactive call in progress. This can be due to closing the app while the authorization was in process.", Toast.LENGTH_LONG).show();
+            }
             finish();
         }
     }


### PR DESCRIPTION
Related common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/839

Repro for the issue:

- Download a browser that doesn't support custom tabs
- Set it as the default browser
- Start an interactive request in MSAL Test App
- Once in the browser, close the MSAL Test App
- Go back to browser to finish the authorization

Currently this results in a crash (NPE when creating custom tab response intent) as the calling activity class is NULL because the MSAL Test App was shut down and all memory was wiped. 

This NPE was introduced with Fragment support. This entire scenario was not handled prior to Fragment support but didn't run into any NPE or crash as we were using a hard coded reference to Authorization Activity. 

To fix the issue, I perform null checks and if we run into this scenario then we finish and return as we can't complete the interactive request as there is no interactive request in progress (in app memory), then we also log a warning as well as show a toast to the user explaining what probably happened.