### PR TITLE
Update consumer-rules.pro

### DIFF
--- a/msal/consumer-rules.pro
+++ b/msal/consumer-rules.pro
@@ -39,7 +39,7 @@
 
 # Prevent proguard from stripping interface information from TypeAdapter, TypeAdapterFactory,
 # JsonSerializer, JsonDeserializer instances (so they can be used in @JsonAdapter)
--keep class * implements com.google.gson.TypeAdapter
+-keep class * extends com.google.gson.TypeAdapter
 -keep class * implements com.google.gson.TypeAdapterFactory
 -keep class * implements com.google.gson.JsonSerializer
 -keep class * implements com.google.gson.JsonDeserializer


### PR DESCRIPTION
GSON's TypeAdapter is an abstract class, not an interface.