### PR TITLE
Allow authenticator to pass older format for redirect uri

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 
+Version 2.2.1
+----------
+- [PATCH] Allow Authenticator to pass older format for redirect uri (#1517)
+
 Version 2.2.0
 ----------
 - Picks up common@3.6.0

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -648,7 +648,7 @@ public class PublicClientApplicationConfiguration {
                 }
             }
         } catch (final PackageManager.NameNotFoundException | NoSuchAlgorithmException e) {
-            Logger.error(TAG, "Unexpected error in getting package info/signature for Autheticator", e);
+            Logger.error(TAG, "Unexpected error in getting package info/signature for Authenticator", e);
         }
 
         return false;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -489,7 +489,7 @@ public class PublicClientApplicationConfiguration {
         boolean isInvalid = false;
         if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
         {
-            isInvalid = verifyAuthenticatorRedirectUri();
+            isInvalid = !isValidAuthenticatorRedirectUri();
         } else {
             isInvalid = TextUtils.isEmpty(redirectUri) || !hasSchemeAndAuthority(redirectUri);
         }
@@ -604,7 +604,7 @@ public class PublicClientApplicationConfiguration {
 
         if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
         {
-            if (verifyAuthenticatorRedirectUri())
+            if (isValidAuthenticatorRedirectUri())
             {
                 return;
             }
@@ -623,7 +623,7 @@ public class PublicClientApplicationConfiguration {
         verifyRedirectUriWithAppSignature();
     }
 
-    private boolean verifyAuthenticatorRedirectUri() {
+    private boolean isValidAuthenticatorRedirectUri() {
         try {
             final PackageInfo info = mAppContext.getPackageManager().getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, PackageManager.GET_SIGNATURES);
             if (info != null && info.signatures != null && info.signatures.length > 0) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -39,6 +39,7 @@ import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.internal.MsalUtils;
+import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.internal.authorities.Authority;
 import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAuthority;
@@ -60,6 +61,7 @@ import javax.crypto.SecretKey;
 
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.ACCOUNT_MODE;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORITIES;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_IN_CURRENT_TASK;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_USER_AGENT;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.BROWSER_SAFE_LIST;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.CLIENT_CAPABILITIES;
@@ -76,7 +78,6 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_ENABLED;
 import static com.microsoft.identity.client.exception.MsalClientException.APP_MANIFEST_VALIDATION_ERROR;
-import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.AUTHORIZATION_IN_CURRENT_TASK;
 
 public class PublicClientApplicationConfiguration {
     private static final String TAG = PublicClientApplicationConfiguration.class.getSimpleName();
@@ -535,6 +536,14 @@ public class PublicClientApplicationConfiguration {
                 final MessageDigest messageDigest = MessageDigest.getInstance("SHA");
                 messageDigest.update(signature.toByteArray());
                 final String signatureHash = Base64.encodeToString(messageDigest.digest(), Base64.NO_WRAP);
+
+                if (packageName.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)
+                    && (signatureHash.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE)
+                        || signatureHash.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE))
+                    && mRedirectUri.equalsIgnoreCase(AuthenticationConstants.Broker.BROKER_REDIRECT_URI))
+                {
+                    return;
+                }
 
                 final Uri.Builder builder = new Uri.Builder();
                 final Uri uri = builder.scheme("msauth")

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -621,7 +621,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     private boolean isValidAuthenticatorRedirectUri() {
-        // This is an temporary fix to allow authenticator to migrate to MSAL
+        // This is a temporary fix to allow authenticator to migrate to MSAL
         // For Legacy reason Authenticator still needs to pass in the old redirect uri to be able to
         // have backward compatibility with older versions of BrokerHost (Company Portal)
         // We should remove this check after the new Broker Host apps are released to >90% of production
@@ -634,9 +634,8 @@ public class PublicClientApplicationConfiguration {
                 MessageDigest md = MessageDigest.getInstance("SHA");
                 md.update(signature.toByteArray());
                 final String signatureHash = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
-                if (signatureHash.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE)
-                    || signatureHash.equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE)
-                ) {
+                if (AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE.equalsIgnoreCase(signatureHash)
+                    || AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE.equalsIgnoreCase(signatureHash)) {
                     final Uri.Builder builder = new Uri.Builder();
                     final Uri uri = builder.scheme("msauth")
                             .authority(mAppContext.getPackageName())

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -487,7 +487,7 @@ public class PublicClientApplicationConfiguration {
 
     private void validateRedirectUri(@NonNull final String redirectUri) {
         boolean isInvalid = false;
-        if (AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(mAppContext.getPackageName())) {
+        if (mAppContext!= null && AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(mAppContext.getPackageName())) {
             isInvalid = !isValidAuthenticatorRedirectUri();
         } else {
             isInvalid = TextUtils.isEmpty(redirectUri) || !hasSchemeAndAuthority(redirectUri);
@@ -601,7 +601,7 @@ public class PublicClientApplicationConfiguration {
             return;
         }
 
-        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
+        if (mAppContext!=null && AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(mAppContext.getPackageName())) {
             if (isValidAuthenticatorRedirectUri()) {
                 return;
             }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -487,8 +487,7 @@ public class PublicClientApplicationConfiguration {
 
     private void validateRedirectUri(@NonNull final String redirectUri) {
         boolean isInvalid = false;
-        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
-        {
+        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
             isInvalid = !isValidAuthenticatorRedirectUri();
         } else {
             isInvalid = TextUtils.isEmpty(redirectUri) || !hasSchemeAndAuthority(redirectUri);
@@ -602,10 +601,8 @@ public class PublicClientApplicationConfiguration {
             return;
         }
 
-        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME))
-        {
-            if (isValidAuthenticatorRedirectUri())
-            {
+        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
+            if (isValidAuthenticatorRedirectUri()) {
                 return;
             }
         }
@@ -624,10 +621,16 @@ public class PublicClientApplicationConfiguration {
     }
 
     private boolean isValidAuthenticatorRedirectUri() {
+        // This is an temporary fix to allow authenticator to migrate to MSAL
+        // For Legacy reason Authenticator still needs to pass in the old redirect uri to be able to
+        // have backward compatibility with older versions of BrokerHost (Company Portal)
+        // We should remove this check after the new Broker Host apps are released to >90% of production
+        // customer.
+        // ADO workitem for tracking: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1576096
         try {
             final PackageInfo info = mAppContext.getPackageManager().getPackageInfo(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME, PackageManager.GET_SIGNATURES);
             if (info != null && info.signatures != null && info.signatures.length > 0) {
-                Signature signature = info.signatures[0];
+                final Signature signature = info.signatures[0];
                 MessageDigest md = MessageDigest.getInstance("SHA");
                 md.update(signature.toByteArray());
                 final String signatureHash = Base64.encodeToString(md.digest(), Base64.NO_WRAP);
@@ -645,10 +648,10 @@ public class PublicClientApplicationConfiguration {
                     }
                 }
             }
-        }
-        catch (PackageManager.NameNotFoundException | NoSuchAlgorithmException e) {
+        } catch (final PackageManager.NameNotFoundException | NoSuchAlgorithmException e) {
             Logger.error(TAG, "Unexpected error in getting package info/signature for Autheticator", e);
         }
+
         return false;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -487,7 +487,7 @@ public class PublicClientApplicationConfiguration {
 
     private void validateRedirectUri(@NonNull final String redirectUri) {
         boolean isInvalid = false;
-        if (mAppContext.getPackageName().equalsIgnoreCase(AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME)) {
+        if (AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_PACKAGE_NAME.equalsIgnoreCase(mAppContext.getPackageName())) {
             isInvalid = !isValidAuthenticatorRedirectUri();
         } else {
             isInvalid = TextUtils.isEmpty(redirectUri) || !hasSchemeAndAuthority(redirectUri);


### PR DESCRIPTION
### What is this change
Allowing Authenticator app to pass older format ("urn:ietf:........:oob") of redirect uri, and exempt it from redirect uri verification.

### Why we need this change
As part of Authenticator moving to msal, they are switching to Broker redirect uri format (msauth://<authority>).
On the broker side we have [logic to override the authenticator redirect uri to older format](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/a89e36d3ad4b7c5a9fe2d6bd3a37a418aa509c1a/common/src/main/java/com/microsoft/identity/common/internal/broker/PackageHelper.java#L144). 
This causes the [Broker side validation of the redirect uri](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/a89e36d3ad4b7c5a9fe2d6bd3a37a418aa509c1a/common/src/main/java/com/microsoft/identity/common/internal/broker/BrokerValidator.java#L305) when the active broker is going to be Company Portal (with older versions)
In order to solve this Authenticator is going to continue to pass old redirect uri for older version of Company portal.
However MSAL doesn't allow older format for redirect uri., 

###  How
We are adding an exemption inthe redirect uri verification logic. To check if the package name and signature matchess with Authenticator, pass the validation if the redirect uri passed is older format.

### Testing
Going to share a build with Authenticator team to validate the changes.