### PR TITLE
Add tenantId when transforming from IAccount to accountrecord

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1564,8 +1564,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             accountRecord.setLocalAccountId(accountForRequest.getId());
             accountRecord.setUsername(accountForRequest.getUsername());
 
-
-
             return accountRecord;
         } else {
             // Unrecognized authority type

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1518,6 +1518,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                                 authority.getAuthorityURL().toString()
                         );
             }
+            // Set the tenant id obtained for the accountRecord
+            accountRecord.setRealm(tenantId);
 
             IAccount accountForRequest;
 
@@ -1561,6 +1563,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
             accountRecord.setLocalAccountId(accountForRequest.getId());
             accountRecord.setUsername(accountForRequest.getUsername());
+
+
 
             return accountRecord;
         } else {


### PR DESCRIPTION
- We currently are not setting the `realm` we got  for `AccountRecord` . Found this issue while testing [FOCI changes PR ](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/920)