### PR TITLE
Remove RC tag and update common dep to 3.6.2

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 Version 2.2.1
 ----------
+- [PATCH] Picks up common@3.6.2
 - [PATCH] Allow Authenticator to pass older format for redirect uri (#1517)
 
 Version 2.2.0

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -274,9 +274,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.2-RC1', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.2', changing: true)
 
-    distApi("com.microsoft.identity:common:3.6.2-RC1") {
+    distApi("com.microsoft.identity:common:3.6.2") {
         transitive = false
     }
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.2.1-RC2
+versionName=2.2.1
 versionCode=0


### PR DESCRIPTION
### In this change

- Updating the common dep to point to 3.6.2 (sept release for common)
- Updating the common submodule to point to master
- Removing the RC tag from release version to create final release version 2.2.1