### PR TITLE
Add Enums for Azure Cloud Instance, and AadAudience + Add TokenParameters builder overloads for fromAuthority to allow use of enums + add tests

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AadAuthorityAudience.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AadAuthorityAudience.java
@@ -1,0 +1,49 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+import androidx.annotation.Nullable;
+
+/**
+ * The audiences that can be used for Authority when making token requests in MSAL
+ */
+public enum AadAuthorityAudience {
+
+    AzureAdAndPersonalMicrosoftAccount("common"),
+    AzureAdMultipleOrgs("organizations"),
+    PersonalMicrosoftAccount("consumers"),
+    AzureAdMyOrg(null);
+
+    @Nullable
+    private String audienceValue;
+
+    AadAuthorityAudience(@Nullable String audienceValue) {
+        this.audienceValue = audienceValue;
+    }
+
+    @Nullable
+    public String getAudienceValue() {
+        return audienceValue;
+    }
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/AadAuthorityAudience.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AadAuthorityAudience.java
@@ -29,9 +29,27 @@ import androidx.annotation.Nullable;
  */
 public enum AadAuthorityAudience {
 
+    /**
+     * Users with a personal Microsoft account, or a work or school account in any organization’s
+     * Azure AD tenant. Maps to https://[instance]/common/
+     */
     AzureAdAndPersonalMicrosoftAccount("common"),
+
+    /**
+     * Users with a Microsoft work or school account in any organization’s Azure AD tenant
+     * (i.e. multi-tenant). Maps to https://[instance]/organizations/
+     */
     AzureAdMultipleOrgs("organizations"),
+
+    /**
+     * Users with a personal Microsoft account. Maps to https://[instance]/consumers/
+     */
     PersonalMicrosoftAccount("consumers"),
+
+    /**
+     * Users with a Microsoft work or school account in my organization’s Azure AD tenant
+     * (i.e. single tenant). Maps to https://[instance]/[tenantId]
+     */
     AzureAdMyOrg(null);
 
     @Nullable

--- a/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
@@ -1,0 +1,44 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+/**
+ * The clouds that can be used for Authority when making token requests in MSAL
+ */
+public enum AzureCloudInstance {
+
+    AzurePublic("https://login.microsoftonline.com"),
+    AzureChina("https://login.partner.microsoftonline.cn"),
+    AzureGermany("https://login.microsoftonline.de"),
+    AzureUsGov("https://login.microsoftonline.us");
+
+    private String cloudInstanceUri;
+
+    AzureCloudInstance(String cloudInstanceUri) {
+        this.cloudInstanceUri = cloudInstanceUri;
+    }
+
+    public String getCloudInstanceUri() {
+        return cloudInstanceUri;
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
@@ -27,9 +27,24 @@ package com.microsoft.identity.client;
  */
 public enum AzureCloudInstance {
 
+    /**
+     * Microsoft Azure public cloud. Maps to https://login.microsoftonline.com
+     */
     AzurePublic("https://login.microsoftonline.com"),
+
+    /**
+     * Microsoft Chinese national cloud. Maps to https://login.partner.microsoftonline.cn
+     */
     AzureChina("https://login.partner.microsoftonline.cn"),
+
+    /**
+     * Microsoft German national cloud (“Black Forest”). Maps to https://login.microsoftonline.de
+     */
     AzureGermany("https://login.microsoftonline.de"),
+
+    /**
+     * US Government cloud. Maps to https://login.microsoftonline.us
+     */
     AzureUsGov("https://login.microsoftonline.us");
 
     private String cloudInstanceUri;

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -22,7 +22,10 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import android.text.TextUtils;
+
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
@@ -186,8 +189,37 @@ public abstract class TokenParameters {
             return self();
         }
 
-        public B fromAuthority(String authority) {
-            mAuthority = authority;
+        public B fromAuthority(String authorityUrl) {
+            mAuthority = authorityUrl;
+            return self();
+        }
+
+        public B fromAuthority(@NonNull final AzureCloudInstance cloudInstance,
+                               @NonNull final AadAuthorityAudience audience,
+                               @Nullable final String tenant) {
+            if (audience == AadAuthorityAudience.AzureAdMyOrg) {
+                if (TextUtils.isEmpty(tenant)) {
+                    throw new IllegalArgumentException(
+                            "Tenant must be specified when the audience is " + audience
+                    );
+                } else {
+                    mAuthority = cloudInstance.getCloudInstanceUri() + "/" + tenant;
+                    return self();
+                }
+            } else {
+                mAuthority = cloudInstance.getCloudInstanceUri() + "/" + audience.getAudienceValue();
+                return self();
+            }
+        }
+
+        public B fromAuthority(@NonNull final AzureCloudInstance cloudInstance,
+                               @NonNull final AadAuthorityAudience audience) {
+            return fromAuthority(cloudInstance, audience, null);
+        }
+
+        public B fromAuthority(@NonNull final AzureCloudInstance cloudInstance,
+                               @NonNull final String tenant) {
+            mAuthority = cloudInstance.getCloudInstanceUri() + "/" + tenant;
             return self();
         }
 
@@ -223,5 +255,10 @@ public abstract class TokenParameters {
         public abstract B self();
 
         public abstract TokenParameters build();
+
+        private String createAuthorityUrl(@NonNull final AzureCloudInstance cloudInstance,
+                                          @NonNull final AadAuthorityAudience audience) {
+            return cloudInstance + "/" + audience;
+        }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -263,10 +263,5 @@ public abstract class TokenParameters {
         public abstract B self();
 
         public abstract TokenParameters build();
-
-        private String createAuthorityUrl(@NonNull final AzureCloudInstance cloudInstance,
-                                          @NonNull final AadAuthorityAudience audience) {
-            return cloudInstance + "/" + audience;
-        }
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -197,7 +197,15 @@ public abstract class TokenParameters {
         public B fromAuthority(@NonNull final AzureCloudInstance cloudInstance,
                                @NonNull final AadAuthorityAudience audience,
                                @Nullable final String tenant) {
-            if (audience == AadAuthorityAudience.AzureAdMyOrg) {
+            if (!TextUtils.isEmpty(tenant)) {
+                if (audience != AadAuthorityAudience.AzureAdMyOrg) {
+                    throw new IllegalArgumentException(
+                            "Audience must be " + AadAuthorityAudience.AzureAdMyOrg + " when tenant is specified"
+                    );
+                } else {
+                    return fromAuthority(cloudInstance, tenant);
+                }
+            } else if (audience == AadAuthorityAudience.AzureAdMyOrg) {
                 if (TextUtils.isEmpty(tenant)) {
                     throw new IllegalArgumentException(
                             "Tenant must be specified when the audience is " + audience

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
@@ -1,0 +1,132 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
+import com.microsoft.identity.internal.testutils.TestUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.USER_READ_SCOPE;
+
+/**
+ * This class tests the fromAuthority builder of {@link TokenParameters} using the AzureAdMyOrg
+ * audience. The tests for other audiences are located in {@link TokenParametersAuthorityTest}
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class TokenParametersAuthorityMyOrgTest {
+
+    private Context mContext;
+    private Activity mActivity;
+    private final List SCOPES = Arrays.asList(USER_READ_SCOPE);
+
+    private static final String testTenant = UUID.randomUUID().toString();
+
+    private AzureCloudInstance azureCloudInstance;
+    private String expectedAuthorityUrl;
+
+    public TokenParametersAuthorityMyOrgTest(final AzureCloudInstance azureCloudInstance,
+                                             final String expectedAuthorityUrl) {
+        this.azureCloudInstance = azureCloudInstance;
+        this.expectedAuthorityUrl = expectedAuthorityUrl;
+    }
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "cloud = {0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {AzureCloudInstance.AzurePublic, "https://login.microsoftonline.com/" + testTenant},
+                {AzureCloudInstance.AzureChina, "https://login.partner.microsoftonline.cn/" + testTenant},
+                {AzureCloudInstance.AzureGermany, "https://login.microsoftonline.de/" + testTenant},
+                {AzureCloudInstance.AzureUsGov, "https://login.microsoftonline.us/" + testTenant},
+        });
+    }
+
+    @Before
+    public void setup() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mActivity = TestUtils.getMockActivity(mContext);
+    }
+
+    @Test
+    public void testCreateAuthorityFromUrl() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(expectedAuthorityUrl)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+
+    @Test
+    public void testCreateAuthorityFromCloudAndTenant() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(azureCloudInstance, testTenant)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+
+    @Test
+    public void testCreateAuthorityFromCloudAndAudienceAndTenantIfAudienceIsMyOrg() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(azureCloudInstance, AadAuthorityAudience.AzureAdMyOrg, testTenant)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateAuthorityFromCloudAndAudienceMyOrgFailsIfTenantNotProvided() {
+        new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(azureCloudInstance, AadAuthorityAudience.AzureAdMyOrg)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.fail("Unexpected failure"); // we should not get here
+    }
+
+}

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
@@ -117,8 +117,8 @@ public class TokenParametersAuthorityTest {
         Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
     }
 
-    @Test
-    public void testCreateAuthorityFromCloudAndAudienceAndTenantIgnoresTenantIfAudienceNotMyOrg() {
+    @Test(expected = IllegalArgumentException.class)
+    public void testCreateAuthorityFromCloudAndAudienceFailsIfTenantSpecifiedAndAudienceNotMyOrg() {
         final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
                 .withScopes(SCOPES)

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
@@ -1,0 +1,131 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
+import com.microsoft.identity.internal.testutils.TestUtils;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.ParameterizedRobolectricTestRunner;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.USER_READ_SCOPE;
+
+/**
+ * This class tests the fromAuthority builder of {@link TokenParameters} using audiences
+ * other than AzureADMyOrg. The tests for AzureADMyOrg are located in {@link TokenParametersAuthorityMyOrgTest}
+ */
+@RunWith(ParameterizedRobolectricTestRunner.class)
+public class TokenParametersAuthorityTest {
+
+    private Context mContext;
+    private Activity mActivity;
+    private final List SCOPES = Arrays.asList(USER_READ_SCOPE);
+
+    private AzureCloudInstance azureCloudInstance;
+    private AadAuthorityAudience aadAuthorityAudience;
+    private String expectedAuthorityUrl;
+
+    private static final String testTenant = UUID.randomUUID().toString();
+
+    public TokenParametersAuthorityTest(final AzureCloudInstance azureCloudInstance,
+                                        final AadAuthorityAudience aadAuthorityAudience,
+                                        final String expectedAuthorityUrl) {
+        this.azureCloudInstance = azureCloudInstance;
+        this.aadAuthorityAudience = aadAuthorityAudience;
+        this.expectedAuthorityUrl = expectedAuthorityUrl;
+    }
+
+    @ParameterizedRobolectricTestRunner.Parameters(name = "cloud = {0}, audience = {1}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.microsoftonline.com/common"},
+                {AzureCloudInstance.AzurePublic, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.microsoftonline.com/organizations"},
+                {AzureCloudInstance.AzurePublic, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.microsoftonline.com/consumers"},
+                {AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.partner.microsoftonline.cn/common"},
+                {AzureCloudInstance.AzureChina, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.partner.microsoftonline.cn/organizations"},
+                {AzureCloudInstance.AzureChina, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.partner.microsoftonline.cn/consumers"},
+                {AzureCloudInstance.AzureGermany, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.microsoftonline.de/common"},
+                {AzureCloudInstance.AzureGermany, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.microsoftonline.de/organizations"},
+                {AzureCloudInstance.AzureGermany, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.microsoftonline.de/consumers"},
+                {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.microsoftonline.us/common"},
+                {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.microsoftonline.us/organizations"},
+                {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.microsoftonline.us/consumers"},
+
+        });
+    }
+
+    @Before
+    public void setup() {
+        mContext = ApplicationProvider.getApplicationContext();
+        mActivity = TestUtils.getMockActivity(mContext);
+    }
+
+    @Test
+    public void testCreateAuthorityFromUrl() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(expectedAuthorityUrl)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+
+    @Test
+    public void testCreateAuthorityFromCloudAndAudience() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(azureCloudInstance, aadAuthorityAudience)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+
+    @Test
+    public void testCreateAuthorityFromCloudAndAudienceAndTenantIgnoresTenantIfAudienceNotMyOrg() {
+        final AcquireTokenParameters tokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(SCOPES)
+                .fromAuthority(azureCloudInstance, aadAuthorityAudience, testTenant)
+                .withCallback(AcquireTokenTestHelper.successfulInteractiveCallback())
+                .build();
+
+        Assert.assertEquals(expectedAuthorityUrl, tokenParameters.getAuthority());
+    }
+}


### PR DESCRIPTION
See this work item (CORPNET REQUIRED): https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1063016

Other platforms have already implemented the work stated in above work item. 

**DotNet**: [See this](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/1cef43d185bb0a1dcc013d2ec232ae9d4c6c053a/src/client/Microsoft.Identity.Client/AppConfig/AzureCloud.cs)
**iOS**: [See this](https://azuread.github.io/microsoft-authentication-library-for-objc/Enums/MSALAzureCloudInstance.html)

In this PR, I've also added overload for the `fromAuthority` method in the `TokenParameters` builder to also achieve parity there with other platforms as other platforms have already done that too. Furthermore, the cloud enums aren't too useful without having a public API for developers via which those could be utilized so it makes sense to get it in the same PR.

Other platforms have done it like this:

**DotNet**: [See this](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/ad2a0088b8eeb229403bc578784a682c5db01f17/src/client/Microsoft.Identity.Client/ApiConfig/AbstractAcquireTokenParameterBuilder.cs#L257)
**iOS**: [See this](https://azuread.github.io/microsoft-authentication-library-for-objc/Classes/MSALAADAuthority.html#/c:objc(cs)MSALAADAuthority(im)initWithEnvironment:audienceType:rawTenant:error:)

In additional to implement this features, I have also added tests for TokenParameters builder / fromAuthority overloads.

There are a total of ((4 x 4) + (12 x 3)) = 52 tests added 😁