### PR TITLE
Make persistedAccount operations thread safe

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.client.internal.controllers.OperationParametersAdapter;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
 import com.microsoft.identity.common.adal.internal.util.JsonExtensions;
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.internal.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
@@ -132,6 +133,7 @@ public class SingleAccountPublicClientApplication
                                 // We do not support switching from MULTIPLE to SINGLE.
                                 // See getAccountFromICacheRecordList() for more details.
                                 checkCurrentAccountNotifyCallback(callback, result);
+                                persistCurrentAccount(result);
                             }
 
                             @Override
@@ -208,11 +210,10 @@ public class SingleAccountPublicClientApplication
                 ? null
                 : getAccountFromICacheRecordList(newAccountRecords);
 
-        if (didCurrentAccountChange(newAccount)) {
+        if (!isHomeAccountIdMatching(localAccount, newAccount)) {
             callback.onAccountChanged(localAccount, newAccount);
         }
 
-        persistCurrentAccount(newAccountRecords);
         callback.onAccountLoaded(newAccount);
     }
 
@@ -293,7 +294,8 @@ public class SingleAccountPublicClientApplication
         final MultiTenantAccount persistedCurrentAccount = getPersistedCurrentAccount();
 
         if (persistedCurrentAccount == null) {
-            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
+            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE));
             return;
         }
 
@@ -326,24 +328,8 @@ public class SingleAccountPublicClientApplication
                     throw new IllegalStateException(NONNULL_CONSTANTS.CALLBACK + NONNULL_CONSTANTS.NULL_ERROR_SUFFIX);
                 }
 
-                //Get Local Authentication Result then check if the current account is set or not
-                final MultiTenantAccount newAccount = getAccountFromICacheRecordList(
-                        localAuthenticationResult.getCacheRecordWithTenantProfileData()
-                );
-
-                if (didCurrentAccountChange(newAccount)) {
-                    if (getPersistedCurrentAccount() != null) {
-                        authenticationCallback.onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH));
-                        return;
-                    } else {
-                        persistCurrentAccount(localAuthenticationResult.getCacheRecordWithTenantProfileData());
-                    }
-                } else {
-                    persistCurrentAccount(localAuthenticationResult.getCacheRecordWithTenantProfileData());
-                }
-
+                persistCurrentAccount(localAuthenticationResult.getCacheRecordWithTenantProfileData());
                 postAuthResult(localAuthenticationResult, tokenParameters, authenticationCallback);
-
             }
 
             @Override
@@ -367,13 +353,17 @@ public class SingleAccountPublicClientApplication
         };
     }
 
-    private boolean didCurrentAccountChange(@Nullable final MultiTenantAccount newAccount) {
-        final MultiTenantAccount persistedAccount = getPersistedCurrentAccount();
+    /**
+     * Returns true if the account ID of both account matches (or both accounts are null).
+     * */
+    private boolean isHomeAccountIdMatching(@Nullable final IAccount firstAccount, @Nullable final IAccount secondAccount) {
+        final MultiTenantAccount firstMultiTenantAccount = firstAccount instanceof MultiTenantAccount ? (MultiTenantAccount) firstAccount : null;
+        final MultiTenantAccount secondMultiTenantAccount = secondAccount instanceof MultiTenantAccount ? (MultiTenantAccount) secondAccount : null;
 
-        final String persistedAccountId = persistedAccount == null ? "" : persistedAccount.getHomeAccountId();
-        final String newAccountId = newAccount == null ? "" : newAccount.getHomeAccountId();
+        final String firstMultiTenantAccountId = firstMultiTenantAccount == null ? "" : firstMultiTenantAccount.getHomeAccountId();
+        final String secondMultiTenantAccountId = secondMultiTenantAccount == null ? "" : secondMultiTenantAccount.getHomeAccountId();
 
-        return !persistedAccountId.equalsIgnoreCase(newAccountId);
+        return firstMultiTenantAccountId.equalsIgnoreCase(secondMultiTenantAccountId);
     }
 
     @Override
@@ -386,7 +376,8 @@ public class SingleAccountPublicClientApplication
         final MultiTenantAccount persistedCurrentAccount = getPersistedCurrentAccount();
 
         if (persistedCurrentAccount == null) {
-            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
+            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE));
             return;
         }
 
@@ -471,33 +462,34 @@ public class SingleAccountPublicClientApplication
      * @return a persisted MultiTenantAccount. This could be null.
      */
     private MultiTenantAccount getPersistedCurrentAccount() {
-        final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
+        synchronized(SingleAccountPublicClientApplication.class) {
+            final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
 
-        if (currentAccountJsonString == null) {
-            return null;
+            if (StringExtensions.isNullOrBlank(currentAccountJsonString)) {
+                return null;
+            }
+
+            final List<ICacheRecord> cacheRecordList = JsonExtensions.getICacheRecordListFromJsonString(currentAccountJsonString);
+            return getAccountFromICacheRecordList(cacheRecordList);
         }
-
-        final List<ICacheRecord> cacheRecordList = JsonExtensions.getICacheRecordListFromJsonString(currentAccountJsonString);
-        return getAccountFromICacheRecordList(cacheRecordList);
     }
 
     /**
      * Persists current account to shared preference.
      *
      * @param cacheRecords list of cache record that belongs to an account.
-     *                     Please note that this layer will not verify if the list ubelongs to a single account or not.
+     *                     Please note that this layer will not verify if the list belongs to a single account or not.
      */
     private void persistCurrentAccount(@Nullable final List<ICacheRecord> cacheRecords) {
+        synchronized(SingleAccountPublicClientApplication.class) {
+            if (cacheRecords == null || cacheRecords.size() == 0) {
+                sharedPreferencesFileManager.clear();
+                return;
+            }
 
-        sharedPreferencesFileManager.clear();
-
-        if (cacheRecords == null || cacheRecords.size() == 0) {
-            // Do nothing.
-            return;
+            final String currentAccountJsonString = JsonExtensions.getJsonStringFromICacheRecordList(cacheRecords);
+            sharedPreferencesFileManager.putString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY, currentAccountJsonString);
         }
-
-        final String currentAccountJsonString = JsonExtensions.getJsonStringFromICacheRecordList(cacheRecords);
-        sharedPreferencesFileManager.putString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY, currentAccountJsonString);
     }
 
     /**
@@ -533,7 +525,8 @@ public class SingleAccountPublicClientApplication
                              @NonNull final AuthenticationCallback callback) {
         final IAccount persistedAccount = getPersistedCurrentAccount();
         if (persistedAccount == null) {
-            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
+            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE));
             return;
         }
 
@@ -561,10 +554,37 @@ public class SingleAccountPublicClientApplication
     public void acquireToken(@NonNull final AcquireTokenParameters acquireTokenParameters) {
         final IAccount persistedAccount = getPersistedCurrentAccount();
 
+        // If persistedAccount exists, a matching account or login hint is expected.
         if (persistedAccount != null) {
-            // If the account exists, overwrite Account and ignore loginHint.
-            acquireTokenParameters.setAccount(persistedAccount);
-            acquireTokenParameters.setLoginHint("");
+            // Nothing is provided.
+            if (acquireTokenParameters.getAccount() == null &&
+                    StringExtensions.isNullOrBlank(acquireTokenParameters.getLoginHint())){
+                acquireTokenParameters
+                        .getCallback()
+                        .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
+                                MsalClientException.CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE));
+                return;
+            }
+
+            // If account is provided, check if the account's homeAccountId matches with the persisted account's.
+            if (acquireTokenParameters.getAccount() != null &&
+                    !isHomeAccountIdMatching(persistedAccount, acquireTokenParameters.getAccount())) {
+                acquireTokenParameters
+                        .getCallback()
+                        .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
+                                MsalClientException.CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE));
+                return;
+            }
+
+            // If login hint is provided, check if the login hint matches with the persisted account's.
+            if (!StringExtensions.isNullOrBlank(acquireTokenParameters.getLoginHint()) &&
+                    !persistedAccount.getUsername().equalsIgnoreCase(acquireTokenParameters.getLoginHint())){
+                acquireTokenParameters
+                        .getCallback()
+                        .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
+                                MsalClientException.CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE));
+                return;
+            }
         }
 
         acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS);
@@ -575,9 +595,9 @@ public class SingleAccountPublicClientApplication
                                         @NonNull final String authority,
                                         @NonNull final SilentAuthenticationCallback callback) {
         final IAccount persistedAccount = getPersistedCurrentAccount();
-
         if (persistedAccount == null) {
-            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
+            callback.onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE));
             return;
         }
 
@@ -600,9 +620,9 @@ public class SingleAccountPublicClientApplication
     public IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                                     @NonNull final String authority) throws MsalException, InterruptedException {
         final IAccount persistedAccount = getPersistedCurrentAccount();
-
         if (persistedAccount == null) {
-            throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT);
+            throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE);
         }
 
         return acquireTokenSilentSyncInternal(
@@ -617,16 +637,21 @@ public class SingleAccountPublicClientApplication
     @Override
     public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
         final IAccount persistedAccount = getPersistedCurrentAccount();
-
         if (persistedAccount == null) {
             acquireTokenSilentParameters
                     .getCallback()
-                    .onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT));
+                    .onError(new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                            MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE));
             return;
         }
 
-        // In SingleAccount mode, always overwrite 'Account' with current account.
-        acquireTokenSilentParameters.setAccount(persistedAccount);
+        if (!isHomeAccountIdMatching(persistedAccount, acquireTokenSilentParameters.getAccount())) {
+            acquireTokenSilentParameters
+                    .getCallback()
+                    .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
+                            MsalClientException.CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE));
+            return;
+        }
 
         acquireTokenSilentAsyncInternal(
                 acquireTokenSilentParameters,
@@ -637,13 +662,15 @@ public class SingleAccountPublicClientApplication
     @Override
     public IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException {
         final IAccount persistedAccount = getPersistedCurrentAccount();
-
         if (persistedAccount == null) {
-            throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT);
+            throw new MsalClientException(MsalClientException.NO_CURRENT_ACCOUNT,
+                    MsalClientException.NO_CURRENT_ACCOUNT_ERROR_MESSAGE);
         }
 
-        // In SingleAccount mode, always overwrite 'Account' with current account.
-        acquireTokenSilentParameters.setAccount(persistedAccount);
+        if (!isHomeAccountIdMatching(persistedAccount, acquireTokenSilentParameters.getAccount())) {
+            throw new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
+                    MsalClientException.CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE);
+        }
 
         return acquireTokenSilentInternal(
                 acquireTokenSilentParameters,

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -168,12 +168,14 @@ public final class MsalClientException extends MsalException {
      /**
      * No account currently signed in to SingleAccountPublicClientApplication
      */
-    public static final String NO_CURRENT_ACCOUNT = "no_current_account";
+     public static final String NO_CURRENT_ACCOUNT = "no_current_account";
+    public static final String NO_CURRENT_ACCOUNT_ERROR_MESSAGE = "There is no signed in account.";
 
     /**
-     * Returned account does not match new account
+     * The account that is being signed in does not match with the provided account.
      */
-    public static final String CURRENT_ACCOUNT_MISMATCH = "returned_account_does_not_match_current_account";
+    public static final String CURRENT_ACCOUNT_MISMATCH = "current_account_mismatch";
+    public static final String CURRENT_ACCOUNT_MISMATCH_ERROR_MESSAGE = "The signed in account does not match with the provided account.";
 
     /**
      * Duplicate command.  The same command is already be processed.


### PR DESCRIPTION
- Make getPersistedCurrentAccount() and persistCurrentAccount() thread safe. (#995)
- Add error checks for function that takes in acquireToken/silent parameters (as we're moving toward making those parameter immutable)
    - This means we'll be returning errors when these API is being misused (instead of trying to 'correct' the values). Technically, this could be considered a breaking change.
- Add error messages.