### PR TITLE
Fix msal dist dep conflict

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -280,7 +280,10 @@ dependencies {
     testImplementation "org.mockito:mockito-inline:$rootProject.ext.mockitoCoreVersion"
     testImplementation ("org.robolectric:robolectric:$rootProject.ext.robolectricVersion")
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
-    testImplementation project(':testutils')
+    implementation(project(":testutils")) {
+        // MSAL has direct dependency on common
+        exclude module: 'common'
+    }
     // instrumentation test dependencies
     androidTestImplementation "androidx.test.ext:junit:$rootProject.ext.androidxJunitVersion"
     // Set this dependency to use JUnit 4 rules


### PR DESCRIPTION
@p3dr0rv noticed an issue with dependency resolution while building msal dist variant. dist was pulling in common 3.4.3 while testutils was trying to pull local module and that was causing the build to fail.