### PR TITLE
Make text selectable in certificate hash dialog

### DIFF
--- a/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
+++ b/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
@@ -156,7 +156,7 @@ public class MainActivity extends AppCompatActivity {
                         msg += "\n\n" + getAuthenticatorAppMetadata(pkgName);
                     }
 
-                    LayoutInflater layoutInflater = (LayoutInflater) MainActivity.this.getSystemService(LAYOUT_INFLATER_SERVICE);
+                    LayoutInflater layoutInflater = LayoutInflater.from(MainActivity.this);
 
                     View dialogView = layoutInflater.inflate(R.layout.dialog_layout, null, false);
                     TextView hashTextView = dialogView.findViewById(R.id.certificateHashTextView);

--- a/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
+++ b/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
@@ -33,12 +33,14 @@ import android.content.pm.Signature;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.Base64;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
+import android.widget.TextView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -148,15 +150,22 @@ public class MainActivity extends AppCompatActivity {
                         packageSigningSha = Base64.encodeToString(digest.digest(), Base64.NO_WRAP);
                     }
 
-                    String msg = "Certificate hash:\n" + packageSigningSha;
+                    String msg = packageSigningSha;
 
                     if (isAnAuthenticatorApp(pkgName)) {
                         msg += "\n\n" + getAuthenticatorAppMetadata(pkgName);
                     }
 
+                    LayoutInflater layoutInflater = (LayoutInflater) MainActivity.this.getSystemService(LAYOUT_INFLATER_SERVICE);
+
+                    View dialogView = layoutInflater.inflate(R.layout.dialog_layout, null, false);
+                    TextView hashTextView = dialogView.findViewById(R.id.certificateHashTextView);
+
+                    hashTextView.setText(msg);
+
                     new AlertDialog.Builder(MainActivity.this)
+                            .setView(dialogView)
                             .setTitle(pkgName)
-                            .setMessage(msg)
                             .setPositiveButton(
                                     MainActivity.this.getString(R.string.dismiss),
                                     new DialogInterface.OnClickListener() {

--- a/package-inspector/src/main/res/layout/dialog_layout.xml
+++ b/package-inspector/src/main/res/layout/dialog_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="20dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/certificate_hash"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    <TextView
+        android:id="@+id/certificateHashTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:textIsSelectable="true" />
+
+</LinearLayout>

--- a/package-inspector/src/main/res/values/strings.xml
+++ b/package-inspector/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <resources>
     <string name="app_name">Package Inspector</string>
     <string name="dismiss">Dismiss</string>
+    <string name="certificate_hash">Certificate Hash:</string>
 </resources>


### PR DESCRIPTION
- Allows the user to copy the certificate hash from the dialog.

![Screenshot_1623315027](https://user-images.githubusercontent.com/25629064/121495194-16f6d880-c9e2-11eb-844a-03d7b0357686.png)
