### PR TITLE
Clean up renamed methods in common MockHttpClient

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
@@ -101,7 +101,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
         mockHttpClient.intercept(
                 HttpRequestMatcher.builder().isPOST().build(), new HttpRequestInterceptor() {
                     @Override
-                    public HttpResponse intercept(
+                    public HttpResponse performIntercept(
                             @NonNull HttpClient.HttpMethod httpMethod,
                             @NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -105,7 +105,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         mockHttpClient.intercept(postRequestMatcher,
                 new HttpRequestInterceptor() {
                     @Override
-                    public HttpResponse intercept(
+                    public HttpResponse performIntercept(
                             @NonNull HttpClient.HttpMethod httpMethod,
                             @NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,


### PR DESCRIPTION
Accomodate changes in common.

Prerequisite: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1423