### PR TITLE
Adding repo and area owners to the codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,22 @@
 # Each line is a file pattern followed by one or more owners.
 # Reference: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-*    @AzureAD/androididentity
+# Repo Code Owners
+#--------------------
+
+*       @AdamBJohnsonx @iambmelt @rpdome @shahzaibj @shoatman
+
+
+# Area Owners
+#---------------------
+
+# Automation
+/msalautomationapp/                                                                 @shahzaibj @rpdome
+/msal/src/test/                                                                     @shahzaibj @rpdome
+/msal/src/androidTest/                                                              @shahzaibj @rpdome
+
+# Build
+*.gradle                                                                            @shoatman @AdamBJohnsonx @shahzaibj
+
+# Pipelines
+/azure-pipelines/                                                                   @shoatman @shahzaibj @p3dr0rv

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,5 +18,15 @@
 # Build
 *.gradle                                                                            @shoatman @AdamBJohnsonx @shahzaibj
 
+# Docs
+/docs                                                                               @iambmelt @AdamBJohnsonx 
+
+# PackageInspector
+/package-inspector                                                                  @iambmelt @shahzaibj 
+
 # Pipelines
 /azure-pipelines/                                                                   @shoatman @shahzaibj @p3dr0rv
+
+# PoP Benchmarker
+/pop-benchmarker                                                                    @iambmelt @AdamBJohnsonx 
+


### PR DESCRIPTION
Adding repo code and area owners as per the list from [here](https://microsoft.sharepoint.com/teams/ADAL/_layouts/15/Doc.aspx?sourcedoc={0339bdd6-b5e5-4d94-b4c9-ea47127f5023}&action=edit&wd=target%28Platforms%2FAndroid.one%7C28086b2a-f539-bc47-b229-1610fc61c903%2FCode%20Owners%7C83d87699-1bfc-46f7-b164-0df4c71a1d16%2F%29)

Once this change is merged, I will enable the branch protection setting to require codeowners approval