### PR TITLE
Add ability to provide common version using project property

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -169,6 +169,8 @@ task sourcesJar(type: Jar) {
     destinationDirectory = reporting.file("$project.buildDir/outputs/jar/")
 }
 
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "0.0.+"
+
 dependencies {
     testImplementation project(path: ':common4j')
 
@@ -204,9 +206,9 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.2', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: commonVersion, changing: true)
 
-    distApi("com.microsoft.identity:common:3.6.2") {
+    distApi("com.microsoft.identity:common:${commonVersion}") {
         transitive = false
     }
 

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -209,7 +209,7 @@ dependencies {
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: commonVersion, changing: true)
 
     distApi("com.microsoft.identity:common:${commonVersion}") {
-        transitive = false
+        transitive = true
     }
 
 }


### PR DESCRIPTION
Add ability to provide common version using project property
Related PR on broker: https://github.com/AzureAD/ad-accounts-for-android/pull/1788