### PR TITLE
Set BuildConfig.VERSON_NAME to be project.version to set it to correct version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,8 +11,5 @@ org.gradle.daemon=true
 # See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
 org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2048m -Dkotlin.daemon.jvm.options\="-Xmx2048M" -XX:ReservedCodeCacheSize=512m
 
-# This the TSL versionName...
-versionName=1.5.9
-
 # For OneAuth default abiSelection
 abiSelection=x86_64

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -84,14 +84,14 @@ android {
         debug {
 //            testCoverageEnabled true
             debuggable true
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
         }
         release {
 //            testCoverageEnabled true
             minifyEnabled false
             debuggable false
             consumerProguardFiles 'consumer-rules.pro'
-            buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
+            buildConfigField("String", "VERSION_NAME", "\"${project.version}\"")
         }
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -96,25 +96,6 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         }
     }
 
-    public static class AzureGermanyCloudUser extends AcquireTokenAADTest {
-        @Override
-        public LabUserQuery getLabUserQuery() {
-            final LabUserQuery query = new LabUserQuery();
-            query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD;
-            return query;
-        }
-    }
-
-    @Ignore
-    public static class AzureGermanyCloudMigratedUser extends AcquireTokenAADTest {
-        @Override
-        public LabUserQuery getLabUserQuery() {
-            final LabUserQuery query = new LabUserQuery();
-            query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD_MIGRATED;
-            return query;
-        }
-    }
-
     public static class MamCaUserAadGraphResource extends AcquireTokenAADTest {
         @Override
         public String[] getScopes() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/MultiAccountAndResourceAcquireTokenNetworkTests.java
@@ -78,7 +78,6 @@ public class MultiAccountAndResourceAcquireTokenNetworkTests extends AcquireToke
 
         final LabUserQuery[] queries = new LabUserQuery[]{
                 new AcquireTokenAADTest.AzureWorldWideCloudUser().getLabUserQuery(),
-                new AcquireTokenAADTest.AzureGermanyCloudUser().getLabUserQuery(),
                 new AcquireTokenAADTest.AzureUsGovCloudUser().getLabUserQuery()};
 
         final IAccount[] accounts = new IAccount[queries.length];


### PR DESCRIPTION
### What
Updating build.gradle file to correctly set VERSON_NAME in the generated BuildConfig.java. to `project.version` (currently `versionName`)

### Why
The `versionName` in Build.gradle is coming from global scope and gets read from gradle.properties where it is defined as `"1.5.9"` for TSL version. This makes it incorrectly set the VERSION_NAME in generated BuildConfig.java under BuildConfig.VERSION_NAME field. This field is used to set the x-client-ver header in ests requests to pass on the MSAL version. because it is being set to 1.5.9 this skews our telemetry as well as makes it difficult in terms of debugging the logs.

### How
Setting the VERSION_NAME to `project.version` which is set in the build.gradle by reading the version.properties file. This way the correct version number as defined in version.properties file will be set and passed to ests.

### Testing
Verified locally generated Build.Config file the version name is set correctly and not 1.5.9
![image](https://user-images.githubusercontent.com/75644120/142037339-934e051f-8ed0-4f42-9ff4-269e2566a1cb.png)
