### PR TITLE
Ignore bf migration robo tests until lab api response is fixed

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -26,6 +26,8 @@ import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
+
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_MOONCAKE_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.AD_GRAPH_USER_READ_SCOPE;
@@ -102,6 +104,7 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         }
     }
 
+    @Ignore
     public static class AzureGermanyCloudMigratedUser extends AcquireTokenAADTest {
         @Override
         public LabUserQuery getLabUserQuery() {


### PR DESCRIPTION
This tenant has now moved to stage 5 i.e. WW....however the LAB API response is still returning the DE endpoint for the authority...and that is breaking our simulated instance aware during ROPC. I've requested a fix from the LAB Team on the API response for this, until that happens I will just ignore these tests.