### PR TITLE
Fix the versionName property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,5 @@ org.gradle.daemon=true
 # See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:ReservedCodeCacheSize=512m
 
-# This the TSL versionName...
-versionName=1.5.9
-
 # For OneAuth default abiSelection
 abiSelection=x86_64

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -77,6 +77,7 @@ android {
         project.archivesBaseName = "msal"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
     }
 
     buildTypes {
@@ -84,14 +85,12 @@ android {
         debug {
 //            testCoverageEnabled true
             debuggable true
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         }
         release {
 //            testCoverageEnabled true
             minifyEnabled false
             debuggable false
             consumerProguardFiles 'consumer-rules.pro'
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
         }
     }
 


### PR DESCRIPTION
The version Name field was incorrect in MSAL, because the property in the gradle.properties file in the root overlapped with the name in use.

We can remove this, and define the versionName property in the defaultConfig