### PR TITLE
Fix lint task problem, update version, update dist common dependency

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -276,7 +276,7 @@ dependencies {
 
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.4.3', changing: true)
 
-    distApi("com.microsoft.identity:common:3.4.3") {
+    distApi("com.microsoft.identity:common:3.4.4-RC1") {
         transitive = false
     }
 }
@@ -418,6 +418,8 @@ publishing {
 }
 
 tasks.whenTaskAdded { task ->
+
+
     if (task.name.contains('assemble')) {
         task.dependsOn 'pmd'
     }
@@ -426,6 +428,10 @@ tasks.whenTaskAdded { task ->
         && !task.name.contains('Snapshot')
         && !task.name.contains('Test')
         && !task.name.contains('Local')) {
-        task.dependsOn 'lint', 'javadocJar', 'sourcesJar'
+        task.dependsOn 'javadocJar', 'sourcesJar'
     }
+
+
+
+
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.0.12
+versionName=2.1.0-RC1
 versionCode=0


### PR DESCRIPTION
- Removed lint as a task dependency for all things for now.  Lint requires you to specify the variant to apply it to.  Currently it was running for all variants which leads to compilation failures for different variants.
- Updated the version of library
- Updated the version of the dependency
https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items