### PR TITLE
[CyberEO] Add sbom-generation task to vsts-release pipeline

### DIFF
--- a/azure-pipelines/vsts-releases/msal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/msal-vsts-release.yml
@@ -43,7 +43,6 @@ jobs:
       sqAnalysisBreakBuildIfQualityGateFailed: false
   - task: Gradle@2
     displayName: Publish
-    enabled: false
     inputs:
       tasks: msal:publish
       publishJUnitResults: false

--- a/azure-pipelines/vsts-releases/msal-vsts-release.yml
+++ b/azure-pipelines/vsts-releases/msal-vsts-release.yml
@@ -9,6 +9,14 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 pr: none
 
+resources:
+  repositories:
+    - repository: common
+      type: github
+      name: AzureAD/microsoft-authentication-library-common-for-android
+      ref: dev
+      endpoint: ANDROID_GITHUB
+
 jobs:
 - job: vsts_release
   displayName: Publish msal to internal feed
@@ -35,9 +43,15 @@ jobs:
       sqAnalysisBreakBuildIfQualityGateFailed: false
   - task: Gradle@2
     displayName: Publish
+    enabled: false
     inputs:
       tasks: msal:publish
       publishJUnitResults: false
+  - template: azure-pipelines/templates/steps/generate-sbom.yml@common
+    parameters:
+      project: msal
+      buildDropPath: $(Build.SourcesDirectory)/msal/build/
+      configuration: distReleaseRuntimeClasspath
   - task: CopyFiles@2
     name: CopyFiles1
     displayName: Copy Files to Artifact Staging Directory

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,10 @@ allprojects {
             }
         }
     }
+
+    dependencyLocking {
+        lockAllConfigurations()
+    }
 }
 
 task clean(type: Delete) {


### PR DESCRIPTION
### What
Adding tasks to generate and publish SBOM ([Software bill of materials](https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/softwarebillofmaterials)) manifest file.

### Why
This is a requirement as part of the [Cyber EO](https://eng.ms/docs/initiatives/executive-order/executive-order-requirements/executiveorderoncybersecurity/overview).

### How
Added a new template to generate-sbom manifest to the vsts-release pipeline. The template was added as part of this common [PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1653) which has details for what it does.

### Testing
Successfully completed test run of the pipeline and generated sbom manifest as pipeline artifact
https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=857519&view=results

### Other
ADO Feature: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1695893/
Similar PR for Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1653