### PR TITLE
remove task when task affinity is null

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
+++ b/msal/src/main/java/com/microsoft/identity/client/CurrentTaskBrowserTabActivity.java
@@ -27,6 +27,9 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -103,11 +106,31 @@ public final class CurrentTaskBrowserTabActivity extends Activity {
             Intent broadcast = new Intent(REDIRECT_RETURNED_ACTION);
             LocalBroadcastManager.getInstance(this).sendBroadcast(broadcast);
 
+
+
+
             // Wait for the custom tab to be removed from the back stack before finishing.
             mCloseBroadcastReceiver = new BroadcastReceiver() {
                 @Override
                 public void onReceive(Context context, Intent intent) {
-                    CurrentTaskBrowserTabActivity.this.finish();
+
+                    boolean hasNullTaskAffinity = false;
+                    final PackageManager packageManager = CurrentTaskBrowserTabActivity.this.getApplicationContext().getPackageManager();
+                    try {
+                        final ActivityInfo activityInfo = CurrentTaskBrowserTabActivity.this.getComponentName() != null ? packageManager.getActivityInfo(CurrentTaskBrowserTabActivity.this.getComponentName(), 0) : null;
+                        if(activityInfo.taskAffinity == null){
+                            hasNullTaskAffinity = true;
+                        }
+                    } catch (PackageManager.NameNotFoundException e) {
+                        e.printStackTrace();
+                    }
+
+                    finishActivity(REDIRECT_RECEIVED_CODE);
+                    if(Build.VERSION.SDK_INT > 21 && hasNullTaskAffinity) {
+                        finishAndRemoveTask();
+                    }else{
+                        finish();
+                    }
                 }
             };
             LocalBroadcastManager.getInstance(this).registerReceiver(


### PR DESCRIPTION
If none of the activities in an application use the default task affinity (package name).  Then when the authorization result is returned the intent filter launches that activity in the default affinity.  When the activities are "finished" for the authorization code flow the task is left behind and is present/clickable in the recents view.  

Since we don't know if there will be other activities currently using the default task affinity.  This change pre-supposes that teams wanting to avoid this situation will set the task affinity of the activity receiving the authorization result (CurrentTaskBrowserTabActivity) to null via the android manifest.  android:taskAffinity="" (empty string interpreted as null).  

When we see a null task affinity in authorization flow we will finish that activity and remove the associated task.  