### PR TITLE
Shoatman/fix instrumented tests

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -1,10 +1,26 @@
-apply plugin: 'com.android.library'
-apply plugin: 'checkstyle'
-apply plugin: 'pmd'
-apply plugin: 'maven'
-apply plugin: 'maven-publish'
+plugins {
+    id 'com.microsoft.identity.buildsystem' version '0.0.1'
+    id 'com.android.library'
+    id 'pmd'
+    id 'checkstyle'
+    id 'maven'
+    id 'maven-publish'
+}
+
 apply from: 'versioning/version_tasks.gradle'
+
 group = 'com.microsoft.identity.client'
+
+def desugarCode = false
+
+if(project.hasProperty("sugar")){
+    desugarCode = sugar.toBoolean()
+}
+
+buildSystem {
+    desugar = desugarCode
+}
+
 //apply plugin: 'jacoco'
 //
 //// To include Robolectric tests in the Jacoco report, flag -> "includeNolocationClasses" is set to true
@@ -244,8 +260,8 @@ task sourcesJar(type: Jar) {
 
 dependencies {
 
-    //Commenting out until the next major version of common/msal/etc...
-    //coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
+    //Please leave this in... desugaring is currently disabled by default; however it's required for running some tests
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 
     def mockito_version = 'latest.release'
 

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -258,7 +258,6 @@ public final class PublicClientApplicationTest {
     /**
      * Verify correct exception is thrown if callback is not provided.
      */
-    @Ignore
     @Test(expected = IllegalArgumentException.class)
     public void testCallBackEmpty() throws PackageManager.NameNotFoundException, MsalClientException {
         final Context context = new MockContext(mAppContext);
@@ -291,57 +290,6 @@ public final class PublicClientApplicationTest {
         new PublicClientApplication(config);
     }
 
-    @Test
-    @Ignore
-    public void testUnknownAuthorityException() throws PackageManager.NameNotFoundException, IOException,
-            InterruptedException {
-        //TODO: to be replaced with Robolectric
-
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    @Ignore
-    public void testAcquireTokenInteractiveScopeWithEmptyString() throws PackageManager.NameNotFoundException, IOException,
-            InterruptedException {
-        //TODO: to be replaced with Robolectric
-    }
-
-    @Test
-    @Ignore
-    public void testClientInfoNotReturned() throws PackageManager.NameNotFoundException, IOException,
-            InterruptedException {
-        //TODO: to be replaced with Robolectric
-    }
-
-    /**
-     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, List, String[],
-     * String, AuthenticationCallback)}. Also check if authority is set on the manifest, we read the authority
-     * from manifest meta-data.
-     * <p>
-     * NOTE: Ignoring until we've updated the code to do authority validation per the new design.  Currently setting an authority other than the default will fail.
-     */
-    @Test
-    @Ignore
-    public void testAuthoritySetInManifestGetTokenFailed() {
-        //TODO: to be replaced with Robolectric
-    }
-
-    /**
-     * Verify {@link PublicClientApplication#acquireToken(Activity, String[], String, UiBehavior, List, String[], String, AuthenticationCallback)}.
-     */
-    // TODO: suppress the test. The purpose is that the API call will eventually send back the cancel to caller.
-    @Ignore
-    @Test
-    public void testGetTokenWithExtraQueryParam()
-            throws PackageManager.NameNotFoundException, IOException, InterruptedException {
-        //TODO: to be replaced with Robolectric
-    }
-
-    @Test
-    @Ignore
-    public void testB2cAuthorityNotInTrustedList() throws PackageManager.NameNotFoundException, IOException, InterruptedException {
-        //TODO: to be replaced with Robolectric
-    }
 
     @Test
     public void testSecretKeysAreSet() throws NoSuchAlgorithmException, InvalidKeySpecException, MsalClientException {

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
@@ -294,7 +294,7 @@ public class PublicClientConfigurationTest {
      */
     @Test(expected = IllegalArgumentException.class)
     public void testUnknownAudienceException() {
-        final PublicClientApplicationConfiguration configWithInvalidAudience = loadConfig(R.raw.test_pcaconfig_unknown_audience);
+        final PublicClientApplicationConfiguration configWithInvalidAudience = loadConfigAndMerge(R.raw.test_pcaconfig_unknown_audience);
         assertNotNull(configWithInvalidAudience);
         assertFalse(configWithInvalidAudience.getAuthorities().isEmpty());
 
@@ -390,6 +390,10 @@ public class PublicClientConfigurationTest {
 
     private PublicClientApplicationConfiguration loadConfig(final int resourceId) {
         return PublicClientApplicationConfigurationFactory.loadConfiguration(mContext, resourceId);
+    }
+
+    private PublicClientApplicationConfiguration loadConfigAndMerge(final int resourceId) {
+        return PublicClientApplicationConfigurationFactory.initializeConfiguration(mContext, resourceId);
     }
 
     private PublicClientApplicationConfiguration loadConfig(final File file) {

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
@@ -283,9 +283,8 @@ public class PublicClientConfigurationTest {
      * Verify that unknown authority type results in exception
      */
     @Test(expected = IllegalArgumentException.class)
-    @Ignore
     public void testUnknownAuthorityException() {
-        final PublicClientApplicationConfiguration b2cConfig = loadConfig(R.raw.test_pcaconfig_unknown);
+        final PublicClientApplicationConfiguration b2cConfig = loadConfigAndMerge(R.raw.test_pcaconfig_unknown);
         b2cConfig.validateConfiguration();
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -38,6 +38,7 @@ import com.google.gson.annotations.SerializedName;
 import com.microsoft.identity.client.configuration.AccountMode;
 import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
+import com.microsoft.identity.common.internal.logging.Logger;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
@@ -46,12 +47,11 @@ import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAu
 import com.microsoft.identity.common.internal.authorities.Environment;
 import com.microsoft.identity.common.internal.authorities.UnknownAudience;
 import com.microsoft.identity.common.internal.authorities.UnknownAuthority;
+import com.microsoft.identity.common.internal.broker.PackageHelper;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.telemetry.TelemetryConfiguration;
 import com.microsoft.identity.common.internal.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.ui.browser.BrowserDescriptor;
-import com.microsoft.identity.common.logging.Logger;
-import com.microsoft.identity.common.internal.broker.PackageHelper;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -454,10 +454,10 @@ public class PublicClientApplicationConfiguration {
         this.mClientCapabilities = config.mClientCapabilities == null ? this.mClientCapabilities : config.mClientCapabilities;
         this.mIsSharedDevice = config.mIsSharedDevice == true ? this.mIsSharedDevice : config.mIsSharedDevice;
         this.mLoggerConfiguration = config.mLoggerConfiguration == null ? this.mLoggerConfiguration : config.mLoggerConfiguration;
-        this.webViewZoomControlsEnabled = config.webViewZoomControlsEnabled == null || config.webViewZoomControlsEnabled;
-        this.webViewZoomEnabled = config.webViewZoomEnabled == null || config.webViewZoomEnabled;
-        this.powerOptCheckEnabled = config.powerOptCheckEnabled == null || config.powerOptCheckEnabled;
-        this.handleNullTaskAffinity = config.handleNullTaskAffinity == null || config.handleNullTaskAffinity;
+        this.webViewZoomControlsEnabled = config.webViewZoomControlsEnabled == null ? this.webViewZoomControlsEnabled : config.webViewZoomControlsEnabled;
+        this.webViewZoomEnabled = config.webViewZoomEnabled == null ? this.webViewZoomEnabled : config.webViewZoomEnabled;
+        this.powerOptCheckEnabled = config.powerOptCheckEnabled == null ? this.powerOptCheckEnabled : config.powerOptCheckEnabled;
+        this.handleNullTaskAffinity = config.handleNullTaskAffinity == null ? this.handleNullTaskAffinity : config.handleNullTaskAffinity;
     }
 
     void validateConfiguration() {

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -9,5 +9,5 @@ gradle -version
 echo =============================================
 echo Running instrumented tests
 echo =============================================
-gradle msal:connectedLocalDebugAndroidTest -i
+gradle msal:connectedLocalDebugAndroidTest -i -Psugar=true
 


### PR DESCRIPTION
- Fixed bugs in mergeConfiguration
- Removed empty ignored instrumented tests
- Returned 2 ignored tests to the living
- Adding support for desugaring
- Updated instrumented test script to use desugaring
- Update Configuration test code to ensure that default config is merged when the method includes a call to validate

NOTE: I'm thinking that we should record in configuration whether the defaults have been merged in.  So that we can fail validation immediately it has not.