### PR TITLE
Resurrect telemetry test

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -99,7 +99,6 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    @Ignore
     public void testServerSideTelemetry() {
         final String username = "fake@test.com";
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
@@ -27,7 +27,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.B2C_CUSTOM_DOMAIN_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.B2C_GLOBAL_DOMAIN_CONFIG_FILE_PATH;
-import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.B2C_SCOPE;
+import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.B2C_READ_SCOPE;
 
 /**
  * Run all tests in the {@link AcquireTokenNetworkTest} class using B2C
@@ -43,7 +43,7 @@ public abstract class AcquireTokenB2CTest extends AcquireTokenNetworkTest {
 
     @Override
     public String[] getScopes() {
-        return B2C_SCOPE;
+        return B2C_READ_SCOPE;
     }
 
     public static class B2CLocalUserGlobalMsftDomain extends AcquireTokenB2CTest {


### PR DESCRIPTION
This PR resurrects the telemetry test which was ignored by https://github.com/AzureAD/microsoft-authentication-library-for-android/commit/4acb524f016e67a0e6d15abdd6e2e173226af74c due to adding support for [deleting token when bad-token error is received](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/940/files). 

This PR depends on common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/988

Also while I'm here (or there in common), I've added a new constant for a scope and renamed existing ones and hence there's that change here as well :)