### PR TITLE
Picks up common 3.6.6, bump to 2.2.3, Remove the broker check for MSA FRT saving function.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,5 +1,9 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 
+Version 2.2.3
+----------
+- Picks up common@3.6.6
+
 Version 2.2.2
 ----------
 - Picks up common@3.6.3

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 Version 2.2.3
 ----------
+- Remove the broker check for MSA FRT saving function (#1571)
 - Picks up common@3.6.6
 
 Version 2.2.2

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -274,9 +274,9 @@ dependencies {
         transitive = false
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.3', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '3.6.6', changing: true)
 
-    distApi("com.microsoft.identity:common:3.6.3") {
+    distApi("com.microsoft.identity:common:3.6.6") {
         transitive = false
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1227,7 +1227,9 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     @Override
     public void saveMsaFamilyRefreshToken(@NonNull final String refreshToken) throws MsalClientException {
         validateNonNullArgument(refreshToken, "refreshToken");
-        validateBrokerNotInUse();
+
+        // todo: Re-enable this when MSA SSO is fully supported by Broker (PRTv3)
+        //validateBrokerNotInUse();
 
         try {
             mTokenShareUtility.saveMsaFamilyRefreshToken(refreshToken);

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=2.2.2
+versionName=2.2.3
 versionCode=0


### PR DESCRIPTION
Also fix bugs where MSA FRT is blocked from being saved when broker is enabled. (Broker doesn't support SSO for MSA yet).