### PR TITLE
New Authorization Behavior - Use current task rather than new task

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -291,12 +291,14 @@ dependencies {
         transitive = true
     }
 
+    /*
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
 
     //TODO: we will have to change transitive to true once common4j is published
     distApi("com.microsoft.identity:common:3.4.3") {
         transitive = false
     }
+    */
 
 
 }

--- a/msal/src/main/AndroidManifest.xml
+++ b/msal/src/main/AndroidManifest.xml
@@ -13,16 +13,26 @@
             android:exported="false"
             android:launchMode="singleTask" />
 
+        <activity
+            android:name="com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskAuthorizationActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
+            android:exported="false"
+            android:launchMode="standard" />
+
         <!-- Helper activity for displaying current broker redirect URI configuration -->
         <activity
             android:name="com.microsoft.identity.client.helper.BrokerHelperActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
             android:exported="false"
-            android:launchMode="singleTask" />
+            android:launchMode="standard" />
 
         <!-- MSAL will use system webview (custom tab) to render the sign-in page, BrowserTabActivity is to get response back from System Webview. Multiple apps on the device could integrate MSAL, OS will check which BrowserTabActivity can handle the intent based on the intent filter declared, so this activity has to be exported.-->
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true" />
+
+        <activity
+            android:name="com.microsoft.identity.client.CurrentTaskBrowserTabActivity"
             android:exported="true" />
     </application>
 </manifest>

--- a/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
@@ -1,0 +1,118 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.microsoft.identity.common.internal.providers.oauth2.BrowserAuthorizationFragment;
+import com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskBrowserAuthorizationFragment;
+import com.microsoft.identity.common.internal.util.StringUtil;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.REDIRECT_RETURNED_ACTION;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.DESTROY_REDIRECT_RECEIVING_ACTIVITY;
+
+
+/**
+ * MSAL activity class (needs to be public in order to be discoverable by the os) to get the browser redirect with auth code from authorize
+ * endpoint. This activity has to be exposed by "android:exported=true", and intent filter has to be declared in the
+ * manifest for the activity.
+ * <p>
+ * When the AuthorizationAgent is launched, and we're redirected back with the redirect
+ * uri (the redirect must be unique across apps on a device), the os will fire an intent with the redirect,
+ * and the BrowserTabActivity will be launched.
+ * <pre>
+ * &lt;intent-filter&gt;
+ *     &lt;action android:name="android.intent.action.VIEW" /&gt;
+ *
+ *     To receive implicit intents, have to put the activity in the category of default.
+ *     &lt;category android:name="android.intent.category.DEFAULT" /&gt;
+ *
+ *     The target activity allows itself to be started by a web browser to display data.
+ *     &lt;category android:name="android.intent.category.BROWSABLE" /&gt;
+ *
+ *     BrowserTabActivity will be launched when matching the custom url scheme.
+ *     &lt;data android:scheme="msalclientid" android:host="auth" /&gt;
+ * &lt;/intent-filter&gt;
+ * </pre>
+ */
+public final class CurrentTaskBrowserTabActivity extends Activity {
+    private static final int REDIRECT_RECEIVED_CODE = 2;
+    private BroadcastReceiver mCloseBroadcastReceiver;
+
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        if (savedInstanceState == null
+                && getIntent() != null
+                && !StringUtil.isEmpty(getIntent().getDataString())) {
+            //Leaving this for now to set static response URI value
+            final Intent responseIntent = CurrentTaskBrowserAuthorizationFragment.createCustomTabResponseIntent(this, getIntent().getDataString());
+
+            if (responseIntent != null) {
+                startActivityForResult(responseIntent, REDIRECT_RECEIVED_CODE);
+            } else {
+                //LoggerTAG, "Received NULL response intent. Unable to complete authorization.");
+                Toast.makeText(getApplicationContext(), "Unable to complete authorization as there is no interactive call in progress. This can be due to closing the app while the authorization was in process.", Toast.LENGTH_LONG).show();
+            }
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode == RESULT_CANCELED) {
+            // We weren't able to open CurrentTaskAuthorizationActivity from the back stack. Send a broadcast
+            // instead.
+            Intent broadcast = new Intent(REDIRECT_RETURNED_ACTION);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+
+            // Wait for the custom tab to be removed from the back stack before finishing.
+            mCloseBroadcastReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    CurrentTaskBrowserTabActivity.this.finish();
+                }
+            };
+            LocalBroadcastManager.getInstance(this).registerReceiver(
+                    mCloseBroadcastReceiver,
+                    new IntentFilter(DESTROY_REDIRECT_RECEIVING_ACTIVITY)
+            );
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mCloseBroadcastReceiver);
+        super.onDestroy();
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -621,7 +621,7 @@ public class PublicClientApplicationConfiguration {
         for (final ResolveInfo info : resolveInfoList) {
             final ActivityInfo activityInfo = info.activityInfo;
 
-            if (activityInfo.name.equals(BrowserTabActivity.class.getName()) &&
+            if ((activityInfo.name.equals(BrowserTabActivity.class.getName()) || (activityInfo.name.equals((CurrentTaskBrowserTabActivity.class.getName())))) &&
                     activityInfo.packageName.equals(context.getPackageName())) {
                 hasActivity = true;
             } else {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.authorities.AuthorityDeserializer;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudienceDeserializer;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.configuration.MsalConfiguration;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherConfiguration;
 import com.microsoft.identity.msal.R;
@@ -102,6 +103,12 @@ public class PublicClientApplicationConfigurationFactory {
 
             CommandDispatcher.configureCommandDispatcher(dispatcherConfiguration);
         }
+
+        if(config.authorizationInCurrentTask()){
+            MsalConfiguration msalConfiguration = MsalConfiguration.builder().authorizationInCurrentTask((true)).build();
+            MsalConfiguration.intializeMsalConfiguration(msalConfiguration);
+        }
+
         config.setOAuth2TokenCache(MsalOAuth2TokenCache.create(context));
         return config;
     }

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -100,7 +100,7 @@ dependencies {
 
     // Compile Dependency
     localImplementation project(':msal')
-    distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
+    //distImplementation "com.microsoft.identity.client:msal:${msalVersion}"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -66,8 +66,8 @@
         </activity>
 
         <activity
-            android:name="com.microsoft.identity.client.BrowserTabActivity"
-            android:launchMode="singleTask">
+            android:name="com.microsoft.identity.client.CurrentTaskBrowserTabActivity"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/testapps/testapp/src/main/res/raw/msal_config_default.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_default.json
@@ -2,8 +2,9 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "handle_null_taskaffinity": true,
+  "handle_null_taskaffinity": false,
   "concurrent_authorization_requests": true,
+  "authorization_in_current_task": true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
- Added a new CurrentTaskBrowserTabActivity to receive the result of the authorization request
- Modified the code that looks for other apps having registered the redirect URI intent filer to account for this new activity
- configured Msalconfiguration singleton in PCAConfig initializeInternal method.