### PR TITLE
Update msal-maven-release.yml

### DIFF
--- a/azure-pipelines/maven-release/msal-maven-release.yml
+++ b/azure-pipelines/maven-release/msal-maven-release.yml
@@ -28,7 +28,7 @@ jobs:
     projectVersion: $(msalVersion)
     checkoutSubmodules: recursive
     envVstsMvnAndroidAccessTokenVar: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
-    gradleAssembleReleaseTask: msal:clean msal:assembleRelease
+    gradleAssembleReleaseTask: msal:clean msal:assembleDistRelease
     gradleGeneratePomFiletask: msal:generatePomFileForMsalPublication
     aarSourceFolder: msal\build\outputs\aar
     jarSourceFolder: msal\build\outputs\jar


### PR DESCRIPTION
msal:assembleRelease attempts to create all release builds.  In this case I only want the dist release.