### PR TITLE
Pick up latest common submodule, update TokenShareUtility ctor call to remove defaultAuthority param

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 Version v.Next
 ----------
 - Moved broker controller and strategy classes to common for MSALCPP brokered auth.
+- Removed 'defaultAuthority' param from TokenShareUtility; MSA RT ingestion always uses WW-/consumers.
 
 Version 1.6.0
 -----------

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1104,7 +1104,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             mTokenShareUtility = new TokenShareUtility(
                     mPublicClientConfiguration.getClientId(),
                     mPublicClientConfiguration.getRedirectUri(),
-                    mPublicClientConfiguration.getDefaultAuthority().getAuthorityURL().toString(),
                     (MsalOAuth2TokenCache) mPublicClientConfiguration.getOAuth2TokenCache()
             );
         } else {


### PR DESCRIPTION
Picks up changes from:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/commit/ef0ffa6ecc3548d10231323cab87f787f6ede482

Removed unnecessary ctor param.

To Do:
- ~Update submodule~
- ~Update ctor call in PCA~
- ~Update changelog~ 61a830123d8492aad28596673fea8423d9c035a1