### PR TITLE
Fix msal get account crash in Account Matcher due to NPE because account id was missing

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -95,6 +95,8 @@ public class Account implements IAccount {
         }
 
         if (StringUtil.isEmpty(id)) {
+            // This could happen because the ID token that we have for WPJ accounts may not contain
+            // oid claim because we used to not ask for PROFILE scope in that token. 
             com.microsoft.identity.common.logging.Logger.warn(
                     TAG + methodName,
                     "Unable to get account id from either ClientInfo or IdToken. Attempting to obtain from home account id."

--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -46,6 +46,7 @@ public class Account implements IAccount {
     private String mHomeOid;
     private String mHomeTenantId;
     private String mEnvironment;
+    private String mHomeAccountId;
 
     public Account(
             @Nullable final String clientInfo,
@@ -68,6 +69,7 @@ public class Account implements IAccount {
     @NonNull
     @Override
     public String getId() {
+        final String methodName = ":getId";
         String id;
 
         ClientInfo clientInfo = null;
@@ -90,6 +92,24 @@ public class Account implements IAccount {
             id = (String) mIdTokenClaims.get(MicrosoftIdToken.OBJECT_ID);
         } else {
             id = mHomeOid;
+        }
+
+        if (StringUtil.isEmpty(id)) {
+            com.microsoft.identity.common.logging.Logger.warn(
+                    TAG + methodName,
+                    "Unable to get account id from either ClientInfo or IdToken. Attempting to obtain from home account id."
+            );
+            id = com.microsoft.identity.common.java.util.StringUtil.getUIdFromHomeAccountId(mHomeAccountId);
+        }
+
+        if (StringUtil.isEmpty(id)) {
+            com.microsoft.identity.common.logging.Logger.warn(
+                    TAG + methodName,
+                    "Account ID is empty. Returning MISSING_FROM_THE_TOKEN_RESPONSE."
+            );
+
+            // must return something because the method is marked as non-null
+            id = MISSING_FROM_THE_TOKEN_RESPONSE;
         }
 
         return id;
@@ -160,5 +180,9 @@ public class Account implements IAccount {
         }
 
         return MISSING_FROM_THE_TOKEN_RESPONSE;
+    }
+
+    public void setHomeAccountId(@NonNull final String homeAccountId) {
+        mHomeAccountId = homeAccountId;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -294,6 +294,10 @@ class AccountAdapter {
                     getIdToken(homeCacheRecord)
             );
 
+            ((MultiTenantAccount) rootAccount).setHomeAccountId(
+                    homeCacheRecord.getAccount().getHomeAccountId()
+            );
+
             // Set the tenant_id
             ((MultiTenantAccount) rootAccount).setTenantId(
                     StringUtil.getTenantInfo(


### PR DESCRIPTION
To resolve, fallback to set MSAL account id from homeAccountId in CacheRecord if …
…not present anywhere else.

Depends on common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1643

Complete description of issue available here: https://github.com/AzureAD/ad-accounts-for-android/pull/1785#issue-1062821554