### PR TITLE
Merge pull request #1346 from AzureAD/amgusain/fixRemoveAccount

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -366,6 +366,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         // The broker strips these properties out of this object to hit the cache
         // Refactor this out...
         final AccountRecord requestAccountRecord = new AccountRecord();
+        requestAccountRecord.setEnvironment(multiTenantAccount.getEnvironment());
         requestAccountRecord.setHomeAccountId(multiTenantAccount.getHomeAccountId());
 
         final RemoveAccountCommandParameters params = CommandParametersAdapter


### PR DESCRIPTION
Revert not passing environment in removeAccount call for backward compat

Cherry-picking my fix from release branch back to dev.
Also updating the common submodule to pick up the corresponding fix in common