### PR TITLE
Add logging config to msal config files used for automation

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
@@ -30,12 +30,14 @@ import com.microsoft.identity.client.ui.automation.logging.LogLevel;
 import com.microsoft.identity.client.ui.automation.logging.appender.FileAppender;
 import com.microsoft.identity.client.ui.automation.logging.formatter.LogcatLikeFormatter;
 import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
+import com.microsoft.identity.common.internal.util.ThreadUtils;
 
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A Junit Rule to enable MSAL logging during automation and set external logger to dump these logs
@@ -45,6 +47,8 @@ public class MsalLoggingRule implements TestRule {
 
     final static String LOG_FOLDER_NAME = "automation";
 
+    public static final String TAG = MsalLoggingRule.class.getSimpleName();
+
     @Override
     public Statement apply(final Statement base, final Description description) {
         return new Statement() {
@@ -53,6 +57,19 @@ public class MsalLoggingRule implements TestRule {
                 final FileAppender msalLogFileAppender = turnOnMsalLogging(description);
 
                 base.evaluate();
+
+                // MSAL (common) logger logs using a background thread, so even though the test is
+                // finished at this point, we may still be receiving logs from the logger. If we
+                // close the stream right now we might the lose the last bit of logs and we might
+                // encounter an IoException when trying to write that last bit of logs to the file
+                // as the stream was closed.
+                // To mitigate it we would just sleep for a tiny bit of time to ensure that we grab
+                // those last bit of logs, dump them to the file and then close the writer.
+                ThreadUtils.sleepSafely(
+                        Math.toIntExact(TimeUnit.SECONDS.toMillis(1)),
+                        TAG,
+                        "Error while sleeping during saving logs."
+                );
 
                 msalLogFileAppender.closeWriter();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
@@ -59,25 +59,26 @@ public class MsalLoggingRule implements TestRule {
                 try {
                     base.evaluate();
                 } finally {
-                // MSAL (common) logger logs using a background thread, so even though the test is
-                // finished at this point, we may still be receiving logs from the logger. If we
-                // close the stream right now we might the lose the last bit of logs and we might
-                // encounter an IoException when trying to write that last bit of logs to the file
-                // as the stream was closed.
-                // To mitigate it we would just sleep for a tiny bit of time to ensure that we grab
-                // those last bit of logs, dump them to the file and then close the writer.
-                ThreadUtils.sleepSafely(
-                        Math.toIntExact(TimeUnit.SECONDS.toMillis(1)),
-                        TAG,
-                        "Error while sleeping during saving logs."
-                );
+                    // MSAL (common) logger logs using a background thread, so even though the test is
+                    // finished at this point, we may still be receiving logs from the logger. If we
+                    // close the stream right now we might the lose the last bit of logs and we might
+                    // encounter an IoException when trying to write that last bit of logs to the file
+                    // as the stream was closed.
+                    // To mitigate it we would just sleep for a tiny bit of time to ensure that we grab
+                    // those last bit of logs, dump them to the file and then close the writer.
+                    ThreadUtils.sleepSafely(
+                            Math.toIntExact(TimeUnit.SECONDS.toMillis(1)),
+                            TAG,
+                            "Error while sleeping during saving logs."
+                    );
 
-                msalLogFileAppender.closeWriter();
+                    msalLogFileAppender.closeWriter();
 
-                CommonUtils.copyFileToFolderInSdCard(
-                        msalLogFileAppender.getLogFile(),
-                        LOG_FOLDER_NAME
-                );
+                    CommonUtils.copyFileToFolderInSdCard(
+                            msalLogFileAppender.getLogFile(),
+                            LOG_FOLDER_NAME
+                    );
+                }
             }
         };
     }
@@ -99,7 +100,8 @@ public class MsalLoggingRule implements TestRule {
         return msalFileLogAppender;
     }
 
-    private LogLevel convertMsalLogLevelToInternalLogLevel(@NonNull final Logger.LogLevel logLevel) {
+    private LogLevel convertMsalLogLevelToInternalLogLevel(
+            @NonNull final Logger.LogLevel logLevel) {
         switch (logLevel) {
             case VERBOSE:
                 return LogLevel.VERBOSE;

--- a/msalautomationapp/src/main/res/raw/msal_automation_config.json
+++ b/msalautomationapp/src/main/res/raw/msal_automation_config.json
@@ -11,5 +11,10 @@
         "type": "AzureADandPersonalMicrosoftAccount"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_arlington.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_arlington.json
@@ -7,5 +7,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.us/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_b2c_siso.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_b2c_siso.json
@@ -6,5 +6,10 @@
       "type": "B2C",
       "authority_url": "https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SISOPolicy/"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_blackforest.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_blackforest.json
@@ -7,5 +7,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.de/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_browser.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_browser.json
@@ -9,5 +9,10 @@
         "type": "AzureADMultipleOrgs"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_default.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_default.json
@@ -9,5 +9,10 @@
         "type": "AzureADMultipleOrgs"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_fairfax.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_fairfax.json
@@ -7,5 +7,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.us/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_instance_aware_common.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_instance_aware_common.json
@@ -8,5 +8,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.com/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_instance_aware_common_skip_broker.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_instance_aware_common_skip_broker.json
@@ -9,5 +9,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.com/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_instance_aware_organization.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_instance_aware_organization.json
@@ -8,5 +8,10 @@
       "type": "AAD",
       "authority_url": "https://login.microsoftonline.com/organizations"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_mooncake.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_mooncake.json
@@ -7,5 +7,10 @@
       "type": "AAD",
       "authority_url": "https://login.chinacloudapi.cn/common"
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_msa.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_msa.json
@@ -9,5 +9,10 @@
         "type": "AzureADandPersonalMicrosoftAccount"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_msa_only.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_msa_only.json
@@ -9,5 +9,10 @@
         "type": "PersonalMicrosoftAccount"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_no_admin_consent.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_no_admin_consent.json
@@ -10,5 +10,10 @@
         "tenant_id": "f645ad92-e38d-4d1a-b510-d1b09a74a8ca"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }

--- a/msalautomationapp/src/main/res/raw/msal_config_webview.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_webview.json
@@ -9,5 +9,10 @@
         "type": "AzureADMultipleOrgs"
       }
     }
-  ]
+  ],
+  "logging": {
+    "pii_enabled": false,
+    "log_level": "VERBOSE",
+    "logcat_enabled": false
+  }
 }


### PR DESCRIPTION
Until we fix the issues around the MSAL logger, I've added logging config to each config file used during automation.

(The logger issue we are talking about is described here: https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1287)

Note: This is a small PR (with just the same minor change made across 15 different resource files)