### PR TITLE
Refactor setting broker for test

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
@@ -50,10 +50,13 @@ public abstract class AbstractMsalBrokerTest extends AbstractMsalUiTest implemen
     @Override
     public ITestBroker getBroker() {
         // only initialize once....so calling getBroker from anywhere returns the same instance
-        if (mBroker != null) {
-            return mBroker;
+        if (mBroker == null) {
+            mBroker = createBrokerFromFlavor();
         }
+        return mBroker;
+    }
 
+    private ITestBroker createBrokerFromFlavor() {
         switch (BuildConfig.SELECTED_BROKER) {
             case BuildConfig.BrokerHost:
                 return new BrokerHost();
@@ -62,13 +65,13 @@ public abstract class AbstractMsalBrokerTest extends AbstractMsalUiTest implemen
             case BuildConfig.BrokerCompanyPortal:
                 return new BrokerCompanyPortal();
             case BuildConfig.AutoBroker: {
-                SupportedBrokers supportedBrokersAnnotation = getClass().getAnnotation(SupportedBrokers.class);
+                final SupportedBrokers supportedBrokersAnnotation = getClass().getAnnotation(SupportedBrokers.class);
                 if (supportedBrokersAnnotation == null) {
                     return new BrokerMicrosoftAuthenticator();
                 }
                 final List<Class<? extends ITestBroker>> supportedBrokerClasses =
                         Arrays.asList(supportedBrokersAnnotation.brokers());
-                if (BuildConfig.FLAVOR_main == "dist" && supportedBrokerClasses.contains(new BrokerCompanyPortal().getClass())) {
+                if (BuildConfig.FLAVOR_main.equals("dist") && supportedBrokerClasses.contains(BrokerCompanyPortal.class)) {
                     return new BrokerCompanyPortal();
                 } else {
                     return new BrokerMicrosoftAuthenticator();


### PR DESCRIPTION
Fixes issue where `getBroker` can return `null`