### PR TITLE
Temporarily ignore all tests in migration tenants

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -72,6 +72,7 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         }
     }
 
+    @Ignore
     public static class AzureUsGovCloudMigratedUser extends AcquireTokenAADTest {
         @Override
         public LabUserQuery getLabUserQuery() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116114.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116114.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 // Interactive token acquisition with instance_aware=true, no login hint, and cloud account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116114
+@Ignore
 public class TestCase1116114 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116115.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116115.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 // Interactive token acquisition with instance_aware=true, login hint present, and cloud account,
 // and WW organizations authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116115
+@Ignore
 public class TestCase1116115 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116116.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116116.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.concurrent.CountDownLatch;
 // Interactive token acquisition with instance_aware=true, login hint present, and federated account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116116
+@Ignore
 public class TestCase1116116 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116117.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116117.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -48,6 +49,7 @@ import java.util.concurrent.CountDownLatch;
 
 // Silent token acquisition with unexpired RT with USGov authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116117
+@Ignore
 public class TestCase1116117 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116118.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/blackforest/TestCase1116118.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -45,6 +46,7 @@ import java.util.concurrent.CountDownLatch;
 
 // Interactive token acquisition with instance_aware=false and USGov authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116118
+@Ignore
 public class TestCase1116118 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116129.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116129.java
@@ -37,12 +37,14 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 // Broker authentication with PRT with USGov account
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116129
+@Ignore
 public class TestCase1116129 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116130.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116130.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -44,6 +45,7 @@ import java.util.Arrays;
 // Brokered authentication without PRT with instance_aware=true, no login hint, and cloud account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116130
+@Ignore
 public class TestCase1116130 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116132.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/blackforest/TestCase1116132.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 // Interactive token acquisition with instance_aware=true and with custom claims request requiring
 // device auth {"access_token":{"deviceid":{"essential":true}}}
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116132
+@Ignore
 public class TestCase1116132 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase938447.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase938447.java
@@ -37,12 +37,14 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 // Broker authentication with PRT with USGov account
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938447
+@Ignore
 public class TestCase938447 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase940393.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase940393.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -44,6 +45,7 @@ import java.util.Arrays;
 // Brokered authentication without PRT with instance_aware=true, no login hint, and cloud account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/940393
+@Ignore
 public class TestCase940393 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase940421.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase940421.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 // Interactive token acquisition with instance_aware=true and with custom claims request requiring
 // device auth {"access_token":{"deviceid":{"essential":true}}}
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/940421
+@Ignore
 public class TestCase940421 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase948676.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/fairfaxmigrated/TestCase948676.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -44,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 
 // Broker authentication with PRT with USGov account with instance_aware=true
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/948676
+@Ignore
 public class TestCase948676 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116091.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116091.java
@@ -46,6 +46,7 @@ import java.util.concurrent.CountDownLatch;
 // Interactive token acquisition with instance_aware=true, no login hint, and cloud account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116091
+@Ignore
 public class TestCase1116091 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116092.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116092.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.concurrent.CountDownLatch;
 // Interactive token acquisition with instance_aware=true, login hint present, and cloud account,
 // and WW organizations authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116092
+@Ignore
 public class TestCase1116092 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116093.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116093.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.concurrent.CountDownLatch;
 // Interactive token acquisition with instance_aware=true, login hint present, and federated account,
 // and WW common authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116093
+@Ignore
 public class TestCase1116093 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116094.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116094.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -48,6 +49,7 @@ import java.util.concurrent.CountDownLatch;
 
 // Silent token acquisition with unexpired RT with USGov authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116094
+@Ignore
 public class TestCase1116094 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116095.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/usgov/fairfaxmigrated/TestCase1116095.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabConfig;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -45,6 +46,7 @@ import java.util.concurrent.CountDownLatch;
 
 // Interactive token acquisition with instance_aware=false and USGov authority
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1116095
+@Ignore
 public class TestCase1116095 extends AbstractMsalUiTest {
 
     @Test


### PR DESCRIPTION
The lab team is not actively maintaining these accounts and hence these are failing from time to time....will add back once/if lab team confirms that it is okay to do so.