### PR TITLE
Use powerlift incident rule for broker tests; reorder rules

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
@@ -96,9 +96,6 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest {
     public ActivityTestRule<MainActivity> mActivityRule =
             new ActivityTestRule(MainActivity.class);
 
-    @Rule(order = 6)
-    public TestRule deviceEnrollmentFailureRecoveryRule = new DeviceEnrollmentFailureRecoveryRule();
-
     @Before
     public void setup() {
         mScopes = getScopes();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
@@ -3,7 +3,9 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker;
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.ui.automation.IBrokerTest;
 import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
+import com.microsoft.identity.client.ui.automation.rules.DeviceEnrollmentFailureRecoveryRule;
 import com.microsoft.identity.client.ui.automation.rules.InstallBrokerTestRule;
+import com.microsoft.identity.client.ui.automation.rules.PowerLiftIncidentRule;
 
 import org.junit.Rule;
 import org.junit.rules.TestRule;
@@ -15,6 +17,12 @@ public abstract class AbstractMsalBrokerTest extends AbstractMsalUiTest implemen
 
     protected ITestBroker mBroker = getBroker();
 
-    @Rule(order = 7)
+    @Rule(order = 6)
     public final TestRule installBrokerRule = new InstallBrokerTestRule(mBroker);
+
+    @Rule(order = 7)
+    public final TestRule powerLiftIncidentRule = new PowerLiftIncidentRule(mBroker);
+
+    @Rule(order = 8)
+    public final TestRule deviceEnrollmentFailureRecoveryRule = new DeviceEnrollmentFailureRecoveryRule();
 }


### PR DESCRIPTION
Related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1009