### PR TITLE
Expose expiresIn in MSAL Device Code flow callback

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 
+v.Next
+----------
+- Expose expiresIn in MSAL Device Code flow callback #1169
+
 Version 2.0.0
 ----------
 - Add Device Code Flow Support (#1112)

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -31,6 +31,7 @@ import androidx.annotation.WorkerThread;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.controllers.TaskCompletedCallbackWithError;
 
+import java.util.Date;
 import java.util.List;
 
 public interface IPublicClientApplication {
@@ -175,7 +176,7 @@ public interface IPublicClientApplication {
      * Callback object used in Device Code Flow.
      * This callback provides the following methods for communicating with the protocol.
      * 1). Receiving authentication information (user_code, verification_uri, and instruction message)
-     * via {@link DeviceCodeFlowCallback#onUserCodeReceived(String, String, String)}.
+     * via {@link DeviceCodeFlowCallback#onUserCodeReceived(String, String, String, Date)}.
      * 2). Receiving a successful authentication result containing a fresh access token
      * via {@link DeviceCodeFlowCallback#onTokenReceived(AuthenticationResult)}.
      * 3). Receiving an exception detailing what went wrong in the protocol
@@ -190,8 +191,14 @@ public interface IPublicClientApplication {
          * @param vUri verification uri
          * @param userCode user code
          * @param message instruction message
+         * @param sessionExpirationDate the expiration date of DCF session to be displayed to the user ONLY.
+         *                              When the session expires, onError() will return an exception with DEVICE_CODE_FLOW_EXPIRED_TOKEN_ERROR_CODE.
+         *                              Please rely on that exception for non-UX purposes.
          */
-        void onUserCodeReceived(@NonNull final String vUri, @NonNull final String userCode, @NonNull final String message);
+        void onUserCodeReceived(@NonNull final String vUri,
+                                @NonNull final String userCode,
+                                @NonNull final String message,
+                                @NonNull final Date sessionExpirationDate);
 
         /**
          * Invoked once token is received and passes the {@link AuthenticationResult} object.

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -101,6 +101,7 @@ import com.microsoft.identity.msal.BuildConfig;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1765,8 +1766,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     private DeviceCodeFlowCommandCallback getDeviceCodeFlowCommandCallback(@NonNull final DeviceCodeFlowCallback callback) {
         return new DeviceCodeFlowCommandCallback<LocalAuthenticationResult, BaseException>() {
             @Override
-            public void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message) {
-                callback.onUserCodeReceived(vUri, userCode, message);
+            public void onUserCodeReceived(@NonNull final String vUri,
+                                           @NonNull final String userCode,
+                                           @NonNull final String message,
+                                           @NonNull final Date sessionExpirationDate) {
+                callback.onUserCodeReceived(vUri, userCode, message, sessionExpirationDate);
             }
 
             @Override

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
@@ -37,7 +37,9 @@ import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Shadow class that simulates Device Code Flow successfully returning an acquire token result object.
@@ -50,11 +52,16 @@ public class ShadowDeviceCodeFlowCommandSuccessful {
 
     @Implementation
     public AcquireTokenResult execute() {
+        // 15 minutes is the default timeout.
+        final Date expiryDate = new Date();
+        expiryDate.setTime(expiryDate.getTime() + TimeUnit.MINUTES.toMillis(15));
+
         final DeviceCodeFlowCommandCallback callback = (DeviceCodeFlowCommandCallback) mDeviceCodeFlowCommand.getCallback();
         callback.onUserCodeReceived(
                 "https://login.microsoftonline.com/common/oauth2/deviceauth",
                 "ABCDEFGH",
-                "Follow these instructions to authenticate.");
+                "Follow these instructions to authenticate.",
+                expiryDate);
 
         // Create parameters for dummy authentication result
         final CacheRecord cacheRecord = new CacheRecord();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandTokenError.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandTokenError.java
@@ -31,6 +31,9 @@ import com.microsoft.identity.common.internal.result.AcquireTokenResult;
 import org.robolectric.annotation.Implements;
 import org.robolectric.annotation.RealObject;
 
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Shadow class that simulates Device Code Flow failing due to an error in the token polling phase.
  */
@@ -42,10 +45,16 @@ public class ShadowDeviceCodeFlowCommandTokenError {
 
     public AcquireTokenResult execute() throws Exception {
         final DeviceCodeFlowCommandCallback callback = (DeviceCodeFlowCommandCallback) mDeviceCodeFlowCommand.getCallback();
+
+        // 15 minutes is the default timeout.
+        final Date expiryDate = new Date();
+        expiryDate.setTime(expiryDate.getTime() + TimeUnit.MINUTES.toMillis(15));
+
         callback.onUserCodeReceived(
                 "https://login.microsoftonline.com/common/oauth2/deviceauth",
                 "ABCDEFGH",
-                "Follow these instructions to authenticate.");
+                "Follow these instructions to authenticate.",
+                expiryDate);
 
         throw new ServiceException(ErrorStrings.DEVICE_CODE_FLOW_EXPIRED_TOKEN_ERROR_CODE, "The device_code expired. No need to continue polling for the token (expired token).", null);
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
@@ -54,6 +54,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.UUID;
 
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.SINGLE_ACCOUNT_DCF_TEST_CONFIG_FILE_PATH;
@@ -237,7 +238,10 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
         String[] scope = {"user.read"};
         mApplication.acquireTokenWithDeviceCode(scope, new IPublicClientApplication.DeviceCodeFlowCallback() {
             @Override
-            public void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message) {
+            public void onUserCodeReceived(@NonNull String vUri,
+                                           @NonNull String userCode,
+                                           @NonNull String message,
+                                           @NonNull Date sessionExpirationDate) {
                 // This shouldn't run if authorization step fails
                 Assert.fail();
             }
@@ -263,11 +267,15 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
         String[] scope = {"user.read"};
         mApplication.acquireTokenWithDeviceCode(scope, new IPublicClientApplication.DeviceCodeFlowCallback() {
             @Override
-            public void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message) {
+            public void onUserCodeReceived(@NonNull String vUri,
+                                           @NonNull String userCode,
+                                           @NonNull String message,
+                                           @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
                 Assert.assertNotNull(vUri);
                 Assert.assertNotNull(userCode);
                 Assert.assertNotNull(message);
+                Assert.assertNotNull(sessionExpirationDate);
 
                 Assert.assertFalse(mUserCodeReceived);
                 mUserCodeReceived = true;
@@ -294,11 +302,15 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
         String[] scope = {"user.read"};
         mApplication.acquireTokenWithDeviceCode(scope, new IPublicClientApplication.DeviceCodeFlowCallback() {
             @Override
-            public void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message) {
+            public void onUserCodeReceived(@NonNull String vUri,
+                                           @NonNull String userCode,
+                                           @NonNull String message,
+                                           @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
                 Assert.assertNotNull(vUri);
                 Assert.assertNotNull(userCode);
                 Assert.assertNotNull(message);
+                Assert.assertNotNull(sessionExpirationDate);
 
                 Assert.assertFalse(mUserCodeReceived);
                 mUserCodeReceived = true;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -27,6 +27,7 @@ import com.microsoft.identity.client.exception.MsalUiRequiredException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 
 /// Acting as a bridge between the result of MsalWrapper's results and the outside world.
@@ -201,10 +202,15 @@ abstract class MsalWrapper {
                 requestOptions.getScopes().toLowerCase().split(" "),
                 new IPublicClientApplication.DeviceCodeFlowCallback() {
                     @Override
-                    public void onUserCodeReceived(@NonNull String vUri, @NonNull String userCode, @NonNull String message) {
+                    public void onUserCodeReceived(@NonNull String vUri,
+                                                   @NonNull String userCode,
+                                                   @NonNull String message,
+                                                   @NonNull Date sessionExpirationDate) {
                         callback.showMessage(
                                 "Uri: " + vUri + "\n" +
-                                "UserCode: " + userCode);
+                                "UserCode: " + userCode + "\n" +
+                                "Message: " + message + "\n" +
+                                "sessionExpirationDate: " + sessionExpirationDate);
                     }
 
                     @Override


### PR DESCRIPTION
MSTeams would like to display the 'time until expires' on their device.

Related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1064