### PR TITLE
MSAL updates to support loading launching custom tabs in current task

### DIFF
--- a/msal/src/main/AndroidManifest.xml
+++ b/msal/src/main/AndroidManifest.xml
@@ -13,16 +13,26 @@
             android:exported="false"
             android:launchMode="singleTask" />
 
+        <activity
+            android:name="com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskAuthorizationActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
+            android:exported="false"
+            android:launchMode="standard" />
+
         <!-- Helper activity for displaying current broker redirect URI configuration -->
         <activity
             android:name="com.microsoft.identity.client.helper.BrokerHelperActivity"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
             android:exported="false"
-            android:launchMode="singleTask" />
+            android:launchMode="standard" />
 
         <!-- MSAL will use system webview (custom tab) to render the sign-in page, BrowserTabActivity is to get response back from System Webview. Multiple apps on the device could integrate MSAL, OS will check which BrowserTabActivity can handle the intent based on the intent filter declared, so this activity has to be exported.-->
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true" />
+
+        <activity
+            android:name="com.microsoft.identity.client.CurrentTaskBrowserTabActivity"
             android:exported="true" />
     </application>
 </manifest>

--- a/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
@@ -1,0 +1,141 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import com.microsoft.identity.common.adal.internal.util.StringExtensions;
+import com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskBrowserAuthorizationFragment;
+import com.microsoft.identity.common.internal.util.StringUtil;
+import com.microsoft.identity.common.logging.Logger;
+
+import java.util.HashMap;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.DESTROY_REDIRECT_RECEIVING_ACTIVITY;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.AuthorizationIntentAction.REDIRECT_RETURNED_ACTION;
+
+
+/**
+ * MSAL activity class (needs to be public in order to be discoverable by the os) to get the browser redirect with auth code from authorize
+ * endpoint. This activity has to be exposed by "android:exported=true", and intent filter has to be declared in the
+ * manifest for the activity.
+ * <p>
+ * When the AuthorizationAgent is launched, and we're redirected back with the redirect
+ * uri (the redirect must be unique across apps on a device), the os will fire an intent with the redirect,
+ * and the CurrentTaskBrowserTabActivity will be launched.
+ *
+ * Only use this if you've configured MSAL to use currenntTaskForAuthorizationActivities
+ * <pre>
+ * &lt;intent-filter&gt;
+ *     &lt;action android:name="android.intent.action.VIEW" /&gt;
+ *
+ *     To receive implicit intents, have to put the activity in the category of default.
+ *     &lt;category android:name="android.intent.category.DEFAULT" /&gt;
+ *
+ *     The target activity allows itself to be started by a web browser to display data.
+ *     &lt;category android:name="android.intent.category.BROWSABLE" /&gt;
+ *
+ *     BrowserTabActivity will be launched when matching the custom url scheme.
+ *     &lt;data android:scheme="msalclientid" android:host="auth" /&gt;
+ * &lt;/intent-filter&gt;
+ * </pre>
+ */
+public final class CurrentTaskBrowserTabActivity extends Activity {
+    private static final String TAG = CurrentTaskBrowserTabActivity.class.getSimpleName();
+    private static final int REDIRECT_RECEIVED_CODE = 2;
+    private BroadcastReceiver mCloseBroadcastReceiver;
+    //private int mTaskIdResponseFor;
+
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        final String response = getIntent().getDataString();
+        final HashMap<String, String> urlParameters = StringUtil.isEmpty(response) ? null : StringExtensions.getUrlParameters(response);
+        if(urlParameters != null){
+            /*
+            if(urlParameters.containsKey("state")) {
+                mTaskIdResponseFor = AndroidTaskStateGenerator.getTaskFromState(decodeState(urlParameters.get("state")));
+            }else{
+                IllegalStateException ex = new IllegalStateException("Did not receive a task id in the authorization response.");
+                com.microsoft.identity.common.logging.Logger.error(TAG, "Did not receive task id in the authorization response", ex);
+                throw ex;
+            }
+             */
+        }
+
+        if (savedInstanceState == null
+                && getIntent() != null
+                && !StringUtil.isEmpty(getIntent().getDataString())) {
+            //Leaving this for now to set static response URI value
+            final Intent responseIntent = CurrentTaskBrowserAuthorizationFragment.createCustomTabResponseIntent(this, response);
+
+            if (responseIntent != null) {
+                startActivityForResult(responseIntent, REDIRECT_RECEIVED_CODE);
+            } else {
+                Logger.warn(TAG,"Received NULL response intent. Unable to complete authorization.");
+                Toast.makeText(getApplicationContext(), "Unable to complete authorization as there is no interactive call in progress. This can be due to closing the app while the authorization was in process.", Toast.LENGTH_LONG).show();
+            }
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode == RESULT_CANCELED) {
+            // We weren't able to open CurrentTaskAuthorizationActivity from the back stack. Send a broadcast
+            // instead.
+            Intent broadcast = new Intent(REDIRECT_RETURNED_ACTION);
+            LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
+
+            // Wait for the custom tab to be removed from the back stack before finishing.
+            mCloseBroadcastReceiver = new BroadcastReceiver() {
+                @Override
+                public void onReceive(Context context, Intent intent) {
+                    CurrentTaskBrowserTabActivity.this.finish();
+                }
+            };
+            LocalBroadcastManager.getInstance(this).registerReceiver(
+                    mCloseBroadcastReceiver,
+                    new IntentFilter(DESTROY_REDIRECT_RECEIVING_ACTIVITY)
+            );
+        }
+    }
+
+    @Override
+    protected void onDestroy() {
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mCloseBroadcastReceiver);
+        super.onDestroy();
+    }
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -75,6 +75,7 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_ENABLED;
 import static com.microsoft.identity.client.exception.MsalClientException.APP_MANIFEST_VALIDATION_ERROR;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_IN_CURRENT_TASK;
 
 public class PublicClientApplicationConfiguration {
     private static final String TAG = PublicClientApplicationConfiguration.class.getSimpleName();
@@ -100,6 +101,8 @@ public class PublicClientApplicationConfiguration {
         static final String WEB_VIEW_ZOOM_CONTROLS_ENABLED = "web_view_zoom_controls_enabled";
         static final String WEB_VIEW_ZOOM_ENABLED = "web_view_zoom_enabled";
         static final String POWER_OPT_CHECK_FOR_NETWORK_REQUEST_ENABLED = "power_opt_check_for_network_req_enabled";
+        static final String AUTHORIZATION_IN_CURRENT_TASK = "authorization_in_current_task";
+
 
     }
 
@@ -153,6 +156,9 @@ public class PublicClientApplicationConfiguration {
 
     @SerializedName(POWER_OPT_CHECK_FOR_NETWORK_REQUEST_ENABLED)
     private Boolean powerOptCheckEnabled;
+
+    @SerializedName(AUTHORIZATION_IN_CURRENT_TASK)
+    private Boolean authorizationInCurrentTask;
 
     transient private OAuth2TokenCache mOAuth2TokenCache;
 
@@ -367,6 +373,10 @@ public class PublicClientApplicationConfiguration {
         this.powerOptCheckEnabled = powerOptCheckEnabled;
     }
 
+    public Boolean authorizationInCurrentTask() {
+        return authorizationInCurrentTask;
+    }
+
     public Authority getDefaultAuthority() {
         if (mAuthorities != null) {
             if (mAuthorities.size() > 1) {
@@ -435,9 +445,10 @@ public class PublicClientApplicationConfiguration {
         this.mClientCapabilities = config.mClientCapabilities == null ? this.mClientCapabilities : config.mClientCapabilities;
         this.mIsSharedDevice = config.mIsSharedDevice == true ? this.mIsSharedDevice : config.mIsSharedDevice;
         this.mLoggerConfiguration = config.mLoggerConfiguration == null ? this.mLoggerConfiguration : config.mLoggerConfiguration;
-        this.webViewZoomControlsEnabled = config.webViewZoomControlsEnabled == null || config.webViewZoomControlsEnabled;
-        this.webViewZoomEnabled = config.webViewZoomEnabled == null || config.webViewZoomEnabled;
-        this.powerOptCheckEnabled = config.powerOptCheckEnabled == null || config.powerOptCheckEnabled;
+        this.webViewZoomControlsEnabled = config.webViewZoomControlsEnabled == null ? this.webViewZoomControlsEnabled : config.webViewZoomControlsEnabled;
+        this.webViewZoomEnabled = config.webViewZoomEnabled == null ? this.webViewZoomEnabled : config.webViewZoomEnabled;
+        this.powerOptCheckEnabled = config.powerOptCheckEnabled == null ? this.powerOptCheckEnabled : config.powerOptCheckEnabled;
+        this.authorizationInCurrentTask = config.authorizationInCurrentTask == null ? this.authorizationInCurrentTask : config.authorizationInCurrentTask;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfigurationFactory.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.common.internal.authorities.AuthorityDeserializer;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudience;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudienceDeserializer;
 import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
+import com.microsoft.identity.common.internal.configuration.LibraryConfiguration;
 import com.microsoft.identity.msal.R;
 
 import java.io.File;
@@ -89,6 +90,11 @@ public class PublicClientApplicationConfigurationFactory {
         if (developerConfig != null) {
             config.mergeConfiguration(developerConfig);
             config.validateConfiguration();
+        }
+
+        if(config.authorizationInCurrentTask()){
+            LibraryConfiguration libraryConfiguration = LibraryConfiguration.builder().authorizationInCurrentTask((true)).build();
+            LibraryConfiguration.intializeLibraryConfiguration(libraryConfiguration);
         }
 
         config.setOAuth2TokenCache(MsalOAuth2TokenCache.create(context));

--- a/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/MsalUtils.java
@@ -41,6 +41,7 @@ import androidx.annotation.Nullable;
 import androidx.browser.customtabs.CustomTabsService;
 
 import com.microsoft.identity.client.BrowserTabActivity;
+import com.microsoft.identity.client.CurrentTaskBrowserTabActivity;
 import com.microsoft.identity.client.exception.MsalArgumentException;
 
 import org.json.JSONException;
@@ -259,7 +260,8 @@ public final class MsalUtils {
         for (final ResolveInfo info : resolveInfoList) {
             final ActivityInfo activityInfo = info.activityInfo;
 
-            if (activityInfo.name.equals(BrowserTabActivity.class.getName())) {
+            if (activityInfo.name.equals(BrowserTabActivity.class.getName()) ||
+                    activityInfo.name.equals(CurrentTaskBrowserTabActivity.class.getName())) {
                 hasActivity = true;
             } else {
                 // another application is listening for this url scheme, don't open

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -16,6 +16,7 @@
   "web_view_zoom_enabled": true,
   "environment": "Production",
   "power_opt_check_for_network_req_enabled": true,
+  "authorization_in_current_task": false,
   "http": {
     "connect_timeout": 10000,
     "read_timeout": 30000

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -43,7 +43,9 @@
         <activity
             android:name="com.microsoft.identity.client.testapp.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:taskAffinity=""
+            >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>

--- a/testapps/testapp/src/main/res/raw/msal_config_default.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_default.json
@@ -2,6 +2,7 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "authorization_in_current_task": false,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
- Added configuration setting for authorization in current task
- Added default configuration value (false) for the same setting
- Fixed mergedConfiguration bug (already fixed in Dev)
- Exported new activity to receive authorization result for the current task scenario
- Initialized LibraryConfiguration based on PCA configuration (As discussed over email... in next release global configuration should be split out from PCA configuration)
- Changed test app main activity task affinity to null to demonstrate the problem with the current default behavior
- Updated the android manifest validation to add the receive authorization activity to it (CurrentTaskBrowserTabActivity vs BrowserTabActivity)