### PR TITLE
Fix mixed casing issue for acquire token with resource

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/TokenParameters.java
@@ -249,7 +249,7 @@ public abstract class TokenParameters {
                 );
             } else {
                 mScopes = new ArrayList<String>() {{
-                    add(resource.toLowerCase(Locale.ROOT).trim() + "/.default");
+                    add(resource.trim() + "/.default");
                 }};
             }
 

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersResourceTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersResourceTest.java
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.client;
+
+
+import android.util.Log;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class TokenParametersResourceTest {
+
+    public final static String RESOURCE_MIXED_CASE = "https://SomeAADApi.aadgraph.onmicrosoft.com";
+    public final static String RESOURCE_MIXED_CASE_DEFAULT_APPENDED = RESOURCE_MIXED_CASE + "/.default";
+
+    /**
+     * Verify that the casing of the provided resource is not altered by the building of the parameters.
+     * In addition verify that the /.default value was added to the reosource to convert it to a scope for the purposes of the v2 endpoint.
+     */
+    @Test
+    public void testVerifyScopeIsAsProvided() {
+
+        AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder().withResource(RESOURCE_MIXED_CASE).build();
+
+        assertEquals(RESOURCE_MIXED_CASE_DEFAULT_APPENDED, acquireTokenParameters.getScopes().get(0));
+
+    }
+}

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -96,7 +96,7 @@ abstract class MsalWrapper {
 
         final AcquireTokenParameters.Builder builder = getAcquireTokenParametersBuilder(activity, requestOptions, callback);
         builder.withAuthorizationQueryStringParameters(null);
-        builder.withResource(requestOptions.getScopes().toLowerCase().trim());
+        builder.withResource(requestOptions.getScopes().trim());
 
         final AcquireTokenParameters parameters = builder.build();
         acquireTokenAsyncInternal(parameters);


### PR DESCRIPTION
Fixes the following issue: https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1416