### PR TITLE
Make the broker uri check case-insensitive

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -481,8 +481,8 @@ public class PublicClientApplicationConfiguration {
 
     private boolean isBrokerRedirectUri() {
         final String BROKER_REDIRECT_URI_REGEX = "msauth://" + mAppContext.getPackageName() + "/.*";
-        final Pattern pairRegex = Pattern.compile(BROKER_REDIRECT_URI_REGEX);
-        final Matcher matcher = pairRegex.matcher(mRedirectUri);
+        final Pattern pairRegex = Pattern.compile(BROKER_REDIRECT_URI_REGEX.toLowerCase());
+        final Matcher matcher = pairRegex.matcher(mRedirectUri.toLowerCase());
         return matcher.matches();
     }
 


### PR DESCRIPTION
Found this during the debugging issue. The customer was registering part of their package name in the portal with capital letters (and MSAL would just perform local auth (without any obvious signal that would make the developer aware)... because the backcompat redirect url support logic [here](https://github.com/AzureAD/microsoft-authentication-library-for-android/blob/44b9414f3be233053f441435440db7fbcee312b0/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java#L554))