### PR TITLE
Enable offline mode for robolectric tests

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -89,6 +89,9 @@ android {
                 // example: ./gradlew testLocalDebugUnitTest -Plabtest
                 exclude 'com/microsoft/identity/client/e2e/tests/network'
             }
+
+            systemProperty 'robolectric.offline', 'true'
+            systemProperty 'robolectric.dependency.dir', './libs'
         }
     }
 }


### PR DESCRIPTION
**What issue does this PR solve?**
Robolectric downloads some jar(s) during runtime execution of tests the first time Robolectric tests are executed on a machine. Downloading of these jars is not reliable -  see this: https://github.com/robolectric/robolectric/issues/5456

**How does it solve the issue?**
To combat this, Robolectric provides an offline mode by which allows the developer to download these jars on their machine in advance and enable [offline mode](http://robolectric.org/configuring/) so Robolectric doesn't have to download these at runtime. This allows the tests to continue to run even if the fetching of jars failed.

**What will need to happen going forward to avoid issues?**
The exact version of the jar required is based on the target sdk of the project or the sdk version that is being used for the execution of Robolectric tests. Multiple jars will be needed if tests are being run on multiple sdk versions. The jars can be downloaded from here https://mvnrepository.com/artifact/org.robolectric/android-all

The jar will need to be updated when we update the target sdk version or if/when we run our tests against a different sdk version than the current target sdk version (tests are currently run against target sdk version which is the default for Robolectric)

**What steps need to be performed to achieve offline mode in Robolectric?**
Here are the steps I followed to enable offline mode in Robolectric:

1.	Identity* the jar(s) needed by Robolectric at runtime during execution of tests
2.	Download the dependency jar needed for Robolectric from here: https://mvnrepository.com/artifact/org.robolectric/android-all
3.	Add the jar locally to the project (and commit it to the repo)
4.	Add the following snippet to build.gradle:
a.	systemProperty ‘robolectric.offline’, ‘true’
b.	systemProperty ‘robolectric.dependency.dir’, ‘<directory_where_jar_was_stored>’
