### PR TITLE
Fixes for Msal Broker UI Automation

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
@@ -22,6 +22,9 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp;
 
+import static com.microsoft.identity.client.ui.automation.rules.LoadLabUserTestRule.TEMP_USER_WAIT_TIME;
+import static org.junit.Assert.fail;
+
 import android.app.Activity;
 import android.content.Context;
 import android.text.TextUtils;
@@ -55,9 +58,6 @@ import org.junit.rules.RuleChain;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import static com.microsoft.identity.client.ui.automation.rules.LoadLabUserTestRule.TEMP_USER_WAIT_TIME;
-import static org.junit.Assert.fail;
-
 /**
  * A base model for an E2E MSAL UI Test. This class will apply all the rules required for an MSAL
  * test and will get everything setup for use by child classes.
@@ -79,9 +79,6 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest, IRuleBa
     @Rule(order = 1)
     public ActivityTestRule<MainActivity> mActivityRule =
             new ActivityTestRule(MainActivity.class);
-
-    @Rule(order = 2)
-    public MsalLoggingRule msalLoggingRule = new MsalLoggingRule();
 
     @Before
     public void setup() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
@@ -80,6 +80,9 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest, IRuleBa
     public ActivityTestRule<MainActivity> mActivityRule =
             new ActivityTestRule(MainActivity.class);
 
+    @Rule(order = 2)
+    public MsalLoggingRule msalLoggingRule = new MsalLoggingRule();
+
     @Before
     public void setup() {
         mActivity = mActivityRule.getActivity();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
@@ -88,14 +88,18 @@ public class MsalLoggingRule implements TestRule {
         final FileAppender msalFileLogAppender = new FileAppender(msalLogFileName, new LogcatLikeFormatter());
         Logger.getInstance().setLogLevel(Logger.LogLevel.VERBOSE);
         Logger.getInstance().setEnableLogcatLog(false);
-        Logger.getInstance().setExternalLogger(new ILoggerCallback() {
-            @Override
-            public void log(final String tag, final Logger.LogLevel logLevel,
-                            final String message, boolean containsPII) {
-                final LogLevel level = convertMsalLogLevelToInternalLogLevel(logLevel);
-                msalFileLogAppender.append(level, tag, message, null);
-            }
-        });
+        try {
+            Logger.getInstance().setExternalLogger(new ILoggerCallback() {
+                @Override
+                public void log(final String tag, final Logger.LogLevel logLevel,
+                                final String message, boolean containsPII) {
+                    final LogLevel level = convertMsalLogLevelToInternalLogLevel(logLevel);
+                    msalFileLogAppender.append(level, tag, message, null);
+                }
+            });
+        } catch (IllegalStateException ex) {
+            // External logger is already set,
+        }
 
         return msalFileLogAppender;
     }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/MsalLoggingRule.java
@@ -97,8 +97,9 @@ public class MsalLoggingRule implements TestRule {
                     msalFileLogAppender.append(level, tag, message, null);
                 }
             });
-        } catch (IllegalStateException ex) {
-            // External logger is already set,
+        } catch (final IllegalStateException ex) {
+            // External logger is already set
+            System.out.println(ex.getMessage());
         }
 
         return msalFileLogAppender;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase796048.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase796048.java
@@ -102,7 +102,7 @@ public class TestCase796048 extends AbstractMsalBrokerTest {
     @Override
     public LabUserQuery getLabUserQuery() {
         final LabUserQuery query = new LabUserQuery();
-        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD;
+        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT;
         return query;
     }
 
@@ -118,7 +118,7 @@ public class TestCase796048 extends AbstractMsalBrokerTest {
 
     @Override
     public String getAuthority() {
-        return "https://login.microsoftonline.de/common";
+        return "https://login.microsoftonline.us/common";
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase796049.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase796049.java
@@ -111,7 +111,7 @@ public class TestCase796049 extends AbstractMsalBrokerTest {
     @Override
     public LabUserQuery getLabUserQuery() {
         final LabUserQuery query = new LabUserQuery();
-        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD;
+        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT;
         return query;
     }
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase833515.java
@@ -129,7 +129,6 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         final AadLoginComponentHandler aadLoginComponentHandler = new AadLoginComponentHandler();
         aadLoginComponentHandler.handleEmailField(username);
         aadLoginComponentHandler.handlePasswordField(password);
-        aadLoginComponentHandler.handleNextButton(); // keep me signed in
 
         //signing out from the application.
         ((SingleAccountPublicClientApplication) mApplication).signOut();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase850455.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/TestCase850455.java
@@ -98,7 +98,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
     @Override
     public LabUserQuery getLabUserQuery() {
         final LabUserQuery query = new LabUserQuery();
-        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_GERMANY_CLOUD;
+        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_US_GOVERNMENT;
         return query;
     }
 
@@ -114,7 +114,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
 
     @Override
     public String getAuthority() {
-        return "https://login.microsoftonline.de/common";
+        return "https://login.microsoftonline.us/common";
     }
 
     @Override


### PR DESCRIPTION
### What 
- Changing Germany to US cloud 
- Update MsalLogging rule to ignore the exception if external logger is set more than once. to avoid the automation app to crash

### Testing
Automation Run with these changes (along with changes in this [PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1645): 
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=850900&view=results
Automation run before these changes : 
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=850275&view=results