### PR TITLE
Add command line support for gradle to generate a build with custom version number

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -233,7 +233,7 @@ android {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.implementation
+    classpath += configurations.compile
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 
     options.memberLevel = JavadocMemberLevel.PUBLIC

--- a/msal/versioning/version_tasks.gradle
+++ b/msal/versioning/version_tasks.gradle
@@ -3,7 +3,7 @@ def getVersionFile() {
 }
 
 def getVersionProps() {
-    def versionProps = new Properties();
+    def versionProps = new Properties()
     getVersionFile().withInputStream {stream -> versionProps.load(stream)}
     return versionProps
 }
@@ -25,7 +25,7 @@ ext.getAppVersionCode = {
 }
 
 ext.getAppVersionName = {
-    getVersionProps()['versionName'].toString()
+    project.findProperty('projVersion') ?: getVersionProps()['versionName'].toString()
 }
 
 private void saveChanges(String versionName) {


### PR DESCRIPTION
### What 
Add support to generate build with custom version numbers by supplying command line argument "projVersion" to gradle. When this argument is passed it will override the version number defined in the version.properties file and generate a build with the version number passed as "projVersion" argument to gradle

> example: below command will assemble and publish msal library with version number "0.0.20211101.1" to maven local.
> `.\gradlew -PprojVersion=0.0.20211101.1 :msal:assembleLocal :msal:publishToMaveLocal`

### Testing
Verified running the command locally and publishing custom versions to maven local.

### More details
More details about Why and How can be found in similar PRs on broker and common repos
broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1769
common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1618