### PR TITLE
Changes to MSAL/MSAL test app to support passing extra parameters

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Add extra '/' in the example intent filter (#1323)
 - [PATCH] Better PublicClientApplicationConfiguration validation to fail when empty string is passed (#1324)
 - [PATCH] Improve redirect_uri validation of PCA manifest (#1327)
+- [MINOR] Addition of extra options on most requests (#1334)
 
 Version 2.0.8
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
@@ -40,7 +40,6 @@ public class AcquireTokenParameters extends TokenParameters {
     private String mLoginHint;
     private Prompt mPrompt;
     private List<String> mExtraScopesToConsent;
-    private List<Pair<String, String>> mExtraQueryStringParameters;
     private AuthenticationCallback mCallback;
 
     public AcquireTokenParameters(AcquireTokenParameters.Builder builder) {
@@ -50,7 +49,6 @@ public class AcquireTokenParameters extends TokenParameters {
         mLoginHint = builder.mLoginHint;
         mPrompt = builder.mPrompt;
         mExtraScopesToConsent = builder.mExtraScopesToConsent;
-        mExtraQueryStringParameters = builder.mExtraQueryStringParameters;
         mCallback = builder.mCallback;
     }
 
@@ -106,16 +104,6 @@ public class AcquireTokenParameters extends TokenParameters {
     }
 
     /**
-     * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can get these here.
-     * Otherwise... would recommend not touching.
-     *
-     * @return
-     */
-    public List<Pair<String, String>> getExtraQueryStringParameters() {
-        return mExtraQueryStringParameters;
-    }
-
-    /**
      * The Non-null {@link AuthenticationCallback} to receive the result back.
      * 1) If user cancels the flow by pressing the device back button, the result will be sent
      * back via {@link AuthenticationCallback#onCancel()}.
@@ -137,7 +125,6 @@ public class AcquireTokenParameters extends TokenParameters {
         private String mLoginHint;
         private Prompt mPrompt;
         private List<String> mExtraScopesToConsent;
-        private List<Pair<String, String>> mExtraQueryStringParameters;
         private AuthenticationCallback mCallback;
 
         public AcquireTokenParameters.Builder startAuthorizationFromActivity(final Activity activity) {
@@ -165,11 +152,6 @@ public class AcquireTokenParameters extends TokenParameters {
             return self();
         }
 
-        public AcquireTokenParameters.Builder withAuthorizationQueryStringParameters(
-                List<Pair<String, String>> parameters) {
-            mExtraQueryStringParameters = parameters;
-            return self();
-        }
 
         public AcquireTokenParameters.Builder withCallback(
                 final AuthenticationCallback authenticationCallback) {

--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
@@ -41,6 +41,7 @@ public class AcquireTokenParameters extends TokenParameters {
     private Prompt mPrompt;
     private List<String> mExtraScopesToConsent;
     private AuthenticationCallback mCallback;
+    private List<Pair<String, String>> mExtraQueryStringParameters;
 
     public AcquireTokenParameters(AcquireTokenParameters.Builder builder) {
         super(builder);
@@ -50,6 +51,7 @@ public class AcquireTokenParameters extends TokenParameters {
         mPrompt = builder.mPrompt;
         mExtraScopesToConsent = builder.mExtraScopesToConsent;
         mCallback = builder.mCallback;
+        mExtraQueryStringParameters = builder.mExtraQueryStringParameters;
     }
 
     /**
@@ -118,6 +120,16 @@ public class AcquireTokenParameters extends TokenParameters {
         return mCallback;
     }
 
+    /**
+     * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can get these here.
+     * Otherwise... would recommend not touching.
+     *
+     * @return the list of query parameters to add to the authorize call.
+     */
+    public List<Pair<String, String>> getExtraQueryStringParameters() {
+        return mExtraQueryStringParameters;
+    }
+
     public static class Builder extends TokenParameters.Builder<AcquireTokenParameters.Builder> {
 
         private Activity mActivity;
@@ -126,6 +138,13 @@ public class AcquireTokenParameters extends TokenParameters {
         private Prompt mPrompt;
         private List<String> mExtraScopesToConsent;
         private AuthenticationCallback mCallback;
+        private List<Pair<String, String>> mExtraQueryStringParameters;
+
+        public Builder withAuthorizationQueryStringParameters(
+                List<Pair<String, String>> parameters) {
+            mExtraQueryStringParameters = parameters;
+            return self();
+        }
 
         public AcquireTokenParameters.Builder startAuthorizationFromActivity(final Activity activity) {
             mActivity = activity;

--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenSilentParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenSilentParameters.java
@@ -22,6 +22,10 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client;
 
+import android.util.Pair;
+
+import java.util.List;
+
 public class AcquireTokenSilentParameters extends TokenParameters {
     private boolean mForceRefresh;
     private SilentAuthenticationCallback mCallback;

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -42,7 +42,6 @@ import java.util.UUID;
  */
 public abstract class TokenParameters {
 
-    private List<Pair<String, String>> mExtraQueryStringParameters;
     private List<String> mScopes;
     private IAccount mAccount;
     private String mAuthority;
@@ -59,7 +58,6 @@ public abstract class TokenParameters {
         mScopes = builder.mScopes;
         mAuthenticationScheme = builder.mAuthenticationScheme;
         mCorrelationId = builder.mCorrelationId;
-        mExtraQueryStringParameters = builder.mExtraQueryStringParameters;
         mExtraOptions = builder.mExtraOptions;
     }
 
@@ -160,19 +158,9 @@ public abstract class TokenParameters {
     }
 
     /**
-     * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can get these here.
-     * Otherwise... would recommend not touching.
+     * If you have been instructed that the client requires extra options, supply them here.
      *
-     * @return
-     */
-    public List<Pair<String, String>> getExtraQueryStringParameters() {
-        return mExtraQueryStringParameters;
-    }
-
-    /**
-     * If you have been instructed that the client requires extra parameters, supply them here.
-     *
-     * @return the extra parameters.
+     * @return the extra options.
      */
     public List<Pair<String, String>> getExtraOptions() {
         return mExtraOptions;
@@ -186,7 +174,6 @@ public abstract class TokenParameters {
     public static abstract class Builder<B extends TokenParameters.Builder<B>> {
 
         public List<Pair<String, String>> mExtraOptions;
-        private List<Pair<String, String>> mExtraQueryStringParameters;
         private List<String> mScopes;
         private IAccount mAccount;
         private String mAuthority;
@@ -215,13 +202,6 @@ public abstract class TokenParameters {
             mExtraOptions = options == null ? options : new ArrayList<Pair<String, String>>(options);
             return self();
         }
-
-        public B withAuthorizationQueryStringParameters(
-                List<Pair<String, String>> parameters) {
-            mExtraQueryStringParameters = parameters;
-            return self();
-        }
-
 
         public B forAccount(IAccount account) {
             mAccount = account;

--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -23,6 +23,7 @@
 package com.microsoft.identity.client;
 
 import android.text.TextUtils;
+import android.util.Pair;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -41,6 +42,7 @@ import java.util.UUID;
  */
 public abstract class TokenParameters {
 
+    private List<Pair<String, String>> mExtraQueryStringParameters;
     private List<String> mScopes;
     private IAccount mAccount;
     private String mAuthority;
@@ -48,6 +50,7 @@ public abstract class TokenParameters {
     private AccountRecord mAccountRecord;
     private AuthenticationScheme mAuthenticationScheme;
     private String mCorrelationId;
+    private List<Pair<String, String>> mExtraOptions;
 
     protected TokenParameters(@NonNull final TokenParameters.Builder builder) {
         mAccount = builder.mAccount;
@@ -56,6 +59,8 @@ public abstract class TokenParameters {
         mScopes = builder.mScopes;
         mAuthenticationScheme = builder.mAuthenticationScheme;
         mCorrelationId = builder.mCorrelationId;
+        mExtraQueryStringParameters = builder.mExtraQueryStringParameters;
+        mExtraOptions = builder.mExtraOptions;
     }
 
     /**
@@ -155,12 +160,33 @@ public abstract class TokenParameters {
     }
 
     /**
+     * If you've been instructed to pass additional query string parameters to the authorization endpoint.  You can get these here.
+     * Otherwise... would recommend not touching.
+     *
+     * @return
+     */
+    public List<Pair<String, String>> getExtraQueryStringParameters() {
+        return mExtraQueryStringParameters;
+    }
+
+    /**
+     * If you have been instructed that the client requires extra parameters, supply them here.
+     *
+     * @return the extra parameters.
+     */
+    public List<Pair<String, String>> getExtraOptions() {
+        return mExtraOptions;
+    }
+
+    /**
      * TokenParameters builder
      *
      * @param <B>
      */
     public static abstract class Builder<B extends TokenParameters.Builder<B>> {
 
+        public List<Pair<String, String>> mExtraOptions;
+        private List<Pair<String, String>> mExtraQueryStringParameters;
         private List<String> mScopes;
         private IAccount mAccount;
         private String mAuthority;
@@ -184,6 +210,18 @@ public abstract class TokenParameters {
 
             return self();
         }
+
+        public B withExtraOptions(List<Pair<String, String>> options) {
+            mExtraOptions = options == null ? options : new ArrayList<Pair<String, String>>(options);
+            return self();
+        }
+
+        public B withAuthorizationQueryStringParameters(
+                List<Pair<String, String>> parameters) {
+            mExtraQueryStringParameters = parameters;
+            return self();
+        }
+
 
         public B forAccount(IAccount account) {
             mAccount = account;

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -183,6 +183,7 @@ public class CommandParametersAdapter {
                 .redirectUri(configuration.getRedirectUri())
                 .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
                 .sdkType(SdkType.MSAL)
+                .extraOptions(parameters.getExtraOptions())
                 .sdkVersion(PublicClientApplication.getSdkVersion())
                 .authority(authority)
                 .claimsRequestJson(claimsRequestJson)

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -142,6 +142,7 @@ public class CommandParametersAdapter {
                 .isWebViewZoomEnabled(configuration.isWebViewZoomEnabled())
                 .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
                 .correlationId(parameters.getCorrelationId())
+                .extraOptions(parameters.getExtraOptions())
                 .build();
 
         return commandParameters;

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -94,6 +94,8 @@ android {
 }
 
 dependencies {
+    //implementation 'org.projectlombok:lombok'
+
 
 // Commented out becuase we haven't supported this in MSAL yet. Having this on could be misleading.
 //  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
@@ -105,4 +107,6 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
     implementation "com.google.android.material:material:$rootProject.ext.materialVersion"
+    compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
+    annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
 }

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -94,8 +94,6 @@ android {
 }
 
 dependencies {
-    //implementation 'org.projectlombok:lombok'
-
 
 // Commented out becuase we haven't supported this in MSAL yet. Having this on could be misleading.
 //  coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -87,9 +87,13 @@ public class AcquireTokenFragment extends Fragment {
     private Spinner mPopHttpMethod;
     private EditText mPopResourceUrl;
     private EditText mPopClientClaims;
+    private EditText mExtraQueryParams;
+    private EditText mExtraOptions;
 
     private LinearLayout mPopSection;
     private LinearLayout mLoginHintSection;
+    private LinearLayout mExtraParamsSection;
+    private LinearLayout mExtraOptionsSection;
 
     private OnFragmentInteractionListener mOnFragmentInteractionListener;
     private MsalWrapper mMsalWrapper;
@@ -130,9 +134,15 @@ public class AcquireTokenFragment extends Fragment {
         mPopHttpMethod = view.findViewById(R.id.pop_http_method);
         mPopResourceUrl = view.findViewById(R.id.pop_resource_url);
         mPopClientClaims = view.findViewById(R.id.pop_client_claims);
+        mExtraQueryParams = view.findViewById(R.id.editQueryParams);
+        mExtraOptions = view.findViewById(R.id.editExtraOptions);
 
         mPopSection = view.findViewById(R.id.pop_section);
         mLoginHintSection = view.findViewById(R.id.login_hint_section);
+        mExtraParamsSection = view.findViewById(R.id.param_section);
+        mExtraParamsSection.setVisibility(View.VISIBLE);
+        mExtraOptionsSection = view.findViewById(R.id.options_section);
+        mExtraOptionsSection = view.findViewById(R.id.param_section);
 
         bindSelectAccountSpinner(mSelectAccount, null);
         mSelectAccount.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
@@ -441,6 +451,8 @@ public class AcquireTokenFragment extends Fragment {
                 : HttpMethod.valueOf(httpMethodTextFromSpinner);
         final String popResourceUrl = mPopResourceUrl.getText().toString();
         final String popClientClaimsTxt = mPopClientClaims.getText().toString();
+        final String extraQueryParamsTxt = mExtraQueryParams.getText().toString();
+        final String extraOptionsTxt = mExtraQueryParams.getText().toString();
 
         return new RequestOptions(
                 configFile,
@@ -456,7 +468,9 @@ public class AcquireTokenFragment extends Fragment {
                 authScheme,
                 popHttpMethod,
                 popResourceUrl,
-                popClientClaimsTxt
+                popClientClaimsTxt,
+                extraQueryParamsTxt,
+                extraOptionsTxt
         );
     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -452,7 +452,7 @@ public class AcquireTokenFragment extends Fragment {
         final String popResourceUrl = mPopResourceUrl.getText().toString();
         final String popClientClaimsTxt = mPopClientClaims.getText().toString();
         final String extraQueryParamsTxt = mExtraQueryParams.getText().toString();
-        final String extraOptionsTxt = mExtraQueryParams.getText().toString();
+        final String extraOptionsTxt = mExtraOptions.getText().toString();
 
         return new RequestOptions(
                 configFile,

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -2,7 +2,9 @@ package com.microsoft.identity.client.testapp;
 
 import android.app.Activity;
 import android.content.Context;
+import android.text.TextUtils;
 import android.util.Log;
+import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
@@ -28,6 +30,7 @@ import com.microsoft.identity.client.exception.MsalUiRequiredException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -193,8 +196,28 @@ abstract class MsalWrapper {
                 return null;
             }
         }
+        if (!TextUtils.isEmpty(requestOptions.getExtraQueryString())) {
+            List<Pair<String, String>> queryParams = getPairs(requestOptions.getExtraQueryString());
+            builder.withAuthorizationQueryStringParameters(queryParams);
+        }
+        if (!TextUtils.isEmpty(requestOptions.getExtraOptionsString())) {
+            List<Pair<String, String>> extraOptions = getPairs(requestOptions.getExtraOptionsString());
+            builder.withExtraOptions(extraOptions);
+        }
 
         return builder;
+    }
+
+    private List<Pair<String, String>> getPairs(String pairString) {
+        List<Pair<String, String>> extraOptions = new ArrayList<Pair<String, String>>();
+        String[] params = pairString.split("&");
+        for (String s : params) {
+            if (!TextUtils.isEmpty(s)) {
+                final String[] split = s.split("=");
+                extraOptions.add(new Pair<String, String>(split[0], split.length > 1 && split[1] == null ? split[1] : ""));
+            }
+        }
+        return extraOptions;
     }
 
     abstract void acquireTokenSilentAsyncInternal(@NonNull final AcquireTokenSilentParameters parameters);

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -115,6 +115,15 @@ abstract class MsalWrapper {
                 .withPrompt(requestOptions.getPrompt())
                 .withCallback(getAuthenticationCallback(callback));
 
+        if (!TextUtils.isEmpty(requestOptions.getExtraQueryString())) {
+            builder.withAuthorizationQueryStringParameters(getPairs(requestOptions.getExtraQueryString()));
+        }
+
+        if (!TextUtils.isEmpty(requestOptions.getExtraOptionsString())) {
+            builder.withExtraOptions(getPairs(requestOptions.getExtraOptionsString()));
+        }
+
+
         if (requestOptions.getAuthority() != null && !requestOptions.getAuthority().isEmpty()) {
             builder.fromAuthority(requestOptions.getAuthority());
         }
@@ -214,7 +223,7 @@ abstract class MsalWrapper {
         for (String s : params) {
             if (!TextUtils.isEmpty(s)) {
                 final String[] split = s.split("=");
-                extraOptions.add(new Pair<String, String>(split[0], split.length > 1 && split[1] == null ? split[1] : ""));
+                extraOptions.add(new Pair<String, String>(split[0], split.length > 1 && split[1] != null ? split[1] : ""));
             }
         }
         return extraOptions;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
@@ -26,6 +26,13 @@ import com.microsoft.identity.client.HttpMethod;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.Prompt;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
+
+@Builder
+@Accessors(prefix = "m")
+@Getter
 class RequestOptions {
 
     final Constants.ConfigFile mConfigFile;
@@ -42,6 +49,8 @@ class RequestOptions {
     final HttpMethod mPopHttpMethod;
     final String mPopResourceUrl;
     final String mPoPClientClaims;
+    final String mExtraQueryString;
+    final String mExtraOptionsString;
 
     RequestOptions(final Constants.ConfigFile configFile,
                    final String loginHint,
@@ -56,7 +65,9 @@ class RequestOptions {
                    final Constants.AuthScheme authScheme,
                    final HttpMethod popHttpMethod,
                    final String popResourceUrl,
-                   final String popClientClaims) {
+                   final String popClientClaims,
+                   final String extraQueryString,
+                   final String extraOptionsString) {
         mConfigFile = configFile;
         mLoginHint = loginHint;
         mAccount = account;
@@ -71,6 +82,8 @@ class RequestOptions {
         mPopHttpMethod = popHttpMethod;
         mPopResourceUrl = popResourceUrl;
         mPoPClientClaims = popClientClaims;
+        mExtraQueryString = extraQueryString;
+        mExtraOptionsString = extraOptionsString;
     }
 
     Constants.ConfigFile getConfigFile() {

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -24,7 +24,8 @@
   -->
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:visibility="visible">
 
     <LinearLayout
         android:id="@+id/activity_main"
@@ -107,7 +108,7 @@
         <LinearLayout
             android:id="@+id/pop_section"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+            android:layout_height="161dp"
             android:orientation="vertical">
 
             <LinearLayout
@@ -203,6 +204,60 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="7"
                 android:textSize="12sp" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/param_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/extraQuery"
+                android:layout_width="63dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/query_params" />
+
+            <EditText
+                android:id="@+id/editQueryParams"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ems="10"
+                android:inputType="textPersonName"
+                android:text="@string/default_query"
+                android:visibility="visible" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/options_section"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:paddingTop="5dp"
+            android:paddingBottom="5dp"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/extraOption"
+                android:layout_width="61dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/extra_options" />
+
+            <EditText
+                android:id="@+id/editExtraOptions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:ems="10"
+                android:inputType="textPersonName"
+                android:text="@string/default_options" />
         </LinearLayout>
 
         <LinearLayout

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -230,7 +230,6 @@
                 android:layout_weight="1"
                 android:ems="10"
                 android:inputType="textPersonName"
-                android:text="@string/default_query"
                 android:visibility="visible" />
         </LinearLayout>
 
@@ -256,8 +255,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:ems="10"
-                android:inputType="textPersonName"
-                android:text="@string/default_options" />
+                android:inputType="textPersonName" />
         </LinearLayout>
 
         <LinearLayout

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -53,6 +53,10 @@
     <string name="btn_removeUser">Remove User</string>
     <string name="config_file_text">Config File</string>
     <string name="auth_scheme_text">Auth Scheme</string>
+    <string name="default_query">query params</string>
+    <string name="query_params">Extra Param</string>
+    <string name="default_options">option pairs</string>
+    <string name="extra_options">Extra Options</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>


### PR DESCRIPTION
I was looking for a way to trigger the PRTv3 flow inside the broker, and I thought it might be easiest just to add a field exposing new options.  Additionally, I did not know of a way to add authorize query strings in the test app, so I added those as well.

I considered using that field for what I was doing, but thought that the confusion that would result from pushing things in that field and then removing them before passing them to the authorize endpoint would be bad.