### PR TITLE
Automation: Initialize activity before loading lab user

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
@@ -85,6 +85,7 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest, IRuleBa
 
     @Before
     public void setup() {
+        mActivity = mActivityRule.getActivity();
         loadLabUser();
         mScopes = getScopes();
         mBrowser = getBrowser();
@@ -93,7 +94,6 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest, IRuleBa
         mBrowser.clear();
 
         mContext = ApplicationProvider.getApplicationContext();
-        mActivity = mActivityRule.getActivity();
         setupPCA();
     }
 


### PR DESCRIPTION
Temp user creation takes time and Firebase is not happy blocking activity launch while it waits for that and throws the below error. This PR fixes that issue.

Error:

java.lang.RuntimeException: Could not launch intent Intent { act=android.intent.action.MAIN flg=0x10000000 cmp=com.msft.identity.client.sample.local/com.microsoft.identity.client.msal.automationapp.MainActivity } within 45 seconds. Perhaps the main thread has not gone idle within a reasonable amount of time? There could be an animation or something constantly repainting the screen. Or the activity is doing network calls on creation? See the threaddump logs. For your reference the last time the event queue was idle before your activity launch request was 1611302798256 and now the last time the queue went idle was: 1611302843262. If these numbers are the same your activity might be hogging the event queue.