### PR TITLE
Update readme for duo sdk instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ dependencies {
 }
 ```
 
+Please also add the following lines to your repositories section in your gradle script:
+
+```gradle
+maven { 
+    url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed%40Local/maven/v1' 
+}
+```
+
 ### Step 2: Create your MSAL configuration file
 
 [Configuration Documentation](https://docs.microsoft.com/azure/active-directory/develop/msal-configuration)


### PR DESCRIPTION
Since MSAL release 1.5.0 developers need to add this for the Duo SDK. Also updating readme with instructions.

See https://github.com/AzureAD/microsoft-authentication-library-for-android/releases/tag/v1.5.0
Also see https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1027