### PR TITLE
Remove unit tests from Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,4 +51,4 @@ before_script:
 
 script:
   - cd $PWD
-  - travis_wait ./gradlew clean msal:assembleLocal msal:testLocalDebugUnitTest msal:connectedLocalDebugAndroidTest -PdisablePreDex
+  - travis_wait ./gradlew clean msal:assembleLocal msal:connectedLocalDebugAndroidTest -PdisablePreDex


### PR DESCRIPTION
Unit [JVM] Tests will be run by the ADO pipeline, whereas the Instrumented tests will be run by the Travis