### PR TITLE
Add parameter to supply msal version for dist

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -1,5 +1,11 @@
 apply plugin: 'com.android.application'
 
+def msalVersion = "2.+"
+
+if (project.hasProperty("distMsalVersion")) {
+    msalVersion = distMsalVersion
+}
+
 android {
 
     final String BROKER_HOST = "BrokerHost"
@@ -137,7 +143,7 @@ android {
 dependencies {
     // Compile Dependency
     localImplementation project(':msal')
-    distImplementation 'com.microsoft.identity.client:msal:2.+'
+    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -25,7 +25,15 @@
 
 apply plugin: 'com.android.application'
 
+def msalVersion = "2.+"
+
+if (project.hasProperty("distMsalVersion")) {
+    msalVersion = distMsalVersion
+}
+
+
 android {
+
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
         applicationId "com.msft.identity.client.sample"
@@ -78,7 +86,7 @@ android {
 dependencies {
     // Compile Dependency
     localImplementation project(':msal')
-    distImplementation 'com.microsoft.identity.client:msal:2.+'
+    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"


### PR DESCRIPTION
This allows to supply the version of msal (from a pipeline or just any CLI) that want to use to build the following:

- MSAL Test App
- Automation tests

Pipeline in action: https://dev.azure.com/IdentityDivision/IDDP/_build?definitionId=1222&_a=summary