### PR TITLE
Added 2 new settings to PCA Configuration

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,7 @@ vNext
 - [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean (#1342)
 - [PATCH] Log and throw exception if there are other apps listening for the redirect URL scheme defined in Android Manifest (#1357)
 - [PATCH] Update Nimbus dependency version (#1382)
+- [MINOR] Added 2 new configuration settings: authorization_in_current_task (boolean, default:false), concurrent_authorization_requests (boolean, default: false)
 
 Version 2.0.12
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -291,12 +291,14 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
+    //snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
 
     //TODO: we will have to change transitive to true once common4j is published
+    /*
     distApi("com.microsoft.identity:common:3.4.3") {
         transitive = false
     }
+    */
 
 }
 

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -291,14 +291,13 @@ dependencies {
         transitive = true
     }
 
-    //snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
 
     //TODO: we will have to change transitive to true once common4j is published
-    /*
     distApi("com.microsoft.identity:common:3.4.3") {
         transitive = false
     }
-    */
+
 
 }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -63,10 +63,12 @@ import javax.crypto.SecretKey;
 
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ACCOUNT_MODE;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORITIES;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_IN_CURRENT_TASK;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_USER_AGENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.BROWSER_SAFE_LIST;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CLIENT_CAPABILITIES;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CLIENT_ID;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CONCURRENT_AUTHORIZATION_REQUESTS;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ENVIRONMENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.HANDLE_TASKS_WITH_NULL_TASKAFFINITY;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.HTTP;
@@ -106,6 +108,8 @@ public class PublicClientApplicationConfiguration {
         static final String WEB_VIEW_ZOOM_ENABLED = "web_view_zoom_enabled";
         static final String POWER_OPT_CHECK_FOR_NETWORK_REQUEST_ENABLED = "power_opt_check_for_network_req_enabled";
         static final String HANDLE_TASKS_WITH_NULL_TASKAFFINITY = "handle_null_taskaffinity";
+        static final String AUTHORIZATION_IN_CURRENT_TASK = "authorization_in_current_task";
+        static final String CONCURRENT_AUTHORIZATION_REQUESTS = "concurrent_authorization_requests";
 
     }
 
@@ -162,6 +166,12 @@ public class PublicClientApplicationConfiguration {
 
     @SerializedName(HANDLE_TASKS_WITH_NULL_TASKAFFINITY)
     private Boolean handleNullTaskAffinity;
+
+    @SerializedName(AUTHORIZATION_IN_CURRENT_TASK)
+    private Boolean authorizationInCurrentTask;
+
+    @SerializedName(CONCURRENT_AUTHORIZATION_REQUESTS)
+    private Boolean concurrentAuthorizationRequests;
 
     transient private OAuth2TokenCache mOAuth2TokenCache;
 
@@ -380,6 +390,14 @@ public class PublicClientApplicationConfiguration {
         return handleNullTaskAffinity;
     }
 
+    public Boolean authorizationInCurrentTask() {
+        return authorizationInCurrentTask;
+    }
+
+    public Boolean concurrentAuthorizationRequests() {
+        return concurrentAuthorizationRequests;
+    }
+
     public Authority getDefaultAuthority() {
         if (mAuthorities != null) {
             if (mAuthorities.size() > 1) {
@@ -462,6 +480,8 @@ public class PublicClientApplicationConfiguration {
         this.webViewZoomEnabled = config.webViewZoomEnabled == null ? this.webViewZoomEnabled : config.webViewZoomEnabled;
         this.powerOptCheckEnabled = config.powerOptCheckEnabled == null ? this.powerOptCheckEnabled : config.powerOptCheckEnabled;
         this.handleNullTaskAffinity = config.handleNullTaskAffinity == null ? this.handleNullTaskAffinity : config.handleNullTaskAffinity;
+        this.authorizationInCurrentTask = config.authorizationInCurrentTask == null ? this.authorizationInCurrentTask : config.authorizationInCurrentTask;
+        this.concurrentAuthorizationRequests = config.concurrentAuthorizationRequests == null ? this.concurrentAuthorizationRequests : config.concurrentAuthorizationRequests;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -37,6 +37,8 @@ import com.microsoft.identity.common.internal.authorities.AuthorityDeserializer;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudienceDeserializer;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
+import com.microsoft.identity.common.internal.controllers.CommandDispatcherConfiguration;
 import com.microsoft.identity.msal.R;
 import com.microsoft.identity.common.logging.Logger;
 
@@ -50,6 +52,7 @@ import static com.microsoft.identity.client.internal.MsalUtils.validateNonNullAr
 
 public class PublicClientApplicationConfigurationFactory {
     private static final String TAG = PublicClientApplicationConfigurationFactory.class.getSimpleName();
+    private static final int DEFAULT_MAX_THREAD_POOL_INTERACTIVE_CONCURRENT = 5;
 
     /**
      * Initializes a default PublicClientApplicationConfiguration object.
@@ -91,6 +94,14 @@ public class PublicClientApplicationConfigurationFactory {
             config.validateConfiguration();
         }
 
+        //Configure dispatcher if required
+        if(config.concurrentAuthorizationRequests()){
+            CommandDispatcherConfiguration dispatcherConfiguration = CommandDispatcherConfiguration.builder()
+                    .maxTheadPoolInteractive(DEFAULT_MAX_THREAD_POOL_INTERACTIVE_CONCURRENT)
+                    .build();
+
+            CommandDispatcher.configureCommandDispatcher(dispatcherConfiguration);
+        }
         config.setOAuth2TokenCache(MsalOAuth2TokenCache.create(context));
         return config;
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -141,6 +141,7 @@ public class CommandParametersAdapter {
                 .isWebViewZoomControlsEnabled(configuration.isWebViewZoomControlsEnabled())
                 .isWebViewZoomEnabled(configuration.isWebViewZoomEnabled())
                 .handleNullTaskAffinity(configuration.isHandleNullTaskAffinityEnabled())
+                .authorizationInCurrentTask(configuration.authorizationInCurrentTask())
                 .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
                 .correlationId(parameters.getCorrelationId())
                 .build();

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -17,6 +17,8 @@
   "environment": "Production",
   "power_opt_check_for_network_req_enabled": true,
   "handle_null_taskaffinity": false,
+  "authorization_in_current_task": false,
+  "concurrent_authorization_requests": false,
   "http": {
     "connect_timeout": 10000,
     "read_timeout": 30000

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     // Compile Dependency
     localImplementation project(':msal')
-    //distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
+    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     // Compile Dependency
     localImplementation project(':msal')
-    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
+    //distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"

--- a/testapps/testapp/src/main/res/raw/msal_config_default.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_default.json
@@ -3,6 +3,7 @@
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "handle_null_taskaffinity": true,
+  "concurrent_authorization_requests": true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
- concurrent_authorization_requests (boolean, default: false) - controls whether concurrent authorization requests are allowed
- authorization_in_current_task  (boolean, default:false)-  controls whether authorization occurs in the same task as the activity that started interactive request or occurs in a new task
- concurrent_authorization_requests setting is used in initializeConfigurationInternal to configure the command dispatcher to allow a new max threads in the interactive thread pool