### PR TITLE
[Test App] Add config for client app not admin consented

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
@@ -41,11 +41,12 @@ public class Constants {
         INSTANCE_AWARE_ORGANIZATION,
         B2C,
         MSA,
-        MSA_ONLY
+        MSA_ONLY,
+        NO_ADMIN_CONSENT
     }
 
-    public static int getResourceIdFromConfigFile(ConfigFile configFile){
-        switch (configFile){
+    public static int getResourceIdFromConfigFile(ConfigFile configFile) {
+        switch (configFile) {
             case BROWSER:
                 return R.raw.msal_config_browser;
 
@@ -81,6 +82,9 @@ public class Constants {
 
             case MSA_ONLY:
                 return R.raw.msal_config_msa_only;
+
+            case NO_ADMIN_CONSENT:
+                return R.raw.msal_config_no_admin_consent;
         }
 
         return R.raw.msal_config_default;

--- a/testapps/testapp/src/main/res/raw/msal_config_no_admin_consent.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_no_admin_consent.json
@@ -1,0 +1,14 @@
+{
+  "client_id" : "a8c8bb57-55f3-4e95-9cf2-a3aac32f0d7a",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "authorities" : [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADMyOrg",
+        "tenant_id": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
See test case (CORPNET REQUIRED): https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99274

For test cases that rely on consent, we need to use an app (client_id) that is not admin consented so the consent page actually shows up. In this PR, I've added a new config file to use this client id. This is provided by the LAB Team and this is the only client id that is NOT admin consented. All other are already admin consented so we would never get the consent page with SELECT_ACCOUNT in those other apps. 