### PR TITLE
Warn if SAPCA used with B2C. Throw Exception if Multiple Policies are Configured

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -114,6 +114,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import static com.microsoft.identity.client.PublicClientApplicationConfigurationFactory.initializeConfiguration;
+import static com.microsoft.identity.client.exception.MsalClientException.SAPCA_USE_WITH_MULTI_POLICY_B2C;
 import static com.microsoft.identity.client.exception.MsalClientException.UNKNOWN_ERROR;
 import static com.microsoft.identity.client.internal.CommandParametersAdapter.createGenerateShrCommandParameters;
 import static com.microsoft.identity.client.internal.MsalUtils.throwOnMainThread;
@@ -939,7 +940,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                                     );
 
                                     if (config.getAuthorities().size() > 1) {
-                                        throw new MsalClientException("SingleAccountPublicClientApplication cannot be used with multiple B2C policies.");
+                                        throw new MsalClientException(SAPCA_USE_WITH_MULTI_POLICY_B2C);
                                     }
                                 }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -930,6 +930,19 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
                         try {
                             if (config.getAccountMode() == AccountMode.SINGLE || isSharedDevice) {
+                                if (null != config.getDefaultAuthority() &&
+                                        config.getDefaultAuthority() instanceof AzureActiveDirectoryB2CAuthority) {
+                                    Logger.warn(
+                                            TAG,
+                                            "Warning! B2C applications should use MultipleAccountPublicClientApplication. "
+                                                    + "Use of SingleAccount mode with multiple IEF policies is unsupported."
+                                    );
+
+                                    if (config.getAuthorities().size() > 1) {
+                                        throw new MsalClientException("SingleAccountPublicClientApplication cannot be used with multiple B2C policies.");
+                                    }
+                                }
+
                                 listener.onCreated(new SingleAccountPublicClientApplication(config));
                             } else {
                                 listener.onCreated(new MultipleAccountPublicClientApplication(config));

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -197,6 +197,12 @@ public final class MsalClientException extends MsalException {
      * for preview.
      */
     static final String ADFS_AUTHORITY_VALIDATION_FAILED = "adfs_authority_validation_failed";
+
+    /**
+     * Configuration error. SingleAccount apps cannot be used with multiple B2C policies, as each policy creates a separate Account.
+     */
+    static final String SAPCA_USE_WITH_MULTI_POLICY_B2C = "SingleAccountPublicClientApplication cannot be used with multiple B2C policies.";
+
     public MsalClientException(final String errorCode) {
         super(errorCode);
     }

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalClientException.java
@@ -201,7 +201,7 @@ public final class MsalClientException extends MsalException {
     /**
      * Configuration error. SingleAccount apps cannot be used with multiple B2C policies, as each policy creates a separate Account.
      */
-    static final String SAPCA_USE_WITH_MULTI_POLICY_B2C = "SingleAccountPublicClientApplication cannot be used with multiple B2C policies.";
+    public static final String SAPCA_USE_WITH_MULTI_POLICY_B2C = "SingleAccountPublicClientApplication cannot be used with multiple B2C policies.";
 
     public MsalClientException(final String errorCode) {
         super(errorCode);


### PR DESCRIPTION
Impetus:
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1256989

Description:
- SAPCA (SingleAccountPublicClientApplication) should not be used with B2C, unless a single policy exists (and only 1 ever will exist)
- Logs a warning if SAPCA is used with B2C
- Throws an Exception if SAPCA is used with B2C _and_ multiple policies (expressed as `Authorities`) are defined