### PR TITLE
Update Common dependency and bump up the release version

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -274,9 +274,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.1-RC1', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.2-RC1', changing: true)
 
-    distApi("com.microsoft.identity:common:3.6.1-RC1") {
+    distApi("com.microsoft.identity:common:3.6.2-RC1") {
         transitive = false
     }
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.2.1-RC1
+versionName=2.2.1-RC2
 versionCode=0


### PR DESCRIPTION
In this change
1. Updating the common dep to point to 3.6.2-RC1
2. Updating the common submodule to point to 3.6.2-RC1 (branch release/3.6.2)
3. Bumping up the version to 2.2.1-RC1
