### PR TITLE
Reenables javadoc + src jars for Xamarin consumption

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -219,11 +219,13 @@ task javadoc(type: Javadoc) {
 task javadocJar(type: Jar, dependsOn: javadoc) {
     from javadoc.destinationDir
     classifier 'javadoc'
+    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
 }
 
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier 'sources'
+    destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
 }
 
 dependencies {


### PR DESCRIPTION
MSAL stopped publishing `src` and `javadoc` jars after `2.0.2` due to the tools updates in #1188 -- this looks to have been accidental in migrating away from the use of [deprecated constants](https://discuss.gradle.org/t/destinationdir-is-deprecated-archivename-is-deprecated/31586).

For comparative purposes, see the artifacts published in the following two builds:
- [2.0.2](https://repo1.maven.org/maven2/com/microsoft/identity/client/msal/2.0.2/)
- [2.0.3](https://repo1.maven.org/maven2/com/microsoft/identity/client/msal/2.0.3/)

Reenabling these artifacts was requested by our Xamarin devs, who are using these artifacts to build C# binding DLLs for MSAL-Android