### PR TITLE
Update common dep and bump up version to 3.0.0-RC1

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -292,9 +292,9 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.2', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0-RC2', changing: true)
 
-    distApi("com.microsoft.identity:common:3.6.2") {
+    distApi("com.microsoft.identity:common:4.0.0-RC2") {
         transitive = false
     }
 

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.2.1
+versionName=3.0.0-RC1
 versionCode=0


### PR DESCRIPTION
### In this change

- Updating the common dep to point to 4.0.0-RC2
- Updating the common submodule to point to 4.0.0-RC2 (branch release/4.0.0)
- Bumping up the version to 3.0.0-RC1