### PR TITLE
[WIP] Expose serviced from cache on Authentication Result + Update Tests to Assert for that

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
@@ -44,10 +44,8 @@ public final class AuthenticationResult implements IAuthenticationResult {
     private final IAccount mAccount;
     private boolean mServicedFromCache;
 
-    AuthenticationResult(
-            @NonNull final List<ICacheRecord> cacheRecords,
-            final boolean isServicedFromCache
-    ) {
+    AuthenticationResult(@NonNull final List<ICacheRecord> cacheRecords,
+                         final boolean isServicedFromCache) {
         final ICacheRecord mostRecentlyAuthorized = cacheRecords.get(0);
         mAccessToken = mostRecentlyAuthorized.getAccessToken();
         mTenantId = mostRecentlyAuthorized.getAccount().getRealm();

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
@@ -113,7 +113,7 @@ public final class AuthenticationResult implements IAuthenticationResult {
     }
 
     @Override
-    public boolean isServicedFromCache() {
+    public boolean wasServicedFromCache() {
         return mServicedFromCache;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResult.java
@@ -42,12 +42,17 @@ public final class AuthenticationResult implements IAuthenticationResult {
     private final String mTenantId;
     private final AccessTokenRecord mAccessToken;
     private final IAccount mAccount;
+    private boolean mServicedFromCache;
 
-    AuthenticationResult(@NonNull final List<ICacheRecord> cacheRecords) {
+    AuthenticationResult(
+            @NonNull final List<ICacheRecord> cacheRecords,
+            final boolean isServicedFromCache
+    ) {
         final ICacheRecord mostRecentlyAuthorized = cacheRecords.get(0);
         mAccessToken = mostRecentlyAuthorized.getAccessToken();
         mTenantId = mostRecentlyAuthorized.getAccount().getRealm();
         mAccount = AccountAdapter.adapt(cacheRecords).get(0);
+        mServicedFromCache = isServicedFromCache;
     }
 
     @Override
@@ -107,5 +112,10 @@ public final class AuthenticationResult implements IAuthenticationResult {
     @NonNull
     public String[] getScope() {
         return mAccessToken.getTarget().split("\\s");
+    }
+
+    @Override
+    public boolean isServicedFromCache() {
+        return mServicedFromCache;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/AuthenticationResultAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AuthenticationResultAdapter.java
@@ -39,10 +39,10 @@ class AuthenticationResultAdapter {
     private static final String TAG = AuthenticationResultAdapter.class.getName();
 
     static IAuthenticationResult adapt(@NonNull final ILocalAuthenticationResult localAuthenticationResult) {
-        final IAuthenticationResult authenticationResult = new AuthenticationResult(
-                localAuthenticationResult.getCacheRecordWithTenantProfileData()
+        return new AuthenticationResult(
+                localAuthenticationResult.getCacheRecordWithTenantProfileData(),
+                localAuthenticationResult.isServicedFromCache()
         );
-        return authenticationResult;
     }
 
 

--- a/msal/src/main/java/com/microsoft/identity/client/IAuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IAuthenticationResult.java
@@ -85,5 +85,5 @@ public interface IAuthenticationResult {
     /**
      * @return A boolean specifying whether the tokens were returned from cache or not.
      */
-    boolean isServicedFromCache();
+    boolean wasServicedFromCache();
 }

--- a/msal/src/main/java/com/microsoft/identity/client/IAuthenticationResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IAuthenticationResult.java
@@ -81,4 +81,9 @@ public interface IAuthenticationResult {
      */
     @NonNull
     String[] getScope();
+
+    /**
+     * @return A boolean specifying whether the tokens were returned from cache or not.
+     */
+    boolean isServicedFromCache();
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
@@ -82,6 +82,12 @@ public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAb
         flushScheduler();
     }
 
+    // This method is used to perform a silent acquire token call with the provided scopes.
+    // The expectingResultFromCache parameters is used to determine whether we expect the result
+    // of this silent request to be served from cache or not. This value will then be compared
+    // against the actual value of isServicedFromCache in Authentication Result to determine
+    // if the test behaved as expected. If the value does not match with what we expect, then the
+    // test will fail.
     public void performSilentAcquireTokenCall(final String[] scopes,
                                               final boolean expectingResultFromCache) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
@@ -96,6 +102,12 @@ public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAb
         flushScheduler();
     }
 
+    // This method is used to perform a silent acquire token call with the provided account.
+    // The expectingResultFromCache parameters is used to determine whether we expect the result
+    // of this silent request to be served from cache or not. This value will then be compared
+    // against the actual value of isServicedFromCache in Authentication Result to determine
+    // if the test behaved as expected. If the value does not match with what we expect, then the
+    // test will fail.
     public void performSilentAcquireTokenCall(final IAccount account,
                                               final boolean expectingResultFromCache) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
@@ -110,6 +122,12 @@ public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAb
         flushScheduler();
     }
 
+    // This method is used to perform a silent acquire token call with the provided account and
+    // authority. The expectingResultFromCache parameters is used to determine whether we expect the
+    // result of this silent request to be served from cache or not. This value will then be
+    // compared against the actual value of isServicedFromCache in Authentication Result to
+    // determine if the test behaved as expected. If the value does not match with what we expect,
+    // then the test will fail.
     public void performSilentAcquireTokenCall(final IAccount account,
                                               final String authority,
                                               final boolean expectingResultFromCache) {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/AcquireTokenAbstractTest.java
@@ -82,39 +82,43 @@ public abstract class AcquireTokenAbstractTest extends PublicClientApplicationAb
         flushScheduler();
     }
 
-    public void performSilentAcquireTokenCall(final String[] scopes) {
+    public void performSilentAcquireTokenCall(final String[] scopes,
+                                              final boolean expectingResultFromCache) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(getAccount())
                 .fromAuthority(getAuthority())
                 .withScopes(Arrays.asList(scopes))
                 .forceRefresh(false)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(expectingResultFromCache))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
         flushScheduler();
     }
 
-    public void performSilentAcquireTokenCall(final IAccount account) {
+    public void performSilentAcquireTokenCall(final IAccount account,
+                                              final boolean expectingResultFromCache) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(account)
                 .fromAuthority(account.getAuthority())
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(expectingResultFromCache))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
         flushScheduler();
     }
 
-    public void performSilentAcquireTokenCall(final IAccount account, final String authority) {
+    public void performSilentAcquireTokenCall(final IAccount account,
+                                              final String authority,
+                                              final boolean expectingResultFromCache) {
         final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(account)
                 .fromAuthority(authority)
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(expectingResultFromCache))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
@@ -194,7 +194,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(true))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -210,7 +210,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                 .forceRefresh(true)
                 .forAccount(account)
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(false))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -226,7 +226,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                 .forceRefresh(false)
                 .fromAuthority(getAuthority())
                 .forAccount(account)
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(true))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -244,7 +244,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                 .forceRefresh(false)
                 .forAccount(account)
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(false))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -366,8 +366,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
     private IAccount loadAccountForTest(IPublicClientApplication application) {
         ICacheRecord cacheRecord = createDataInCache(application);
         final String loginHint = cacheRecord.getAccount().getUsername();
-        final IAccount account = performGetAccount(application, loginHint);
-        return account;
+        return performGetAccount(application, loginHint);
     }
 
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -131,7 +131,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(true))
                 .build();
 
         MockHttpResponse.setHttpResponse(MockServerResponse.getMockTokenSuccessResponse());
@@ -242,7 +242,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(true)
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                .withCallback(AcquireTokenTestHelper.successfulSilentCallback(false))
                 .build();
 
         MockHttpResponse.setHttpResponse(MockServerResponse.getMockTokenSuccessResponse());

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CommandResultCachingTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CommandResultCachingTest.java
@@ -221,7 +221,7 @@ public final class CommandResultCachingTest extends AcquireTokenAbstractTest {
                     .forceRefresh(false)
                     .fromAuthority(AAD_MOCK_AUTHORITY)
                     .withClaims(cr)
-                    .withCallback(AcquireTokenTestHelper.successfulSilentCallback())
+                    .withCallback(AcquireTokenTestHelper.successfulSilentCallback(false))
                     .build();
 
             mApplication.acquireTokenSilentAsync(silentParameters);

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
@@ -93,7 +93,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
                 .fromAuthority(getAuthority())
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(true))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -117,7 +117,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
                 .fromAuthority(getAuthority())
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(true)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(false))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);
@@ -171,7 +171,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
                 .fromAuthority(getAuthority())
                 .withScopes(Arrays.asList(mScopes))
                 .forceRefresh(false)
-                .withCallback(successfulSilentCallback())
+                .withCallback(successfulSilentCallback(false))
                 .build();
 
         mApplication.acquireTokenSilentAsync(silentParameters);

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/GuestAccountAcquireTokenNetworkTests.java
@@ -57,14 +57,14 @@ public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTe
         performInteractiveAcquireTokenCall(labGuest.getHomeUpn());
 
         // get token silently for home tenant
-        performSilentAcquireTokenCall(getAccount(), authorityPrefix + labGuest.getHomeTenantId());
+        performSilentAcquireTokenCall(getAccount(), authorityPrefix + labGuest.getHomeTenantId(), true);
 
         // get a token silently for each guest tenant
         for (String guestLabTenant : labGuest.getGuestLabTenants()) {
             // just making sure that it is indeed guest tenant by comparing against home tenant
             Assert.assertNotSame(labGuest.getHomeTenantId(), guestLabTenant);
             // create authority from guest tenant id and use to obtain a token silently for guest tenant
-            performSilentAcquireTokenCall(getAccount(), authorityPrefix + guestLabTenant);
+            performSilentAcquireTokenCall(getAccount(), authorityPrefix + guestLabTenant, false);
         }
 
         Assert.assertTrue(getAccount() instanceof MultiTenantAccount);
@@ -118,7 +118,7 @@ public class GuestAccountAcquireTokenNetworkTests extends AcquireTokenAbstractTe
         }
 
         // now get a token silently for home tenant
-        performSilentAcquireTokenCall(multiTenantAccount, authorityPrefix + labGuest.getHomeTenantId());
+        performSilentAcquireTokenCall(multiTenantAccount, authorityPrefix + labGuest.getHomeTenantId(), false);
 
         multiTenantAccount = (MultiTenantAccount) getAccount();
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
@@ -85,7 +85,7 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
 
         // perform silent call for each account
         for (final IAccount account : accounts) {
-            performSilentAcquireTokenCall(account);
+            performSilentAcquireTokenCall(account, true);
         }
     }
 
@@ -105,10 +105,10 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
         mApplication.acquireToken(parameters);
         flushScheduler();
 
-        performSilentAcquireTokenCall(USER_READ_SCOPE);
-        performSilentAcquireTokenCall(MS_GRAPH_USER_READ_SCOPE);
-        performSilentAcquireTokenCall(OFFICE_USER_READ_SCOPE);
-        performSilentAcquireTokenCall(AD_GRAPH_USER_READ_SCOPE);
+        performSilentAcquireTokenCall(USER_READ_SCOPE, true);
+        performSilentAcquireTokenCall(MS_GRAPH_USER_READ_SCOPE, false);
+        performSilentAcquireTokenCall(OFFICE_USER_READ_SCOPE, false);
+        performSilentAcquireTokenCall(AD_GRAPH_USER_READ_SCOPE, false);
     }
 
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/AcquireTokenTestHelper.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/AcquireTokenTestHelper.java
@@ -93,7 +93,7 @@ public class AcquireTokenTestHelper {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
                 Assert.assertFalse(StringUtil.isEmpty(authenticationResult.getAccessToken()));
-                Assert.assertSame(expectingResultFromCache, authenticationResult.isServicedFromCache());
+                Assert.assertSame(expectingResultFromCache, authenticationResult.wasServicedFromCache());
                 sAccount = authenticationResult.getAccount();
             }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/AcquireTokenTestHelper.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/AcquireTokenTestHelper.java
@@ -47,10 +47,10 @@ public class AcquireTokenTestHelper {
     }
 
     public static AuthenticationCallback successfulInteractiveCallback() {
-        AuthenticationCallback callback = new AuthenticationCallback() {
+        return new AuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
-                Assert.assertTrue(!StringUtil.isEmpty(authenticationResult.getAccessToken()));
+                Assert.assertFalse(StringUtil.isEmpty(authenticationResult.getAccessToken()));
                 sAccount = authenticationResult.getAccount();
             }
 
@@ -64,12 +64,10 @@ public class AcquireTokenTestHelper {
                 fail("User cancelled flow");
             }
         };
-
-        return callback;
     }
 
     public static AuthenticationCallback failedSilentRequestDuplicateCommandCallback() {
-        AuthenticationCallback callback = new AuthenticationCallback() {
+        return new AuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
                 fail("not expected for this request to succeed");
@@ -85,16 +83,17 @@ public class AcquireTokenTestHelper {
                 fail("No expected to receive cancel");
             }
         };
-
-        return callback;
     }
 
 
-    public static SilentAuthenticationCallback successfulSilentCallback() {
-        SilentAuthenticationCallback callback = new SilentAuthenticationCallback() {
+    public static SilentAuthenticationCallback successfulSilentCallback(
+            final boolean expectingResultFromCache
+    ) {
+        return new SilentAuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
-                Assert.assertTrue(!StringUtil.isEmpty(authenticationResult.getAccessToken()));
+                Assert.assertFalse(StringUtil.isEmpty(authenticationResult.getAccessToken()));
+                Assert.assertSame(expectingResultFromCache, authenticationResult.isServicedFromCache());
                 sAccount = authenticationResult.getAccount();
             }
 
@@ -103,12 +102,10 @@ public class AcquireTokenTestHelper {
                 fail(exception.getMessage());
             }
         };
-
-        return callback;
     }
 
     public static AuthenticationCallback failureInteractiveCallback(final String errorCode) {
-        AuthenticationCallback callback = new AuthenticationCallback() {
+        return new AuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
                 fail("Unexpected success");
@@ -124,12 +121,10 @@ public class AcquireTokenTestHelper {
                 fail("User cancelled flow");
             }
         };
-
-        return callback;
     }
 
     public static SilentAuthenticationCallback failureSilentCallback(final String errorCode) {
-        SilentAuthenticationCallback callback = new SilentAuthenticationCallback() {
+        return new SilentAuthenticationCallback() {
             @Override
             public void onSuccess(IAuthenticationResult authenticationResult) {
                 fail("Unexpected success");
@@ -140,8 +135,6 @@ public class AcquireTokenTestHelper {
                 Assert.assertEquals(errorCode, exception.getErrorCode());
             }
         };
-
-        return callback;
     }
 
 }


### PR DESCRIPTION
See BackLog Item (CORPNET REQUIRED): https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/1022804

We are exposing whether the result (Authentication Result) was serviced from cache or not. I've also updated the tests to assert for this value.

This PR also depends on common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/917 for some changes to test code as a couple of tests (silent requests) were failing after this change due to running into cache misses.