### PR TITLE
Add metadata to TSL result payload

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/ITokenShare.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ITokenShare.java
@@ -24,11 +24,18 @@ package com.microsoft.identity.client;
 
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.common.adal.internal.tokensharing.ITokenShareInternal;
+import com.microsoft.identity.common.adal.internal.tokensharing.ITokenShareResultInternal;
 
 /**
  * Interface defining necessary methods for TokenShareLibrary (TSL) integration.
  */
 public interface ITokenShare extends ITokenShareInternal {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    TokenShareResult getOrgIdFamilyRefreshTokenWithMetadata(String identifier) throws MsalClientException;
 
     /**
      * {@inheritDoc}
@@ -41,6 +48,12 @@ public interface ITokenShare extends ITokenShareInternal {
      */
     @Override
     void saveOrgIdFamilyRefreshToken(String ssoStateSerializerBlob) throws MsalClientException;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    TokenShareResult getMsaFamilyRefreshTokenWithMetadata(String identifier) throws MsalClientException;
 
     /**
      * {@inheritDoc}

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -48,11 +48,11 @@ import com.microsoft.identity.client.exception.MsalServiceException;
 import com.microsoft.identity.client.helper.BrokerHelperActivity;
 import com.microsoft.identity.client.internal.AsyncResult;
 import com.microsoft.identity.client.internal.CommandParametersAdapter;
-import com.microsoft.identity.common.internal.controllers.LocalMSALController;
 import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
 import com.microsoft.identity.client.internal.controllers.MsalExceptionAdapter;
 import com.microsoft.identity.common.adal.internal.cache.IStorageHelper;
 import com.microsoft.identity.common.adal.internal.cache.StorageHelper;
+import com.microsoft.identity.common.adal.internal.tokensharing.ITokenShareResultInternal;
 import com.microsoft.identity.common.adal.internal.tokensharing.TokenShareUtility;
 import com.microsoft.identity.common.exception.BaseException;
 import com.microsoft.identity.common.exception.ClientException;
@@ -68,8 +68,8 @@ import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.cache.SchemaUtil;
 import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager;
 import com.microsoft.identity.common.internal.commands.CommandCallback;
-import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommandCallback;
 import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommand;
+import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommandCallback;
 import com.microsoft.identity.common.internal.commands.GetDeviceModeCommand;
 import com.microsoft.identity.common.internal.commands.InteractiveTokenCommand;
 import com.microsoft.identity.common.internal.commands.SilentTokenCommand;
@@ -80,6 +80,7 @@ import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCom
 import com.microsoft.identity.common.internal.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.controllers.ExceptionAdapter;
+import com.microsoft.identity.common.internal.controllers.LocalMSALController;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.internal.logging.Logger;
@@ -1132,12 +1133,13 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     }
 
     @Override
-    public String getOrgIdFamilyRefreshToken(@NonNull final String identifier) throws MsalClientException {
+    public TokenShareResult getOrgIdFamilyRefreshTokenWithMetadata(@NonNull final String identifier) throws MsalClientException {
         validateNonNullArgument(identifier, "identifier");
         validateBrokerNotInUse();
 
         try {
-            return mTokenShareUtility.getOrgIdFamilyRefreshToken(identifier);
+            final ITokenShareResultInternal resultInternal = mTokenShareUtility.getOrgIdFamilyRefreshTokenWithMetadata(identifier);
+            return new TokenShareResult(resultInternal);
         } catch (final Exception e) {
             throw new MsalClientException(
                     TOKEN_CACHE_ITEM_NOT_FOUND,
@@ -1145,6 +1147,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                     e
             );
         }
+    }
+
+    @Override
+    public String getOrgIdFamilyRefreshToken(@NonNull final String identifier) throws MsalClientException {
+        return getOrgIdFamilyRefreshTokenWithMetadata(identifier).getRefreshToken();
     }
 
     @Override
@@ -1164,12 +1171,13 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     }
 
     @Override
-    public String getMsaFamilyRefreshToken(@NonNull final String identifier) throws MsalClientException {
+    public TokenShareResult getMsaFamilyRefreshTokenWithMetadata(@NonNull final String identifier) throws MsalClientException {
         validateNonNullArgument(identifier, "identifier");
         validateBrokerNotInUse();
 
         try {
-            return mTokenShareUtility.getMsaFamilyRefreshToken(identifier);
+            final ITokenShareResultInternal resultInternal = mTokenShareUtility.getMsaFamilyRefreshTokenWithMetadata(identifier);
+            return new TokenShareResult(resultInternal);
         } catch (final Exception e) {
             throw new MsalClientException(
                     TOKEN_CACHE_ITEM_NOT_FOUND,
@@ -1177,6 +1185,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                     e
             );
         }
+    }
+
+    @Override
+    public String getMsaFamilyRefreshToken(@NonNull final String identifier) throws MsalClientException {
+        return getMsaFamilyRefreshTokenWithMetadata(identifier).getRefreshToken();
     }
 
     @Override

--- a/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
@@ -27,8 +27,14 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.common.adal.internal.tokensharing.ITokenShareResultInternal;
 import com.microsoft.identity.common.adal.internal.tokensharing.TokenShareResultInternal;
 
+/**
+ * Refresh Token Related Metadata for consumption by TSL.
+ */
 public class TokenShareResult extends TokenShareResultInternal {
 
+    /**
+     * The format of the refresh token in this result payload.
+     */
     public static class TokenShareExportFormat {
 
         /**

--- a/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
@@ -1,0 +1,7 @@
+package com.microsoft.identity.client;
+
+import com.microsoft.identity.common.adal.internal.tokensharing.TokenShareResultInternal;
+
+public class ITokenShareResult extends TokenShareResultInternal {
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenShareResult.java
@@ -1,7 +1,62 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.common.adal.internal.tokensharing.ITokenShareResultInternal;
 import com.microsoft.identity.common.adal.internal.tokensharing.TokenShareResultInternal;
 
-public class ITokenShareResult extends TokenShareResultInternal {
+public class TokenShareResult extends TokenShareResultInternal {
 
+    public static class TokenShareExportFormat {
+
+        /**
+         * Used for ORG_ID accounts. Legacy format used by ADAL.
+         */
+        public static final String SSO_STATE_SERIALIZER_BLOB = TokenShareExportFormatInternal.SSO_STATE_SERIALIZER_BLOB;
+
+        /**
+         * Raw RT String. Used by MSA format.
+         */
+        public static final String RAW = TokenShareExportFormatInternal.RAW;
+    }
+
+    TokenShareResult(@NonNull final ITokenShareResultInternal resultInternal) {
+        super(
+                resultInternal.getCacheRecord(),
+                resultInternal.getRefreshToken(),
+                resultInternal.getFormat()
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @see TokenShareExportFormat
+     */
+    @Override
+    public String getFormat() {
+        return super.getFormat();
+    }
 }


### PR DESCRIPTION
Extends work in:
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1033

Exposes RT/Account metadata such that it can be consumed by TSL.
Adds additional metadata to _external_ TSL-API.