### PR TITLE
Added showMsalRedirectUriInfo command and activity to MSAL

### DIFF
--- a/msal/src/main/AndroidManifest.xml
+++ b/msal/src/main/AndroidManifest.xml
@@ -13,6 +13,13 @@
             android:exported="false"
             android:launchMode="singleTask" />
 
+        <!-- Helper activity for displaying current broker redirect URI configuration -->
+        <activity
+            android:name="com.microsoft.identity.client.helper.BrokerHelperActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
+            android:exported="false"
+            android:launchMode="singleTask" />
+
         <!-- MSAL will use system webview (custom tab) to render the sign-in page, BrowserTabActivity is to get response back from System Webview. Multiple apps on the device could integrate MSAL, OS will check which BrowserTabActivity can handle the intent based on the intent filter declared, so this activity has to be exported.-->
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalDeclinedScopeException;
 import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.client.helper.BrokerHelperActivity;
 import com.microsoft.identity.client.internal.AsyncResult;
 import com.microsoft.identity.client.internal.CommandParametersAdapter;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
@@ -1213,6 +1214,10 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         return BuildConfig.VERSION_NAME;
     }
 
+    public static void showMsalRedirectUriInfo(Activity activity){
+        activity.startActivity(BrokerHelperActivity.createStartIntent(activity.getApplicationContext()));
+    }
+
     @Override
     public PublicClientApplicationConfiguration getConfiguration() {
         return mPublicClientConfiguration;
@@ -1916,4 +1921,5 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
         return isAccountHomeTenant;
     }
+
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1214,7 +1214,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         return BuildConfig.VERSION_NAME;
     }
 
-    public static void showMsalRedirectUriInfo(Activity activity){
+    /**
+     * Presents an activity that includes the package name, signature, redirect URI and manifest entry required for your application
+     * @param activity
+     */
+    public static void showExpectedMsalRedirectUriInfo(Activity activity){
         activity.startActivity(BrokerHelperActivity.createStartIntent(activity.getApplicationContext()));
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/helper/BrokerHelperActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/helper/BrokerHelperActivity.java
@@ -1,0 +1,81 @@
+package com.microsoft.identity.client.helper;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.widget.TextView;
+
+import androidx.annotation.Nullable;
+
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
+import com.microsoft.identity.common.internal.broker.BrokerValidator;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
+import com.microsoft.identity.msal.R;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+
+public class BrokerHelperActivity extends Activity {
+
+    TextView mPackageName;
+    TextView mSignature;
+    TextView mRedirect;
+    TextView mManifest;
+
+    String mManifestTemplate= "<activity android:name=\"com.microsoft.identity.client.BrowserTabActivity\">\n" +
+            "    <intent-filter>\n" +
+            "        <action android:name=\"android.intent.action.VIEW\" />\n" +
+            "        <category android:name=\"android.intent.category.DEFAULT\" />\n" +
+            "        <category android:name=\"android.intent.category.BROWSABLE\" />\n" +
+            "        <data\n" +
+            "            android:host=\"%s\"\n" +
+            "            android:path=\"%s\"\n" +
+            "            android:scheme=\"msauth\" />\n" +
+            "    </intent-filter>\n" +
+            "</activity>";
+
+    public static Intent createStartIntent(final Context context) {
+        final Intent intent = new Intent(context, BrokerHelperActivity.class);
+          return intent;
+    }
+
+    @Override
+    protected void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.broker_helper);
+
+        mPackageName = findViewById(R.id.txtPackageName);
+        mSignature = findViewById(R.id.txtSignature);
+        mRedirect = findViewById(R.id.txtRedirect);
+        mManifest = findViewById(R.id.txtManifest);
+
+        mSignature.append(getSignature(false));
+        mRedirect.append(BrokerValidator.getBrokerRedirectUri(this.getApplicationContext(), this.getPackageName()));
+        mManifest.append(String.format(mManifestTemplate, this.getPackageName(), getSignature(false)));
+        mPackageName.append(this.getPackageName());
+
+
+    }
+
+    private String getSignature(Boolean urlEncode){
+
+        final PackageHelper info = new PackageHelper(this.getApplicationContext().getPackageManager());
+        final String signatureDigest = info.getCurrentSignatureForPackage(this.getPackageName());
+        String signature = "";
+
+        try {
+            if(urlEncode) {
+                signature = URLEncoder.encode(signatureDigest, AuthenticationConstants.ENCODING_UTF8);
+            }else{
+                signature = signatureDigest;
+            }
+        } catch (UnsupportedEncodingException e) {
+            Log.e("getSignature", "Error encoding signature digest", e);
+        }
+
+        return signature;
+
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/helper/BrokerHelperActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/helper/BrokerHelperActivity.java
@@ -17,14 +17,12 @@ import com.microsoft.identity.msal.R;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
+/**
+ * Activity to show the expected redirect URL (which includes support for Broker)
+ */
 public class BrokerHelperActivity extends Activity {
 
-    TextView mPackageName;
-    TextView mSignature;
-    TextView mRedirect;
-    TextView mManifest;
-
-    String mManifestTemplate= "<activity android:name=\"com.microsoft.identity.client.BrowserTabActivity\">\n" +
+    private final String MANIFEST_TEMPLATE = "<activity android:name=\"com.microsoft.identity.client.BrowserTabActivity\">\n" +
             "    <intent-filter>\n" +
             "        <action android:name=\"android.intent.action.VIEW\" />\n" +
             "        <category android:name=\"android.intent.category.DEFAULT\" />\n" +
@@ -35,10 +33,14 @@ public class BrokerHelperActivity extends Activity {
             "            android:scheme=\"msauth\" />\n" +
             "    </intent-filter>\n" +
             "</activity>";
+    TextView mPackageName;
+    TextView mSignature;
+    TextView mRedirect;
+    TextView mManifest;
 
     public static Intent createStartIntent(final Context context) {
         final Intent intent = new Intent(context, BrokerHelperActivity.class);
-          return intent;
+        return intent;
     }
 
     @Override
@@ -53,29 +55,27 @@ public class BrokerHelperActivity extends Activity {
 
         mSignature.append(getSignature(false));
         mRedirect.append(BrokerValidator.getBrokerRedirectUri(this.getApplicationContext(), this.getPackageName()));
-        mManifest.append(String.format(mManifestTemplate, this.getPackageName(), getSignature(false)));
+        mManifest.append(String.format(MANIFEST_TEMPLATE, this.getPackageName(), getSignature(false)));
         mPackageName.append(this.getPackageName());
-
-
     }
 
-    private String getSignature(Boolean urlEncode){
+    private String getSignature(final boolean urlEncode) {
 
         final PackageHelper info = new PackageHelper(this.getApplicationContext().getPackageManager());
         final String signatureDigest = info.getCurrentSignatureForPackage(this.getPackageName());
         String signature = "";
 
         try {
-            if(urlEncode) {
+            if (urlEncode) {
                 signature = URLEncoder.encode(signatureDigest, AuthenticationConstants.ENCODING_UTF8);
-            }else{
+            } else {
                 signature = signatureDigest;
             }
         } catch (UnsupportedEncodingException e) {
-            Log.e("getSignature", "Error encoding signature digest", e);
+            Log.e("getSignature", "Character encoding " + AuthenticationConstants.ENCODING_UTF8 + " is not supported.", e);
+            throw new RuntimeException("Unexpected: Unable to get the signature for this application package.");
         }
 
         return signature;
-
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/BrokerAuthServiceStrategy.java
@@ -33,7 +33,6 @@ import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.IMicrosoftAuthService;
 import com.microsoft.identity.client.exception.BrokerCommunicationException;
-import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
 import com.microsoft.identity.common.exception.ErrorStrings;

--- a/msal/src/main/res/layout/broker_helper.xml
+++ b/msal/src/main/res/layout/broker_helper.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" >
+
+        <TextView
+            android:id="@+id/txtTitle"
+            android:padding="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="20dp"
+            android:textStyle="bold"
+            android:text="@string/broker_helper_title"
+            />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+        <TextView
+            android:id="@+id/txtPackageLabel"
+            android:padding="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/broker_helper_package"
+            />
+    <TextView
+        android:id="@+id/txtPackageName"
+        android:padding="10dp"
+        android:maxLines="10"
+        android:textIsSelectable="true"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+        <TextView
+            android:id="@+id/txtSignatureLabel"
+            android:padding="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/broker_helper_signature"
+            />
+    <TextView
+        android:id="@+id/txtSignature"
+        android:padding="10dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="10"
+        android:textIsSelectable="true" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+        <TextView
+            android:id="@+id/txtRedirectLabel"
+            android:padding="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/broker_helper_redirect"
+            />
+
+    <TextView
+        android:id="@+id/txtRedirect"
+        android:padding="10dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="10"
+        android:textIsSelectable="true" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" >
+        <TextView
+            android:id="@+id/txtManifestLabel"
+            android:padding="10dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold"
+            android:text="@string/broker_helper_manifest"
+            />
+
+    <TextView
+        android:id="@+id/txtManifest"
+        android:padding="10dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxLines="100"
+        android:textIsSelectable="true" />
+    </LinearLayout>
+    </LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/msal/src/main/res/values/strings.xml
+++ b/msal/src/main/res/values/strings.xml
@@ -9,4 +9,10 @@
     <string name="http_auth_dialog_login">Login</string>
     <string name="http_auth_dialog_cancel">Cancel</string>
 
+    <string name="broker_helper_package">Package name to enter when registering app</string>
+    <string name="broker_helper_signature">Signature to enter when registering app</string>
+    <string name="broker_helper_redirect">Redirect URI for configuration json file</string>
+    <string name="broker_helper_manifest">Intent filter for AndroidManifest.xml</string>
+    <string name="broker_helper_title">MSAL Redirect URI Info</string>
+
 </resources>

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -22,6 +22,7 @@
 //   THE SOFTWARE.
 package com.microsoft.identity.client.testapp;
 
+import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
@@ -45,6 +46,7 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.PublicClientApplication;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +72,7 @@ public class AcquireTokenFragment extends Fragment {
     private Button mAcquireTokenSilent;
     private Button mAcquireTokenWithResource;
     private Button mAcquireTokenSilentWithResource;
+    private Button mBrokerHelper;
     private Spinner mSelectAccount;
     private Spinner mConfigFileSpinner;
     private Spinner mAuthScheme;
@@ -108,6 +111,7 @@ public class AcquireTokenFragment extends Fragment {
         mAcquireTokenSilent = view.findViewById(R.id.btn_acquiretokensilent);
         mAcquireTokenWithResource = view.findViewById(R.id.btn_acquiretokenWithResource);
         mAcquireTokenSilentWithResource = view.findViewById(R.id.btn_acquiretokensilentWithResource);
+        mBrokerHelper = view.findViewById(R.id.btnBrokerHelper);
         mConfigFileSpinner = view.findViewById(R.id.configFile);
         mAuthScheme = view.findViewById(R.id.authentication_scheme);
         mPublicApplicationMode = view.findViewById(R.id.public_application_mode);
@@ -117,6 +121,8 @@ public class AcquireTokenFragment extends Fragment {
 
         mPopSection = view.findViewById(R.id.pop_section);
         mLoginHintSection = view.findViewById(R.id.login_hint_section);
+
+
 
         bindSelectAccountSpinner(mSelectAccount, null);
         mSelectAccount.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -194,6 +200,14 @@ public class AcquireTokenFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 mMsalWrapper.acquireTokenSilentWithResource(getCurrentRequestOptions(), acquireTokenCallback);
+            }
+        });
+
+        final Activity activity = this.getActivity();
+        mBrokerHelper.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                PublicClientApplication.showMsalRedirectUriInfo(activity);
             }
         });
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -122,8 +122,6 @@ public class AcquireTokenFragment extends Fragment {
         mPopSection = view.findViewById(R.id.pop_section);
         mLoginHintSection = view.findViewById(R.id.login_hint_section);
 
-
-
         bindSelectAccountSpinner(mSelectAccount, null);
         mSelectAccount.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
             @Override
@@ -207,7 +205,7 @@ public class AcquireTokenFragment extends Fragment {
         mBrokerHelper.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                PublicClientApplication.showMsalRedirectUriInfo(activity);
+                PublicClientApplication.showExpectedMsalRedirectUriInfo(activity);
             }
         });
 

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -484,5 +484,24 @@
                 android:text="@string/acquire_token_silent_with_resource_button" />
 
         </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
+            android:weightSum="10">
+
+            <Button
+                android:id="@+id/btnBrokerHelper"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="5"
+                android:gravity="center"
+                android:text="Broker Helper" />
+
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Hi Folks,

Given the very large number of customers confused about how to register their redirect URI and configure it within MSAL.  I added an activity to MSAL that can be launched using a static method of PublicClientApplication called showMsalRedirectUriInfo.  This method shows the following information.

@hamiltonha - Take a look if you want to change any strings.  Let's explore if we can replace current instructions with just invoking this method.

![image](https://user-images.githubusercontent.com/8864677/88484771-e9b64e80-cf25-11ea-98d1-d7876ff8028c.png)
