### PR TITLE
Merge Release/2.0.12 to master

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,8 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
+Version 2.0.12
+----------
+- Picks up common@3.4.3
+
 Version 2.0.10
 ----------
 - [PATCH] Add extra '/' in the example intent filter (#1323)

--- a/changelog
+++ b/changelog
@@ -1,5 +1,5 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
-Version 2.1.0
+Version 2.0.10
 ----------
 - [PATCH] Add extra '/' in the example intent filter (#1323)
 - [PATCH] Better PublicClientApplicationConfiguration validation to fail when empty string is passed (#1324)

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -274,9 +274,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.3.2', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
 
-    distApi("com.microsoft.identity:common:3.3.2") {
+    distApi("com.microsoft.identity:common:3.4.3") {
         transitive = false
     }
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.0.12
+versionName=2.0.12-RC1
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.0.12-RC1
+versionName=2.0.12
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.1.0
+versionName=2.0.10
 versionCode=0


### PR DESCRIPTION
MSAL release 2.0.12 merge to Master.
Picks up common 3.4.3

PR checkin tests are failing because I also updated submodule to point to common 3.4.3 branch and this has changes in `testutils` that are incompatible with this MSAL...so I am not worried about these. UI Automation was already run here: https://dev.azure.com/IdentityDivision/IDDP/_build/results?buildId=771759&view=ms.vss-test-web.build-test-results-tab

and manual tests were performed as well.