### PR TITLE
Accommodate changes in common

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -37,12 +37,12 @@ import com.microsoft.identity.common.internal.cache.MsalOAuth2TokenCache;
 import com.microsoft.identity.common.internal.commands.parameters.InteractiveTokenCommandParameters;
 import com.microsoft.identity.common.internal.commands.parameters.SilentTokenCommandParameters;
 import com.microsoft.identity.common.internal.providers.oauth2.OAuth2TokenCache;
-import com.microsoft.identity.internal.testutils.TestUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.robolectric.RobolectricTestRunner;
 
 import java.io.File;
@@ -62,7 +62,10 @@ public class CommandParametersTest {
     @Before
     public void setup() {
         mContext = ApplicationProvider.getApplicationContext();
-        mActivity = TestUtils.getMockActivity(mContext);
+        final Activity mockedActivity = Mockito.mock(Activity.class);
+        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(mContext);
+
+        mActivity = mockedActivity;
     }
 
 

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
@@ -28,7 +28,6 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
-import com.microsoft.identity.internal.testutils.TestUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -78,7 +77,10 @@ public class TokenParametersAuthorityMyOrgTest {
     @Before
     public void setup() {
         mContext = ApplicationProvider.getApplicationContext();
-        mActivity = TestUtils.getMockActivity(mContext);
+        final Activity mockedActivity = Mockito.mock(Activity.class);
+        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(mContext);
+
+        mActivity = mockedActivity;
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
@@ -28,7 +28,6 @@ import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
 
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
-import com.microsoft.identity.internal.testutils.TestUtils;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -90,7 +89,10 @@ public class TokenParametersAuthorityTest {
     @Before
     public void setup() {
         mContext = ApplicationProvider.getApplicationContext();
-        mActivity = TestUtils.getMockActivity(mContext);
+        final Activity mockedActivity = Mockito.mock(Activity.class);
+        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(mContext);
+
+        mActivity = mockedActivity;
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/PublicClientApplicationAbstractTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/PublicClientApplicationAbstractTest.java
@@ -32,9 +32,9 @@ import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper;
-import com.microsoft.identity.internal.testutils.TestUtils;
 
 import org.junit.Before;
+import org.mockito.Mockito;
 
 import java.io.File;
 
@@ -52,7 +52,10 @@ public abstract class PublicClientApplicationAbstractTest implements IPublicClie
     @Before
     public void setup() {
         mContext = ApplicationProvider.getApplicationContext();
-        mActivity = TestUtils.getMockActivity(mContext);
+        final Activity mockedActivity = Mockito.mock(Activity.class);
+        Mockito.when(mockedActivity.getApplicationContext()).thenReturn(mContext);
+
+        mActivity = mockedActivity;
         setupPCA();
         Logger.getInstance().setEnableLogcatLog(true);
         Logger.getInstance().setEnablePII(true);


### PR DESCRIPTION
Updating the mockito dependency structure in common means that we need to alter the unit tests by inlining the mock activity method.