### PR TITLE
changes to support null task affinity

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,7 +3,7 @@ vNext
 - [PATCH] Add extra '/' in the example intent filter (#1323)
 - [PATCH] Better PublicClientApplicationConfiguration validation to fail when empty string is passed (#1324)
 - [PATCH] Improve redirect_uri validation of PCA manifest (#1327)
-- [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean.
+- [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean (#1342)
 
 Version 2.0.8
 ----------

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Add extra '/' in the example intent filter (#1323)
 - [PATCH] Better PublicClientApplicationConfiguration validation to fail when empty string is passed (#1324)
 - [PATCH] Improve redirect_uri validation of PCA manifest (#1327)
+- [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean.
 
 Version 2.0.8
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -271,14 +271,16 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:$rootProject.ext.mockitoAndroidVersion"
     // 'local' flavor dependencies
     localApi(project(":common")) {
-        transitive = false
+        transitive = true
     }
 
+    /*
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.1.2', changing: true)
 
     distApi("com.microsoft.identity:common:3.1.2") {
         transitive = false
     }
+    */
 }
 
 def configDir = new File(buildscript.sourceFile.parentFile.parentFile, 'config')

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -271,16 +271,16 @@ dependencies {
     androidTestImplementation "org.mockito:mockito-android:$rootProject.ext.mockitoAndroidVersion"
     // 'local' flavor dependencies
     localApi(project(":common")) {
-        transitive = true
+        transitive = false
     }
 
-    /*
+
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.1.2', changing: true)
 
     distApi("com.microsoft.identity:common:3.1.2") {
         transitive = false
     }
-    */
+
 }
 
 def configDir = new File(buildscript.sourceFile.parentFile.parentFile, 'config')

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -394,7 +394,7 @@ public class PublicClientApplicationConfiguration {
 
     private void checkManifestPermissions(){
         if(this.handleNullTaskAffinity){
-            PackageManager packageManager = mAppContext.getPackageManager();
+            final PackageManager packageManager = mAppContext.getPackageManager();
             int reorderTasksGranted = packageManager.checkPermission(Manifest.permission.REORDER_TASKS, mAppContext.getPackageName());
             if(reorderTasksGranted != PackageManager.PERMISSION_GRANTED) {
                 throw new IllegalStateException("You requested that we handle null taskAffinity but your manifest does not include the REORDER_TASKS permission");

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -395,7 +395,7 @@ public class PublicClientApplicationConfiguration {
     private void checkManifestPermissions(){
         if(this.handleNullTaskAffinity){
             final PackageManager packageManager = mAppContext.getPackageManager();
-            int reorderTasksGranted = packageManager.checkPermission(Manifest.permission.REORDER_TASKS, mAppContext.getPackageName());
+            final int reorderTasksGranted = packageManager.checkPermission(Manifest.permission.REORDER_TASKS, mAppContext.getPackageName());
             if(reorderTasksGranted != PackageManager.PERMISSION_GRANTED) {
                 throw new IllegalStateException("You requested that we handle null taskAffinity but your manifest does not include the REORDER_TASKS permission");
             }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -140,6 +140,7 @@ public class CommandParametersAdapter {
                 .prompt(getPromptParameter(parameters))
                 .isWebViewZoomControlsEnabled(configuration.isWebViewZoomControlsEnabled())
                 .isWebViewZoomEnabled(configuration.isWebViewZoomEnabled())
+                .handleNullTaskAffinity(configuration.isHandleNullTaskAffinityEnabled())
                 .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
                 .correlationId(parameters.getCorrelationId())
                 .build();

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -16,6 +16,7 @@
   "web_view_zoom_enabled": true,
   "environment": "Production",
   "power_opt_check_for_network_req_enabled": true,
+  "handle_null_taskaffinity": false,
   "http": {
     "connect_timeout": 10000,
     "read_timeout": 30000

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,10 @@
+pluginManagement {
+    repositories {
+        google()
+        jcenter()
+        gradlePluginPortal()
+    }
+}
 include ':msal', ':common', ':keyvault', ':labapi', ':testutils', ':pop-benchmarker',
         ':package-inspector', ':msalautomationapp', ':uiautomationutilities'
 project(':common').projectDir = new File('common/common')

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     // Compile Dependency
     localImplementation project(':msal')
-    //distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
+    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     // Compile Dependency
     localImplementation project(':msal')
-    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
+    //distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -32,6 +32,8 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.MANAGE_ACCOUNTS" />
     <uses-permission android:name="android.permission.USE_CREDENTIALS" />
+    <uses-permission android:name="android.permission.REORDER_TASKS" />
+
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
@@ -43,7 +45,8 @@
         <activity
             android:name="com.microsoft.identity.client.testapp.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:taskAffinity="">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
+        <!-- taskAffinity is set equal to empty string.  This translated to "null" taskAffinity at runtime.
+            null task affinity may be used when creating multi-window apps-->
+        <!-- https://developer.android.com/guide/topics/manifest/activity-element#aff -->
         <activity
             android:name="com.microsoft.identity.client.testapp.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"

--- a/testapps/testapp/src/main/res/raw/msal_config_default.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_default.json
@@ -2,6 +2,7 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "handle_null_taskaffinity": true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
When authentication is completed interactive token requests that were started from an activity which do not have a taskAffinity (null taskAffinity) that activity is not brought to the foreground after the interaction with the authorization endpoint is complete.  This is a problem for some apps that leverage null taskaffinity in multi-window scenarios.  