### PR TITLE
Build.Gradle fixes for msal release branch

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -233,7 +233,7 @@ android {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.implementation
+    classpath += configurations.compile
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 
     options.memberLevel = JavadocMemberLevel.PUBLIC

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -295,7 +295,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0-RC2', changing: true)
 
     distApi("com.microsoft.identity:common:4.0.0-RC2") {
-        transitive = false
+        transitive = true
     }
 
 }


### PR DESCRIPTION
### In this change

1.  Fixing below error which occur when running javadoc task as part of publish

```
Could not determine the dependencies of task ':msal:javadoc'.
> Resolving dependency configuration 'implementation' is not allowed as it is defined as 'canBeResolved=false'.
Instead, a resolvable ('canBeResolved=true') dependency configuration that extends 'implementation' should be resolved.

```

2. Setting the transitive property on android-common dep to true, so that it brings common4j along with it, and we dont have to explicitly add common4j dependency.