### PR TITLE
Use an existing utility method to check for email claim, if preferred user name is absent when adapting to AccountRecord

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.common.internal.cache.SchemaUtil;
 import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftIdToken;
 import com.microsoft.identity.common.internal.providers.microsoft.azureactivedirectory.AzureActiveDirectoryIdToken;
@@ -141,17 +142,7 @@ public class Account implements IAccount {
     @Override
     public String getUsername() {
         if (null != getClaims()) {
-            final String preferredUsername = (String) getClaims().get(IDToken.PREFERRED_USERNAME);
-            if (null != preferredUsername) {
-                return preferredUsername;
-            }
-
-            // For backward compatibility.
-            // If AcquireToken was done in ADAL, cached id_token might not have the "preferred_username" field.
-            final String upn = (String) getClaims().get(AzureActiveDirectoryIdToken.UPN);
-            if (null != upn) {
-                return upn;
-            }
+            return SchemaUtil.getDisplayableId(getClaims());
         }
 
         return MISSING_FROM_THE_TOKEN_RESPONSE;


### PR DESCRIPTION
- Passthru accounts doesn't seem to have `preferred_username` claim, use `email` instead.
- Bug reported by teams  where broker can't return the token due to `name` mismatch : https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1023276