### PR TITLE
Disable java 1.8

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -23,18 +23,18 @@ def bothTestType = "BothTest"
 
 android {
 
-    testOptions {
-        compileOptions {
-            // Flag to enable support for the new language APIs
-            coreLibraryDesugaringEnabled true
-            // Sets Java compatibility to Java 8
-            sourceCompatibility JavaVersion.VERSION_1_8
-            targetCompatibility JavaVersion.VERSION_1_8
-        }
-        dependencies {
-            coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
-        }
-    }
+//    testOptions {
+//        compileOptions {
+//            // Flag to enable support for the new language APIs
+//            coreLibraryDesugaringEnabled true
+//            // Sets Java compatibility to Java 8
+//            sourceCompatibility JavaVersion.VERSION_1_8
+//            targetCompatibility JavaVersion.VERSION_1_8
+//        }
+//        dependencies {
+//            coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
+//        }
+//    }
 
     /*
     //Commenting out until the next major version of common/msal/etc...

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -34,13 +34,14 @@ if (project.hasProperty("distMsalVersion")) {
 
 android {
 
-    compileOptions {
-        // Flag to enable support for the new language APIs
-        coreLibraryDesugaringEnabled true
-        // Sets Java compatibility to Java 8
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+// Commented out becuase we haven't supported this in MSAL yet. Having this on could be misleading.
+//    compileOptions {
+//        // Flag to enable support for the new language APIs
+//        coreLibraryDesugaringEnabled true
+//        // Sets Java compatibility to Java 8
+//        sourceCompatibility JavaVersion.VERSION_1_8
+//        targetCompatibility JavaVersion.VERSION_1_8
+//    }
 
     compileSdkVersion rootProject.ext.compileSdkVersion
     defaultConfig {
@@ -94,7 +95,8 @@ android {
 
 dependencies {
 
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
+// Commented out becuase we haven't supported this in MSAL yet. Having this on could be misleading.
+//  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 
     // Compile Dependency
     localImplementation project(':msal')


### PR DESCRIPTION
For some reason, this is also affect the common library itself - the calling app is still asking for JAVA 1.8.

For now, I'll disable this to unblock the release. Once we have capacity, we could revisit this to have this re-enabled for test projects.

related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1252