### PR TITLE
Fix logging deserialization

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -180,7 +180,7 @@ public class PublicClientApplicationConfigurationFactory {
                         new AzureActiveDirectoryAudienceDeserializer()
                 )
                 .registerTypeAdapter(
-                        Logger.LogLevel.class,
+                        com.microsoft.identity.client.Logger.LogLevel.class,
                         new LogLevelDeserializer()
                 )
                 .create();


### PR DESCRIPTION
The wrong class is being deserialized by Gson when loading configs - fix this by using the FQN