### PR TITLE
update msal-vsts-release.yml remove credscan and policheck

### DIFF
--- a/azure-pipelines/vsts-releases/msal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/msal-vsts-release.yml
@@ -9,17 +9,6 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 pr: none
 
-resources:
-  repositories:
-  - repository: self
-    type: git
-    ref: master
-  - repository: common
-    type: github
-    name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: dev
-    endpoint: ANDROID_GITHUB
-
 jobs:
 - job: Phase_1
   displayName: Phase 1
@@ -36,9 +25,6 @@ jobs:
     inputs:
       filename: echo
       arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(mvnAccessToken)'
-  - template: azure-pipelines/templates/steps/credscan-policheck.yml@common
-    parameters:
-      policheckCmdLineArgsDir: msal
   - task: Gradle@1
     name: Gradle1
     displayName: Assemble Release


### PR DESCRIPTION
credscan and policheck where moved to be individual tasks instead of being a step in all the pipelines,
I removed the template reference `azure-pipelines/templates/steps/credscan-policheck.yml@common`  because it does not exist in common dev anymore 