### PR TITLE
Fix to add callback instead of identifier for null check

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -193,7 +193,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
                                     @NonNull final String publicApiId) {
         try {
             validateNonNullArg(identifier, "identifier");
-            validateNonNullArg(identifier, "callback");
+            validateNonNullArg(callback, "callback");
         } catch (MsalArgumentException e) {
             callback.onError(e);
         }

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -191,9 +191,11 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
     private void getAccountInternal(@NonNull final String identifier,
                                     @NonNull final GetAccountCallback callback,
                                     @NonNull final String publicApiId) {
+        if(callback == null){
+            throw new IllegalArgumentException("callback cannot be null or empty");
+        }
         try {
             validateNonNullArg(identifier, "identifier");
-            validateNonNullArg(callback, "callback");
         } catch (MsalArgumentException e) {
             callback.onError(e);
         }


### PR DESCRIPTION
Related PR : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1005