### PR TITLE
adding product flavor to support all testcases in msalautomationapp

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -15,6 +15,7 @@ android {
     final String BROKER_HOST = "BrokerHost"
     final String BROKER_MICROSOFT_AUTHENTICATOR = "BrokerMicrosoftAuthenticator"
     final String BROKER_COMPANY_PORTAL = "BrokerCompanyPortal"
+    final String AUTO_BROKER = "AutoBroker"
     final String SELECTED_BROKER = "SELECTED_BROKER"
 
     signingConfigs {
@@ -52,6 +53,7 @@ android {
         buildConfigField("String", BROKER_MICROSOFT_AUTHENTICATOR, "\"$BROKER_MICROSOFT_AUTHENTICATOR\"")
         buildConfigField("String", BROKER_COMPANY_PORTAL, "\"$BROKER_COMPANY_PORTAL\"")
         buildConfigField("String", BROKER_HOST, "\"$BROKER_HOST\"")
+        buildConfigField("String", AUTO_BROKER, "\"$AUTO_BROKER\"")
     }
 
     testOptions {
@@ -111,6 +113,11 @@ android {
             dimension "broker"
             buildConfigField("String", SELECTED_BROKER, "\"$BROKER_HOST\"")
         }
+
+        AutoBroker {
+            dimension "broker"
+            buildConfigField("String", SELECTED_BROKER, "\"$AUTO_BROKER\"")
+        }
     }
 
     variantFilter { variant ->
@@ -128,6 +135,11 @@ android {
         }
 
         if (flavorName.contains("local") && flavorName.contains("BrokerCompanyPortal") && buildType.contains("debug")) {
+            // Gradle ignores any variants that satisfy the conditions above.
+            setIgnore(true)
+        }
+
+        if (flavorName.contains("local") && flavorName.contains("AutoBroker")) {
             // Gradle ignores any variants that satisfy the conditions above.
             setIgnore(true)
         }
@@ -158,7 +170,7 @@ ext.createCoverageTask = { buildVariant, testType ->
     def androidTestFile = "outputs/code_coverage/${buildVariant}AndroidTest/connected/*.ec"
 
     // Task to generate coverage report for particular build variant, that depends on additional tasks(androidTestTask)
-    task "${buildVariant}Msal${testType}CoverageReport" (type:JacocoReport, dependsOn: [androidTestTask]) {
+    task "${buildVariant}Msal${testType}CoverageReport"(type: JacocoReport, dependsOn: [androidTestTask]) {
         group = "Code Coverage MsalAutomation"
         description = "Generate Msal Coverage Reports(${testType}) on the ${buildVariant.capitalize()}"
 
@@ -180,8 +192,8 @@ ext.createCoverageTask = { buildVariant, testType ->
                 "${projectDir}/../common/common/src/main/java",
         ]
         def additionalJavaClasses = [
-                fileTree( dir: "${buildDir}/../${commonFilePath}/intermediates/javac/${commonBuild}/classes", excludes: fileFilter),
-                fileTree( dir: "${buildDir}/../${msalFilePath}/intermediates/javac/${msalBuild}/classes", excludes: fileFilter)
+                fileTree(dir: "${buildDir}/../${commonFilePath}/intermediates/javac/${commonBuild}/classes", excludes: fileFilter),
+                fileTree(dir: "${buildDir}/../${msalFilePath}/intermediates/javac/${msalBuild}/classes", excludes: fileFilter)
         ]
 
         //Include all those directories for source files and additional source files defined above

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
@@ -27,6 +27,7 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.ui.automation.IBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
@@ -34,6 +35,9 @@ import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
 import com.microsoft.identity.client.ui.automation.rules.RulesHelper;
 
 import org.junit.rules.RuleChain;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * An MSAL test model that would leverage an {@link ITestBroker} installed on the device.
@@ -57,6 +61,19 @@ public abstract class AbstractMsalBrokerTest extends AbstractMsalUiTest implemen
                 return new BrokerMicrosoftAuthenticator();
             case BuildConfig.BrokerCompanyPortal:
                 return new BrokerCompanyPortal();
+            case BuildConfig.AutoBroker: {
+                SupportedBrokers supportedBrokersAnnotation = getClass().getAnnotation(SupportedBrokers.class);
+                if (supportedBrokersAnnotation == null) {
+                    return new BrokerMicrosoftAuthenticator();
+                }
+                final List<Class<? extends ITestBroker>> supportedBrokerClasses =
+                        Arrays.asList(supportedBrokersAnnotation.brokers());
+                if (BuildConfig.FLAVOR_main == "dist" && supportedBrokerClasses.contains(new BrokerCompanyPortal().getClass())) {
+                    return new BrokerCompanyPortal();
+                } else {
+                    return new BrokerMicrosoftAuthenticator();
+                }
+            }
             default:
                 throw new UnsupportedOperationException("Unsupported broker :(");
         }


### PR DESCRIPTION
Adds a product flavor to automation app that doesn't specify a specific broker to use but rather picks the appropriate broker based on whether we are testing local vs dist as well as based on which brokers are actually supported for the test being executed.