### PR TITLE
Kill HTTP layer adapters. make changes to accommodate common

### DIFF
--- a/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestMockUtil.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/AndroidTestMockUtil.java
@@ -31,6 +31,8 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 
+import javax.net.ssl.HttpsURLConnection;
+
 /**
  * Util class for mocking.
  */
@@ -40,7 +42,7 @@ public final class AndroidTestMockUtil {
     }
 
     static HttpURLConnection getMockedConnectionWithSuccessResponse(final String message) throws IOException {
-        final HttpURLConnection mockedHttpUrlConnection = getCommonHttpUrlConnection();
+        final HttpsURLConnection mockedHttpUrlConnection = getCommonHttpsUrlConnection();
 
         Mockito.when(mockedHttpUrlConnection.getInputStream()).thenReturn(AndroidTestUtil.createInputStream(message));
         Mockito.when(mockedHttpUrlConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
@@ -48,9 +50,9 @@ public final class AndroidTestMockUtil {
         return mockedHttpUrlConnection;
     }
 
-    static HttpURLConnection getMockedConnectionWithFailureResponse(final int statusCode, final String errorMessage)
+    static HttpsURLConnection getMockedConnectionWithFailureResponse(final int statusCode, final String errorMessage)
             throws IOException {
-        final HttpURLConnection mockedHttpUrlConnection = getCommonHttpUrlConnection();
+        final HttpsURLConnection mockedHttpUrlConnection = getCommonHttpsUrlConnection();
 
         Mockito.when(mockedHttpUrlConnection.getInputStream()).thenThrow(IOException.class);
         Mockito.when(mockedHttpUrlConnection.getErrorStream()).thenReturn(AndroidTestUtil.createInputStream(errorMessage));
@@ -59,15 +61,15 @@ public final class AndroidTestMockUtil {
         return mockedHttpUrlConnection;
     }
 
-    static HttpURLConnection getMockedConnectionWithSocketTimeout() throws IOException {
-        final HttpURLConnection mockedUrlConnection = getCommonHttpUrlConnection();
+    static HttpsURLConnection getMockedConnectionWithSocketTimeout() throws IOException {
+        final HttpsURLConnection mockedUrlConnection = getCommonHttpsUrlConnection();
 
         Mockito.when(mockedUrlConnection.getInputStream()).thenThrow(SocketTimeoutException.class);
         return mockedUrlConnection;
     }
 
-    static HttpURLConnection getCommonHttpUrlConnection() throws IOException {
-        final HttpURLConnection mockedConnection = Mockito.mock(HttpURLConnection.class);
+    static HttpsURLConnection getCommonHttpsUrlConnection() throws IOException {
+        final HttpsURLConnection mockedConnection = Mockito.mock(HttpsURLConnection.class);
         Mockito.doNothing().when(mockedConnection).setConnectTimeout(Mockito.anyInt());
         Mockito.doNothing().when(mockedConnection).setDoInput(Mockito.anyBoolean());
         return mockedConnection;

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -47,7 +47,7 @@ import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
-import com.microsoft.identity.common.internal.result.ResultFuture;
+import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -38,7 +38,6 @@ import androidx.fragment.app.Fragment;
 
 import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.client.configuration.AccountMode;
-import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -89,7 +88,6 @@ import com.microsoft.identity.common.internal.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.internal.migration.AdalMigrationAdapter;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
 import com.microsoft.identity.common.internal.migration.TokenMigrationUtility;
-import com.microsoft.identity.common.internal.net.HttpRequest;
 import com.microsoft.identity.common.internal.net.cache.HttpCache;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftAccount;
 import com.microsoft.identity.common.internal.providers.microsoft.MicrosoftRefreshToken;
@@ -98,7 +96,7 @@ import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.internal.result.GenerateShrResult;
 import com.microsoft.identity.common.internal.result.ILocalAuthenticationResult;
 import com.microsoft.identity.common.internal.result.LocalAuthenticationResult;
-import com.microsoft.identity.common.internal.result.ResultFuture;
+import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 import com.microsoft.identity.msal.BuildConfig;
 
@@ -1069,7 +1067,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
         Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
 
-        initializeHttpSettings(mPublicClientConfiguration.getHttpConfiguration());
         initializeLoggerSettings(mPublicClientConfiguration.getLoggerConfiguration());
 
         initializeTokenSharingLibrary();
@@ -1100,32 +1097,6 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
             logger.setEnablePII(configPiiState);
             logger.setEnableLogcatLog(configLogcatState);
-        }
-    }
-
-    private void initializeHttpSettings(@Nullable final HttpConfiguration httpConfiguration) {
-        final String methodName = ":initializeHttpSettings";
-
-        if (null == httpConfiguration) {
-            Logger.info(
-                    TAG + methodName,
-                    "HttpConfiguration not provided - using defaults."
-            );
-
-            return;
-        }
-
-        final int readTimeout = httpConfiguration.getReadTimeout();
-        final int connectTimeout = httpConfiguration.getConnectTimeout();
-
-        // Configured values must be >= 0
-
-        if (readTimeout >= 0) {
-            HttpRequest.READ_TIMEOUT = readTimeout;
-        }
-
-        if (connectTimeout >= 0) {
-            HttpRequest.CONNECT_TIMEOUT = connectTimeout;
         }
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -51,7 +51,7 @@ import com.microsoft.identity.common.internal.controllers.CommandDispatcher;
 import com.microsoft.identity.common.internal.dto.AccountRecord;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
 import com.microsoft.identity.common.internal.result.ILocalAuthenticationResult;
-import com.microsoft.identity.common.internal.result.ResultFuture;
+import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.List;

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/PublicClientApplicationAbstractTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/PublicClientApplicationAbstractTest.java
@@ -35,12 +35,16 @@ import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelpe
 
 import org.junit.Before;
 import org.mockito.Mockito;
+import org.robolectric.annotation.LooperMode;
 
 import java.io.File;
 
 import static com.microsoft.identity.client.e2e.utils.RoboTestUtils.flushScheduler;
 import static org.junit.Assert.fail;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 
+// TODO: move to "PAUSED". A work in RoboTestUtils will be needed though.
+@LooperMode(LEGACY)
 public abstract class PublicClientApplicationAbstractTest implements IPublicClientApplicationTest {
 
     protected final String SHARED_PREFERENCES_NAME = "com.microsoft.identity.client.account_credential_cache";


### PR DESCRIPTION
See: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1396