### PR TITLE
SA-PCA: New overloads, javadoc cleanup

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -20,7 +20,6 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-
 package com.microsoft.identity.client;
 
 import android.app.Activity;
@@ -81,9 +80,10 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * @link AuthenticationCallback#onError(MsalException)}.
      */
     void signIn(@NonNull final Activity activity,
-                @NonNull final String loginHint,
+                @Nullable final String loginHint,
                 @NonNull final String[] scopes,
-                @NonNull final AuthenticationCallback callback);
+                @NonNull final AuthenticationCallback callback
+    );
 
     /**
      * Signs out the current the Account and Credentials (tokens).
@@ -117,7 +117,8 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      */
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                  @NonNull final String authority,
-                                 @NonNull final SilentAuthenticationCallback callback);
+                                 @NonNull final SilentAuthenticationCallback callback
+    );
 
     /**
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
@@ -139,7 +140,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
         /**
          * Invoked when the account is loaded.
          *
-         * @param activeAccount the signed-in account. This could be nil.
+         * @param activeAccount the signed-in account. This could be null.
          */
         void onAccountLoaded(@Nullable final IAccount activeAccount);
 
@@ -147,8 +148,8 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
          * Invoked when signed-in account is changed after the application resumes, or prior to running a scheduled background operation.
          * The calling app is responsible for keeping track of this account and cleaning its states if the account changes.
          *
-         * @param priorAccount   the previous signed-in account. This could be nil.
-         * @param currentAccount the current signed-in account. This could be nil.
+         * @param priorAccount   the previous signed-in account. This could be null.
+         * @param currentAccount the current signed-in account. This could be null.
          */
         void onAccountChanged(@Nullable final IAccount priorAccount, @Nullable final IAccount currentAccount);
 

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -86,6 +86,57 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     );
 
     /**
+     * Allows a user to sign in to your application with one of their accounts.
+     * <p>
+     * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
+     * or the default authority specified by you in your configuration
+     *
+     * @param activity  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param scopes    The non-null array of scopes to be consented to during sign in.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     *                  The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
+     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
+     */
+    void signIn(@NonNull final Activity activity,
+                @Nullable final String loginHint,
+                @NonNull final String[] scopes,
+                @Nullable final Prompt prompt,
+                @NonNull final AuthenticationCallback callback
+    );
+
+    /**
+     * Reauthorizes the current account according to the supplied scopes and prompt behavior.
+     * <p>
+     * Note: The authority used to make the sign in request will be either the MSAL default:
+     * https://login.microsoftonline.com/common or the default authority specified by you in your
+     * configuration.
+     *
+     * @param activity Non-null {@link Activity} that is used as the parent activity for
+     *                 launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param scopes   The non-null array of scopes to be consented to during sign in.
+     *                 MSAL always sends the scopes 'openid profile offline_access'. Do
+     *                 not include any of these scopes in the scope parameter. The access
+     *                 token returned is for MS Graph and will allow you to query for
+     *                 additional information about the signed in account.
+     * @param prompt   Nullable. Indicates the type of user interaction that is required.
+     *                 If no argument is supplied the default behavior will be used.
+     * @param callback {@link AuthenticationCallback} that is used to send the result back.
+     *                 The success result will be sent back via
+     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                 Failure case will be sent back via {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void reauthorize(@NonNull final Activity activity,
+                @NonNull final String[] scopes,
+                @Nullable final Prompt prompt,
+                @NonNull final AuthenticationCallback callback
+    );
+
+    /**
      * Signs out the current the Account and Credentials (tokens).
      * NOTE: If a device is marked as a shared device within broker signout will be device wide.
      *

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -63,7 +63,11 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     ICurrentAccountResult getCurrentAccount() throws InterruptedException, MsalException;
 
     /**
-     * Allows a user to sign in to your application with one of their accounts.
+     * Allows a user to sign in to your application with one of their accounts. This method may only
+     * be called once: once a user is signed in, they must first be signed out before another user
+     * may sign in. If you wish to prompt the existing user for credentials use
+     * {@link #reauthorize(Activity, String[], Prompt, AuthenticationCallback)} or
+     * {@link #acquireToken(AcquireTokenParameters)}.
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
      * or the default authority specified by you in your configuration
@@ -86,7 +90,11 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     );
 
     /**
-     * Allows a user to sign in to your application with one of their accounts.
+     * Allows a user to sign in to your application with one of their accounts. This method may only
+     * be called once: once a user is signed in, they must first be signed out before another user
+     * may sign in. If you wish to prompt the existing user for credentials use
+     * {@link #reauthorize(Activity, String[], Prompt, AuthenticationCallback)} or
+     * {@link #acquireToken(AcquireTokenParameters)}.
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
      * or the default authority specified by you in your configuration
@@ -131,9 +139,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      *                 Failure case will be sent back via {@link AuthenticationCallback#onError(MsalException)}.
      */
     void reauthorize(@NonNull final Activity activity,
-                @NonNull final String[] scopes,
-                @Nullable final Prompt prompt,
-                @NonNull final AuthenticationCallback callback
+                     @NonNull final String[] scopes,
+                     @Nullable final Prompt prompt,
+                     @NonNull final AuthenticationCallback callback
     );
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -66,7 +66,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * Allows a user to sign in to your application with one of their accounts. This method may only
      * be called once: once a user is signed in, they must first be signed out before another user
      * may sign in. If you wish to prompt the existing user for credentials use
-     * {@link #reauthorize(Activity, String[], Prompt, AuthenticationCallback)} or
+     * {@link #signInAgain(Activity, String[], Prompt, AuthenticationCallback)} or
      * {@link #acquireToken(AcquireTokenParameters)}.
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
@@ -93,7 +93,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * Allows a user to sign in to your application with one of their accounts. This method may only
      * be called once: once a user is signed in, they must first be signed out before another user
      * may sign in. If you wish to prompt the existing user for credentials use
-     * {@link #reauthorize(Activity, String[], Prompt, AuthenticationCallback)} or
+     * {@link #signInAgain(Activity, String[], Prompt, AuthenticationCallback)} or
      * {@link #acquireToken(AcquireTokenParameters)}.
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
@@ -138,7 +138,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
      *                 Failure case will be sent back via {@link AuthenticationCallback#onError(MsalException)}.
      */
-    void reauthorize(@NonNull final Activity activity,
+    void signInAgain(@NonNull final Activity activity,
                      @NonNull final String[] scopes,
                      @Nullable final Prompt prompt,
                      @NonNull final AuthenticationCallback callback

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -286,7 +286,7 @@ public class SingleAccountPublicClientApplication
     }
 
     @Override
-    public void reauthorize(@NonNull final Activity activity,
+    public void signInAgain(@NonNull final Activity activity,
                             @NonNull final String[] scopes,
                             @Nullable final Prompt prompt,
                             @NonNull final AuthenticationCallback callback) {

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -188,7 +188,7 @@ public class SingleAccountPublicClientApplication extends PublicClientApplicatio
 
     @Override
     public void signIn(@NonNull final Activity activity,
-                       @NonNull final String loginHint,
+                       @Nullable final String loginHint,
                        @NonNull final String[] scopes,
                        @NonNull final AuthenticationCallback callback) {
         final IAccount persistedAccount = getPersistedCurrentAccount();


### PR DESCRIPTION
See #991 

## Changes in this PR:
- Changes a `@NonNull` annot to `@Nullable` to match 'Optional' notes in javadoc
- Adds `final` to some params, instance vars
- Tweaks some formatting to remove
- Changes 'nil' to 'null' in javadocs
- Adds new `signIn()` overload which adds a `prompt` param
- Adds new `reauthorize()` method which lets your set a `prompt` for the already-signed-in account