### PR TITLE
Adding the functionality of Prompt Parameter UNSET

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/Prompt.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Prompt.java
@@ -74,7 +74,6 @@ public enum Prompt {
     public OpenIdConnectPromptParameter toOpenIdConnectPromptParameter() {
         String tag = Prompt.class.getSimpleName() + ":toOpenIdConnectPromptParameter";
         switch (this) {
-
             case LOGIN:
                 return OpenIdConnectPromptParameter.LOGIN;
             case CONSENT:

--- a/msal/src/main/java/com/microsoft/identity/client/Prompt.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Prompt.java
@@ -74,16 +74,14 @@ public enum Prompt {
     public OpenIdConnectPromptParameter toOpenIdConnectPromptParameter() {
         String tag = Prompt.class.getSimpleName() + ":toOpenIdConnectPromptParameter";
         switch (this) {
-            case SELECT_ACCOUNT:
-                return OpenIdConnectPromptParameter.SELECT_ACCOUNT;
+
             case LOGIN:
                 return OpenIdConnectPromptParameter.LOGIN;
             case CONSENT:
                 return OpenIdConnectPromptParameter.CONSENT;
             case WHEN_REQUIRED:
-                String error = "WHEN_REQUIRED Does not have corresponding value in in the OIDC prompt enumeration.  It's meant to convey do not sent the prompt parameter.";
-                Logger.info(tag, error);
-                throw new UnsupportedOperationException(error);
+                return OpenIdConnectPromptParameter.UNSET;
+            case SELECT_ACCOUNT:
             default:
                 return OpenIdConnectPromptParameter.SELECT_ACCOUNT;
         }

--- a/msal/src/main/java/com/microsoft/identity/client/Prompt.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Prompt.java
@@ -72,7 +72,6 @@ public enum Prompt {
     }
 
     public OpenIdConnectPromptParameter toOpenIdConnectPromptParameter() {
-        String tag = Prompt.class.getSimpleName() + ":toOpenIdConnectPromptParameter";
         switch (this) {
             case LOGIN:
                 return OpenIdConnectPromptParameter.LOGIN;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -399,7 +399,7 @@ public class CommandParametersAdapter {
     }
 
     private static OpenIdConnectPromptParameter getPromptParameter(@NonNull final AcquireTokenParameters parameters) {
-        if (parameters.getPrompt() == null || parameters.getPrompt() == Prompt.WHEN_REQUIRED) {
+        if (parameters.getPrompt() == null) {
             return OpenIdConnectPromptParameter.SELECT_ACCOUNT;
         } else {
             return parameters.getPrompt().toOpenIdConnectPromptParameter();

--- a/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
@@ -1,0 +1,42 @@
+package com.microsoft.identity.client;
+
+import com.microsoft.identity.common.internal.providers.oauth2.OpenIdConnectPromptParameter;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class PromptTest {
+    private Prompt prompt;
+
+    @Test
+    public void testOpenIdConnectParameterSelectAccount() {
+        prompt = Prompt.SELECT_ACCOUNT;
+        final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
+        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.SELECT_ACCOUNT);
+    }
+
+    @Test
+    public void testOpenIdConnectParameterLogin() {
+        prompt = Prompt.LOGIN;
+        final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
+        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.LOGIN);
+    }
+
+    @Test
+    public void testOpenIdConnectParameterConsent() {
+        prompt = Prompt.CONSENT;
+        final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
+        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.CONSENT);
+    }
+
+    @Test
+    public void testOpenIdConnectParameterWhenRequired() {
+        prompt = Prompt.WHEN_REQUIRED;
+        final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
+        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.UNSET);
+    }
+
+}


### PR DESCRIPTION
Fix for the github issue #1122

Added support for OpenIdConnectPromptParameter.NONE and reworked the logic to handle Prompt.WHEN_REQUIRED