### PR TITLE
Update Declared Nimbus Dependency Version in MSAL (8.2 -> 9.9)

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ vNext
 - [PATCH] Fixes deprecated PackageInfo.signatures and PackageManager.GET_SIGNATURES (#1321)
 - [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean (#1342)
 - [PATCH] Log and throw exception if there are other apps listening for the redirect URL scheme defined in Android Manifest (#1357)
+- [PATCH] Update Nimbus dependency version (#1382)
 
 Version 2.0.10
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -35,7 +35,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "8.2"
+    nimbusVersion = "9.9"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
Aligns MSAL Nimbus version with Common's

https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1346