### PR TITLE
Make brokerEligible generic to all strategies. Make BrokerMsalControler throws MsalClientException.

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/BrokerCommunicationException.java
@@ -30,9 +30,8 @@ import com.microsoft.identity.common.exception.ErrorStrings;
  * An exception that represents an error where MSAL cannot reach Broker (i.e. through Bind Service or AccountManager).
  */
 public class BrokerCommunicationException extends BaseException {
-
     /**
-     * Initiates the {@link com.microsoft.identity.common.exception.BrokerCommunicationException} with error message and throwable.
+     * Initiates the {@link com.microsoft.identity.client.exception.BrokerCommunicationException} with error message and throwable.
      *
      * @param errorMessage The error message contained in the exception.
      * @param throwable    The {@link Throwable} contains the cause for the exception.

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAccountManagerStrategy.java
@@ -135,11 +135,6 @@ public class BrokerAccountManagerStrategy extends BrokerBaseStrategy {
     @SuppressLint("MissingPermission")
     String hello(@NonNull final CommandParameters parameters)
             throws BaseException {
-
-        if (!AccountManagerUtil.canUseAccountManagerOperation(parameters.getAndroidApplicationContext())) {
-            throw new BrokerCommunicationException("AccountManager permissions are not granted", null);
-        }
-
         return invokeBrokerAccountManagerOperation(parameters, new OperationInfo<CommandParameters, String>() {
             @Override
             public Bundle getRequestBundle(CommandParameters parameters) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerMsalController.java
@@ -34,6 +34,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.exception.BrokerCommunicationException;
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
@@ -61,6 +62,7 @@ import com.microsoft.identity.common.internal.telemetry.Telemetry;
 import com.microsoft.identity.common.internal.telemetry.TelemetryEventStrings;
 import com.microsoft.identity.common.internal.telemetry.events.ApiEndEvent;
 import com.microsoft.identity.common.internal.telemetry.events.ApiStartEvent;
+import com.microsoft.identity.common.internal.util.AccountManagerUtil;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -75,6 +77,11 @@ public class BrokerMsalController extends BaseController {
     private static final String TAG = BrokerMsalController.class.getSimpleName();
 
     private BrokerResultFuture mBrokerResultFuture;
+    private Context mApplicationContext;
+
+    public BrokerMsalController(final Context applicationContext){
+        mApplicationContext = applicationContext;
+    }
 
     @Override
     public AcquireTokenResult acquireToken(InteractiveTokenCommandParameters parameters) throws Exception {
@@ -184,7 +191,7 @@ public class BrokerMsalController extends BaseController {
             try {
                 com.microsoft.identity.common.internal.logging.Logger.info(
                         TAG + strategyTask.getMethodName(),
-                        "Executing with strategy: "
+                        "Executing with broker strategy: "
                                 + strategy.getClass().getSimpleName()
                 );
 
@@ -216,8 +223,9 @@ public class BrokerMsalController extends BaseController {
 
         // This means that we've tried every strategies...
         if (result == null) {
-            final BrokerCommunicationException exception = new BrokerCommunicationException(
-                    "MSAL failed to communicate to Broker.",
+            final MsalClientException exception = new MsalClientException(
+                    MsalClientException.BROKER_BIND_FAILURE,
+                    "Unable to connect to the broker",
                     lastCaughtException);
 
             if (strategyTask.getTelemetryApiId() != null) {
@@ -246,8 +254,14 @@ public class BrokerMsalController extends BaseController {
     // The order matters.
     private List<BrokerBaseStrategy> getStrategies() {
         final List<BrokerBaseStrategy> strategies = new ArrayList<>();
-        strategies.add(new BrokerAuthServiceStrategy());
-        strategies.add(new BrokerAccountManagerStrategy());
+
+        if (isMicrosoftAuthServiceSupported(mApplicationContext)) {
+            strategies.add(new BrokerAuthServiceStrategy());
+        }
+        if (AccountManagerUtil.canUseAccountManagerOperation(mApplicationContext)){
+            strategies.add(new BrokerAccountManagerStrategy());
+        }
+
         return strategies;
     }
 


### PR DESCRIPTION
brokerEligible will no longer try to check if MSAL can bind. BrokerMsalController will do the work.
@kreedula this would probably affect your change. 