### PR TITLE
Revert not passing environment in removeAccount call for backward compat

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -366,6 +366,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         // The broker strips these properties out of this object to hit the cache
         // Refactor this out...
         final AccountRecord requestAccountRecord = new AccountRecord();
+        requestAccountRecord.setEnvironment(multiTenantAccount.getEnvironment());
         requestAccountRecord.setHomeAccountId(multiTenantAccount.getHomeAccountId());
 
         final RemoveAccountCommandParameters params = CommandParametersAdapter


### PR DESCRIPTION
We need to revert the change to pass environment to null, to remove account api for backward compat.
As older version of broker will reject request if environment is set to null in remove account bundler, causing the remove account scenario to break.

Instead we will locally override the environment value to null in local Msal Controller (for msal only scenario) and in broker (for broker scenario) [PR 1287](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1287)