### PR TITLE
Added overloads to use List<String> in AcquireToken

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -110,6 +110,28 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      *                  {@link AuthenticationCallback#onError(MsalException)}.
      */
     void acquireToken(@NonNull final Activity activity,
+                      @NonNull final List<String> scopes,
+                      @Nullable final String loginHint,
+                      @NonNull final AuthenticationCallback callback
+    );
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     *
+     * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param callback  The Non-null {@link AuthenticationCallback} to receive the result back.
+     *                  1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                  back via {@link AuthenticationCallback#onCancel()}.
+     *                  2) If the sdk successfully receives the token back, result will be sent back via
+     *                  {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                  3) All the other errors will be sent back via
+     *                  {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
                       @NonNull final String[] scopes,
                       @Nullable final String loginHint,
                       @NonNull final AuthenticationCallback callback

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -40,6 +40,26 @@ public interface IPublicClientApplication {
      * Default value for {@link Prompt} is {@link Prompt#SELECT_ACCOUNT}.
      *
      * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param scopes   The non-null list of scopes to be requested for the access token.
+     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param callback The {@link AuthenticationCallback} to receive the result back.
+     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                 back via {@link AuthenticationCallback#onCancel()}.
+     *                 2) If the sdk successfully receives the token back, result will be sent back via
+     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                 3) All the other errors will be sent back via
+     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     */
+    void acquireToken(@NonNull final Activity activity,
+                      @NonNull final List<String> scopes,
+                      @NonNull final AuthenticationCallback callback
+    );
+
+    /**
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link Prompt} is {@link Prompt#SELECT_ACCOUNT}.
+     *
+     * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
      * @param scopes   The non-null array of scopes to be requested for the access token.
      *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param callback The {@link AuthenticationCallback} to receive the result back.
@@ -84,6 +104,15 @@ public interface IPublicClientApplication {
      */
     @WorkerThread
     IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException;
+
+    /**
+     * Perform the Device Code Flow (DCF) protocol to allow a device without input capability to authenticate and get a new access token.
+     * Currently, flow is only supported in local MSAL. No Broker support.
+     *
+     * @param scopes   the desired access scopes
+     * @param callback callback object used to communicate with the API throughout the protocol
+     */
+    void acquireTokenWithDeviceCode(@NonNull List<String> scopes, @NonNull final DeviceCodeFlowCallback callback);
 
     /**
      * Perform the Device Code Flow (DCF) protocol to allow a device without input capability to authenticate and get a new access token.

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -433,6 +433,15 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
     @Override
     public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final List<String> scopes,
+                             @Nullable final String loginHint,
+                             @NonNull final AuthenticationCallback callback) {
+        final String[] scopesAsArray = (String[]) scopes.toArray();
+        acquireToken(activity, scopesAsArray, loginHint, callback);
+    }
+
+    @Override
+    public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @Nullable final String loginHint,
                              @NonNull final AuthenticationCallback callback) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1382,6 +1382,14 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
     @Override
     public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final List<String> scopes,
+                             @NonNull final AuthenticationCallback callback) {
+        final String[] scopesAsArray = (String[]) scopes.toArray();
+        acquireToken(activity, scopesAsArray, callback);
+    }
+
+    @Override
+    public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
         AcquireTokenParameters acquireTokenParameters = buildAcquireTokenParameters(
@@ -1781,6 +1789,11 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                     e
             );
         }
+    }
+
+    public void acquireTokenWithDeviceCode(@Nullable List<String> scopes, @NonNull final DeviceCodeFlowCallback callback) {
+        final String[] scopesAsArray = (String[]) scopes.toArray();
+        acquireTokenWithDeviceCode(scopesAsArray, callback);
     }
 
     public void acquireTokenWithDeviceCode(@Nullable String[] scopes, @NonNull final DeviceCodeFlowCallback callback) {

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -553,6 +553,14 @@ public class SingleAccountPublicClientApplication
 
     @Override
     public void acquireToken(@NonNull final Activity activity,
+                             @NonNull final List<String> scopes,
+                             @NonNull final AuthenticationCallback callback) {
+        final String[] scopesAsArray = (String[]) scopes.toArray();
+        acquireToken(activity, scopesAsArray, callback);
+    }
+
+    @Override
+    public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
         final IAccount persistedAccount = getPersistedCurrentAccount();


### PR DESCRIPTION
Added changes to address this bug https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1104317. This is to make AcquireToken call consistent with other parts of the API. Also did this for AcquireTokenWithDeviceCode. Should this also be done for Sign-in methods in SingleAccountPCA and AcquireTokenSilent in both SingleAccountPCA and MultipleAccountPCA?