### PR TITLE
Added support for http intercept of device code request (MSAL)

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -231,7 +231,7 @@ public interface IPublicClientApplication {
      * 1). Receiving authentication information (user_code, verification_uri, and instruction message)
      * via {@link DeviceCodeFlowCallback#onUserCodeReceived(String, String, String, Date)}.
      * 2). Receiving a successful authentication result containing a fresh access token
-     * via {@link DeviceCodeFlowCallback#onTokenReceived(AuthenticationResult)}.
+     * via {@link DeviceCodeFlowCallback#onTokenReceived(IAuthenticationResult)}.
      * 3). Receiving an exception detailing what went wrong in the protocol
      * via {@link DeviceCodeFlowCallback#onError(MsalException)}.
      * <p>
@@ -258,14 +258,14 @@ public interface IPublicClientApplication {
          *
          * @param authResult the authentication result
          */
-        void onTokenReceived(@NonNull final AuthenticationResult authResult);
+        void onTokenReceived(@NonNull final IAuthenticationResult authResult);
 
         /**
          * Invoked if an error is encountered during the device code flow and passes the exception object.
          *
-         * @param error error exception
+         * @param exception error exception
          */
-        void onError(@NonNull final MsalException error);
+        void onError(@NonNull final MsalException exception);
     }
 
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1879,7 +1879,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         };
     }
 
-    private DeviceCodeFlowCommandCallback getDeviceCodeFlowCommandCallback(@NonNull final DeviceCodeFlowCallback callback) {
+    protected DeviceCodeFlowCommandCallback getDeviceCodeFlowCommandCallback(@NonNull final DeviceCodeFlowCallback callback) {
         return new DeviceCodeFlowCommandCallback<LocalAuthenticationResult, BaseException>() {
 
             @Override

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1891,36 +1891,16 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             }
 
             @Override
-            public void onTaskCompleted(LocalAuthenticationResult tokenResult) {
+            public void onTaskCompleted(@NonNull final LocalAuthenticationResult tokenResult) {
                 // Convert tokenResult to an AuthenticationResult object
                 final IAuthenticationResult convertedResult = AuthenticationResultAdapter.adapt(
                         tokenResult);
-
-                // Type cast the interface object
-                final AuthenticationResult authResult = (AuthenticationResult) convertedResult;
-
-                callback.onTokenReceived(authResult);
+                callback.onTokenReceived(convertedResult);
             }
 
             @Override
-            public void onError(BaseException error) {
-                final MsalException msalException;
-
-                if (error instanceof ServiceException) {
-                    msalException = new MsalServiceException(
-                            error.getErrorCode(),
-                            error.getMessage(),
-                            ((ServiceException) error).getHttpStatusCode(),
-                            error
-                    );
-                } else {
-                    msalException = new MsalClientException(
-                            error.getErrorCode(),
-                            error.getMessage(),
-                            error
-                    );
-                }
-
+            public void onError(@NonNull final BaseException exception) {
+                final MsalException msalException = MsalExceptionAdapter.msalExceptionFromBaseException(exception);
                 callback.onError(msalException);
             }
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -723,39 +723,19 @@ public class SingleAccountPublicClientApplication
             }
 
             @Override
-            public void onTaskCompleted(LocalAuthenticationResult tokenResult) {
+            public void onTaskCompleted(@NonNull final LocalAuthenticationResult tokenResult) {
                 // Convert tokenResult to an AuthenticationResult object
                 final IAuthenticationResult convertedResult = AuthenticationResultAdapter.adapt(
                         tokenResult);
 
-                // Type cast the interface object
-                final AuthenticationResult authResult = (AuthenticationResult) convertedResult;
-
                 // Persist the account in single account mode
                 persistCurrentAccount(tokenResult.getCacheRecordWithTenantProfileData());
-
-                callback.onTokenReceived(authResult);
+                callback.onTokenReceived(convertedResult);
             }
 
             @Override
-            public void onError(BaseException error) {
-                final MsalException msalException;
-
-                if (error instanceof ServiceException) {
-                    msalException = new MsalServiceException(
-                            error.getErrorCode(),
-                            error.getMessage(),
-                            ((ServiceException) error).getHttpStatusCode(),
-                            error
-                    );
-                } else {
-                    msalException = new MsalClientException(
-                            error.getErrorCode(),
-                            error.getMessage(),
-                            error
-                    );
-                }
-
+            public void onError(@NonNull final BaseException exception) {
+                final MsalException msalException = MsalExceptionAdapter.msalExceptionFromBaseException(exception);
                 callback.onError(msalException);
             }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
@@ -23,10 +23,14 @@
 package com.microsoft.identity.client.e2e.shadows;
 
 import com.microsoft.identity.common.java.cache.CacheRecord;
-import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommand;
 import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommandCallback;
+import com.microsoft.identity.common.java.cache.ICacheRecord;
+import com.microsoft.identity.common.java.dto.AccessTokenRecord;
 import com.microsoft.identity.common.java.dto.AccountRecord;
+import com.microsoft.identity.common.java.dto.CredentialType;
+import com.microsoft.identity.common.java.dto.IdTokenRecord;
+import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.request.SdkType;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult;
@@ -46,6 +50,22 @@ import java.util.concurrent.TimeUnit;
  */
 @Implements(DeviceCodeFlowCommand.class)
 public class ShadowDeviceCodeFlowCommandSuccessful {
+    private final static String AUTHORITY_TYPE = "MSSTS";
+    private final static String LOCAL_ACCOUNT_ID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
+    private final static String USERNAME = "mock-username";
+    private final static String HOME_ACCOUNT_ID = "mock-home-account-id";
+    private final static String ENVIRONMENT = "login.windows.net";
+    private final static String REALM = "3c62ac97-29eb-4aed-a3c8-add0298508d";
+    private final static String TARGET = "mock-target";
+    private final static String CACHE_AT = "mock-cache-at";
+    private final static String EXPIRES_ON = String.valueOf(System.currentTimeMillis() + 100000);
+    private final static String AT_SECRET = "d22d37bf-6e2c-40ea-b763-774897c05262";
+    private final static String CLIENT_ID = "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0";
+    private final static String RT_SECRET = "adf49b53-a92f-4930-9de6-926505d29e18";
+    private final static String RAW_ID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJUZXN0U3ViamVjdCIsImF1ZCI6ImF1ZGllbmNlLWZvci10ZXN0aW5nIiwidmVyIjoiMi4wIiwibmJmIjoxNjMyMzYxODY1LCJpc3MiOiJodHRwczpcL1wvdGVzdC5hdXRob3JpdHlcLzM1OTY1NDJlLTFlMGItNGM4Yy05YjM0LWI4M2ZkZDA1Mjk5MFwvdjIuMCIsIm5hbWUiOiJ0ZXN0IiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdEB0ZXN0Lm9ubWljcm9zb2Z0LmNvbSIsIm9pZCI6Ijk5YTEzNDBlLTBmMzUtNGFjMS05NGFjLTA4Mzc3MThmMGIxZiIsImV4cCI6MTYzMjM2NTQ2NSwiaWF0IjoxNjMyMzYxODY1LCJ0aWQiOiIzNTk2NTQyZS0xZTBiLTRjOGMtOWIzNC1iODNmZGQwNTI5OTAifQ.1VvzdN6NuiP8kXqnblJNX_NR9kegC5m44uibA2q3c-Y";
+    private final static String FAMILY_ID = "mock-family-id";
+    private final static String PRT_SESSION_KEY = "mock-prt-session-key";
+    private final static CredentialType ID_TOKEN_TYPE = CredentialType.IdToken;
 
     @RealObject
     private DeviceCodeFlowCommand mDeviceCodeFlowCommand;
@@ -58,17 +78,50 @@ public class ShadowDeviceCodeFlowCommandSuccessful {
 
         final DeviceCodeFlowCommandCallback callback = (DeviceCodeFlowCommandCallback) mDeviceCodeFlowCommand.getCallback();
         callback.onUserCodeReceived(
-                "https://login.microsoftonline.com/common/oauth2/deviceauth",
+                "vUri Here",
                 "ABCDEFGH",
                 "Follow these instructions to authenticate.",
                 expiryDate);
 
         // Create parameters for dummy authentication result
-        final CacheRecord.CacheRecordBuilder recordBuilder = CacheRecord.builder();
         final AccountRecord accountRecord = new AccountRecord();
+        accountRecord.setHomeAccountId(HOME_ACCOUNT_ID);
+        accountRecord.setLocalAccountId(LOCAL_ACCOUNT_ID);
+        accountRecord.setEnvironment(ENVIRONMENT);
+        accountRecord.setRealm(REALM);
+        accountRecord.setUsername(USERNAME);
+        accountRecord.setFirstName("mock");
+        accountRecord.setMiddleName("mock");
+        accountRecord.setFamilyName("mock");
+        accountRecord.setClientInfo("mock");
+        accountRecord.setName("mock");
+        accountRecord.setAuthorityType(AUTHORITY_TYPE);
+
+        final RefreshTokenRecord refreshTokenRecord = new RefreshTokenRecord();
+
+        final AccessTokenRecord accessTokenRecord = new AccessTokenRecord();
+        accessTokenRecord.setRealm(REALM);
+        accessTokenRecord.setAuthority("https://login.microsoftonline.com/common");
+        accessTokenRecord.setClientId(CLIENT_ID);
+        accessTokenRecord.setSecret(AT_SECRET);
+        accessTokenRecord.setExpiresOn(EXPIRES_ON);
+        accessTokenRecord.setExtendedExpiresOn(EXPIRES_ON + 40000);
+        accessTokenRecord.setAccessTokenType("Bearer");
+
+        final IdTokenRecord idTokenRecord = new IdTokenRecord();
+        idTokenRecord.setHomeAccountId(HOME_ACCOUNT_ID);
+        idTokenRecord.setEnvironment(ENVIRONMENT);
+        idTokenRecord.setCredentialType(ID_TOKEN_TYPE.toString());
+        idTokenRecord.setClientId(CLIENT_ID);
+        idTokenRecord.setRealm(REALM);
+        idTokenRecord.setSecret(RAW_ID_TOKEN);
+
+        final CacheRecord.CacheRecordBuilder recordBuilder = CacheRecord.builder();
+        recordBuilder.refreshToken(refreshTokenRecord);
+        recordBuilder.accessToken(accessTokenRecord);
         recordBuilder.account(accountRecord);
-        accountRecord.setHomeAccountId("abcd");
-        accountRecord.setLocalAccountId("abcd");
+        recordBuilder.idToken(idTokenRecord);
+
         final List<ICacheRecord> cacheRecordList = new ArrayList<>();
         final ICacheRecord cacheRecord = recordBuilder.build();
         cacheRecordList.add(cacheRecord);
@@ -81,7 +134,6 @@ public class ShadowDeviceCodeFlowCommandSuccessful {
                 false
         );
 
-        // Create dummy token result
         final AcquireTokenResult tokenResult = new AcquireTokenResult();
         tokenResult.setLocalAuthenticationResult(localAuthenticationResult);
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDeviceCodeFlowCommandSuccessful.java
@@ -23,14 +23,10 @@
 package com.microsoft.identity.client.e2e.shadows;
 
 import com.microsoft.identity.common.java.cache.CacheRecord;
+import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommand;
 import com.microsoft.identity.common.internal.commands.DeviceCodeFlowCommandCallback;
-import com.microsoft.identity.common.java.cache.ICacheRecord;
-import com.microsoft.identity.common.java.dto.AccessTokenRecord;
 import com.microsoft.identity.common.java.dto.AccountRecord;
-import com.microsoft.identity.common.java.dto.CredentialType;
-import com.microsoft.identity.common.java.dto.IdTokenRecord;
-import com.microsoft.identity.common.java.dto.RefreshTokenRecord;
 import com.microsoft.identity.common.java.request.SdkType;
 import com.microsoft.identity.common.java.result.AcquireTokenResult;
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult;
@@ -50,22 +46,6 @@ import java.util.concurrent.TimeUnit;
  */
 @Implements(DeviceCodeFlowCommand.class)
 public class ShadowDeviceCodeFlowCommandSuccessful {
-    private final static String AUTHORITY_TYPE = "MSSTS";
-    private final static String LOCAL_ACCOUNT_ID = "99a1340e-0f35-4ac1-94ac-0837718f0b1f";
-    private final static String USERNAME = "mock-username";
-    private final static String HOME_ACCOUNT_ID = "mock-home-account-id";
-    private final static String ENVIRONMENT = "login.windows.net";
-    private final static String REALM = "3c62ac97-29eb-4aed-a3c8-add0298508d";
-    private final static String TARGET = "mock-target";
-    private final static String CACHE_AT = "mock-cache-at";
-    private final static String EXPIRES_ON = String.valueOf(System.currentTimeMillis() + 100000);
-    private final static String AT_SECRET = "d22d37bf-6e2c-40ea-b763-774897c05262";
-    private final static String CLIENT_ID = "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0";
-    private final static String RT_SECRET = "adf49b53-a92f-4930-9de6-926505d29e18";
-    private final static String RAW_ID_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJUZXN0U3ViamVjdCIsImF1ZCI6ImF1ZGllbmNlLWZvci10ZXN0aW5nIiwidmVyIjoiMi4wIiwibmJmIjoxNjMyMzYxODY1LCJpc3MiOiJodHRwczpcL1wvdGVzdC5hdXRob3JpdHlcLzM1OTY1NDJlLTFlMGItNGM4Yy05YjM0LWI4M2ZkZDA1Mjk5MFwvdjIuMCIsIm5hbWUiOiJ0ZXN0IiwicHJlZmVycmVkX3VzZXJuYW1lIjoidGVzdEB0ZXN0Lm9ubWljcm9zb2Z0LmNvbSIsIm9pZCI6Ijk5YTEzNDBlLTBmMzUtNGFjMS05NGFjLTA4Mzc3MThmMGIxZiIsImV4cCI6MTYzMjM2NTQ2NSwiaWF0IjoxNjMyMzYxODY1LCJ0aWQiOiIzNTk2NTQyZS0xZTBiLTRjOGMtOWIzNC1iODNmZGQwNTI5OTAifQ.1VvzdN6NuiP8kXqnblJNX_NR9kegC5m44uibA2q3c-Y";
-    private final static String FAMILY_ID = "mock-family-id";
-    private final static String PRT_SESSION_KEY = "mock-prt-session-key";
-    private final static CredentialType ID_TOKEN_TYPE = CredentialType.IdToken;
 
     @RealObject
     private DeviceCodeFlowCommand mDeviceCodeFlowCommand;
@@ -78,50 +58,17 @@ public class ShadowDeviceCodeFlowCommandSuccessful {
 
         final DeviceCodeFlowCommandCallback callback = (DeviceCodeFlowCommandCallback) mDeviceCodeFlowCommand.getCallback();
         callback.onUserCodeReceived(
-                "vUri Here",
+                "https://login.microsoftonline.com/common/oauth2/deviceauth",
                 "ABCDEFGH",
                 "Follow these instructions to authenticate.",
                 expiryDate);
 
         // Create parameters for dummy authentication result
-        final AccountRecord accountRecord = new AccountRecord();
-        accountRecord.setHomeAccountId(HOME_ACCOUNT_ID);
-        accountRecord.setLocalAccountId(LOCAL_ACCOUNT_ID);
-        accountRecord.setEnvironment(ENVIRONMENT);
-        accountRecord.setRealm(REALM);
-        accountRecord.setUsername(USERNAME);
-        accountRecord.setFirstName("mock");
-        accountRecord.setMiddleName("mock");
-        accountRecord.setFamilyName("mock");
-        accountRecord.setClientInfo("mock");
-        accountRecord.setName("mock");
-        accountRecord.setAuthorityType(AUTHORITY_TYPE);
-
-        final RefreshTokenRecord refreshTokenRecord = new RefreshTokenRecord();
-
-        final AccessTokenRecord accessTokenRecord = new AccessTokenRecord();
-        accessTokenRecord.setRealm(REALM);
-        accessTokenRecord.setAuthority("https://login.microsoftonline.com/common");
-        accessTokenRecord.setClientId(CLIENT_ID);
-        accessTokenRecord.setSecret(AT_SECRET);
-        accessTokenRecord.setExpiresOn(EXPIRES_ON);
-        accessTokenRecord.setExtendedExpiresOn(EXPIRES_ON + 40000);
-        accessTokenRecord.setAccessTokenType("Bearer");
-
-        final IdTokenRecord idTokenRecord = new IdTokenRecord();
-        idTokenRecord.setHomeAccountId(HOME_ACCOUNT_ID);
-        idTokenRecord.setEnvironment(ENVIRONMENT);
-        idTokenRecord.setCredentialType(ID_TOKEN_TYPE.toString());
-        idTokenRecord.setClientId(CLIENT_ID);
-        idTokenRecord.setRealm(REALM);
-        idTokenRecord.setSecret(RAW_ID_TOKEN);
-
         final CacheRecord.CacheRecordBuilder recordBuilder = CacheRecord.builder();
-        recordBuilder.refreshToken(refreshTokenRecord);
-        recordBuilder.accessToken(accessTokenRecord);
+        final AccountRecord accountRecord = new AccountRecord();
         recordBuilder.account(accountRecord);
-        recordBuilder.idToken(idTokenRecord);
-
+        accountRecord.setHomeAccountId("abcd");
+        accountRecord.setLocalAccountId("abcd");
         final List<ICacheRecord> cacheRecordList = new ArrayList<>();
         final ICacheRecord cacheRecord = recordBuilder.build();
         cacheRecordList.add(cacheRecord);
@@ -134,6 +81,7 @@ public class ShadowDeviceCodeFlowCommandSuccessful {
                 false
         );
 
+        // Create dummy token result
         final AcquireTokenResult tokenResult = new AcquireTokenResult();
         tokenResult.setLocalAuthenticationResult(localAuthenticationResult);
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
@@ -24,7 +24,7 @@ package com.microsoft.identity.client.e2e.tests.mocked;
 
 import androidx.annotation.NonNull;
 
-import com.microsoft.identity.client.AuthenticationResult;
+import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
 import com.microsoft.identity.client.e2e.shadows.ShadowDeviceCodeFlowCommandAuthError;
@@ -46,6 +46,7 @@ import com.microsoft.identity.common.java.providers.oauth2.OAuth2Strategy;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2StrategyParameters;
 import com.microsoft.identity.common.java.providers.oauth2.TokenRequest;
 import com.microsoft.identity.common.java.providers.oauth2.TokenResult;
+import com.microsoft.identity.common.java.util.StringUtil;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -252,16 +253,18 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
                 // This shouldn't run if authorization step fails
                 Assert.fail();
             }
+
             @Override
-            public void onTokenReceived(@NonNull AuthenticationResult authResult) {
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                 // This shouldn't run if authorization step fails
                 Assert.fail();
             }
+
             @Override
-            public void onError(@NonNull MsalException error) {
+            public void onError(@NonNull MsalException exception) {
                 // Handle exception when authorization fails
                 Assert.assertFalse(mUserCodeReceived);
-                Assert.assertEquals(ErrorStrings.INVALID_SCOPE, error.getErrorCode());
+                Assert.assertEquals(ErrorStrings.INVALID_SCOPE, exception.getErrorCode());
             }
         });
 
@@ -279,24 +282,26 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
                                            @NonNull String message,
                                            @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
-                Assert.assertNotNull(vUri);
-                Assert.assertNotNull(userCode);
-                Assert.assertNotNull(message);
+                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
                 Assert.assertNotNull(sessionExpirationDate);
 
                 Assert.assertFalse(mUserCodeReceived);
                 mUserCodeReceived = true;
             }
+
             @Override
-            public void onTokenReceived(@NonNull AuthenticationResult authResult) {
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                 // This shouldn't run
                 Assert.fail();
             }
+
             @Override
-            public void onError(@NonNull MsalException error) {
+            public void onError(@NonNull MsalException exception) {
                 // Handle Exception
                 Assert.assertTrue(mUserCodeReceived);
-                Assert.assertEquals(ErrorStrings.DEVICE_CODE_FLOW_EXPIRED_TOKEN_ERROR_CODE, error.getErrorCode());
+                Assert.assertEquals(ErrorStrings.DEVICE_CODE_FLOW_EXPIRED_TOKEN_ERROR_CODE, exception.getErrorCode());
             }
         });
 
@@ -314,23 +319,25 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
                                            @NonNull String message,
                                            @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
-                Assert.assertNotNull(vUri);
-                Assert.assertNotNull(userCode);
-                Assert.assertNotNull(message);
+                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
                 Assert.assertNotNull(sessionExpirationDate);
 
                 Assert.assertFalse(mUserCodeReceived);
                 mUserCodeReceived = true;
             }
+
             @Override
-            public void onTokenReceived(@NonNull AuthenticationResult authResult) {
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                 Assert.assertTrue(mUserCodeReceived);
                 Assert.assertNotNull(authResult);
             }
+
             @Override
-            public void onError(@NonNull MsalException error) {
+            public void onError(@NonNull MsalException exception) {
                 // This shouldn't run
-                Assert.fail();
+                throw new AssertionError(exception);
             }
         });
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -393,6 +393,8 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
             @Override
             public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                 Assert.assertNotNull(authResult);
+                Assert.assertNotNull(authResult.getAccount());
+                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
                 Assert.assertNotNull(authResult.getAccessToken());
                 AcquireTokenTestHelper.setAccount(authResult.getAccount());
             }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -31,7 +31,6 @@ import com.microsoft.identity.client.Account;
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AuthenticationCallback;
-import com.microsoft.identity.client.AuthenticationResult;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IPublicClientApplication;
@@ -49,6 +48,7 @@ import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.providers.oauth2.IDToken;
+import com.microsoft.identity.common.java.util.StringUtil;
 import com.microsoft.identity.internal.testutils.HttpRequestMatcher;
 import com.microsoft.identity.internal.testutils.TestConstants;
 import com.microsoft.identity.internal.testutils.TestUtils;
@@ -375,9 +375,9 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                                            final @NonNull String message,
                                            final @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
-                Assert.assertNotNull(vUri);
-                Assert.assertNotNull(userCode);
-                Assert.assertNotNull(message);
+                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
                 Assert.assertNotNull(sessionExpirationDate);
 
                 // Load Token interceptor
@@ -389,15 +389,18 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                         MockServerResponse.getMockTokenSuccessResponse()
                 );
             }
+
             @Override
-            public void onTokenReceived(@NonNull AuthenticationResult authResult) {
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                 Assert.assertNotNull(authResult);
+                Assert.assertNotNull(authResult.getAccessToken());
                 AcquireTokenTestHelper.setAccount(authResult.getAccount());
             }
+
             @Override
-            public void onError(@NonNull MsalException error) {
+            public void onError(@NonNull MsalException exception) {
                 // This shouldn't run
-                Assert.fail();
+                throw new AssertionError(exception);
             }
         });
         RoboTestUtils.flushScheduler();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -365,10 +365,10 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     public void testCanAcquireTokenSilentlyAfterDeviceCode() {
         mSingleAccountPCA.acquireTokenWithDeviceCode(mScopes, new IPublicClientApplication.DeviceCodeFlowCallback() {
             @Override
-            public void onUserCodeReceived(@NonNull String vUri,
-                                           @NonNull String userCode,
-                                           @NonNull String message,
-                                           @NonNull Date sessionExpirationDate) {
+            public void onUserCodeReceived(final @NonNull String vUri,
+                                           final @NonNull String userCode,
+                                           final @NonNull String message,
+                                           final @NonNull Date sessionExpirationDate) {
                 // Assert that the protocol returns the userCode and others after successful authorization
                 Assert.assertNotNull(vUri);
                 Assert.assertNotNull(userCode);

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AuthenticationCallback;
-import com.microsoft.identity.client.AuthenticationResult;
 import com.microsoft.identity.client.HttpMethod;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
@@ -218,7 +217,7 @@ abstract class MsalWrapper {
                     }
 
                     @Override
-                    public void onTokenReceived(@NonNull AuthenticationResult authResult) {
+                    public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
                         callback.onSuccess(authResult);
                     }
 


### PR DESCRIPTION
MSAL side of the persist account fix and added test case. Added here for reviews, will be merged after https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1572, related to Bug https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1509622/