### PR TITLE
Check nullability of handleNullTaskAffinity

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -394,7 +394,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     private void checkManifestPermissions(){
-        if(this.handleNullTaskAffinity){
+        if(this.handleNullTaskAffinity != null && this.handleNullTaskAffinity){
             final PackageManager packageManager = mAppContext.getPackageManager();
             final int reorderTasksGranted = packageManager.checkPermission(Manifest.permission.REORDER_TASKS, mAppContext.getPackageName());
             if(reorderTasksGranted != PackageManager.PERMISSION_GRANTED) {

--- a/scripts/run-instrumented-tests.sh
+++ b/scripts/run-instrumented-tests.sh
@@ -9,5 +9,5 @@ gradle -version
 echo =============================================
 echo Running instrumented tests
 echo =============================================
-gradle msal:connectedLocalDebugAndroidTest -i
+gradle msal:connectedLocalDebugAndroidTest -i -Psugar=true
 


### PR DESCRIPTION
Tests are failing because some unit tests are not doing the config merge, and this field is not set in those config files.

I could've added the field in those config files, but figured it might make more sense doing a null check here.

also added -psugar to the build script.