### PR TITLE
Cherry-pick changes from PR#1571 (released in 2.2.3)

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Fix msal get account crash in Account Matcher due to NPE because account id was missing (#1560)
 - [PATCH] Better messaging clarity around redirect URI (#1265).
 - [PATCH] Fixes deprecated PackageInfo.signatures and PackageManager.GET_SIGNATURES (#1321)
 - [MINOR] Added support for handling null taskAffinity.  Add configuration to enable this new feature.  "handle_null_taskaffinity" which is a boolean (#1342)
@@ -9,6 +10,12 @@ vNext
 - [PATCH] Update Nimbus dependency version (#1382)
 - [MAJOR] Migrate *TokenCache classes to common4j (#1652)
 - [MINOR] Adapt to BaseController migration (#1483)
+
+Version 2.2.3
+----------
+- Remove the broker check for MSA FRT saving function (#1571)
+- Fix msal get account crash in Account Matcher due to NPE because account id was missing (#1558)
+- Picks up common@3.6.7
 
 Version 2.2.2
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -292,9 +292,9 @@ dependencies {
         transitive = true
     }
 
-    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.0', changing: true)
+    snapshotApi(group: 'com.microsoft.identity', name: 'common', version: '4.0.1', changing: true)
 
-    distApi("com.microsoft.identity:common:4.0.0") {
+    distApi("com.microsoft.identity:common:4.0.1") {
         transitive = true
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1188,7 +1188,9 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     @Override
     public void saveMsaFamilyRefreshToken(@NonNull final String refreshToken) throws MsalClientException {
         validateNonNullArgument(refreshToken, "refreshToken");
-        validateBrokerNotInUse();
+
+        // todo: Re-enable this when MSA SSO is fully supported by Broker (PRTv3)
+        //validateBrokerNotInUse();
 
         try {
             mTokenShareUtility.saveMsaFamilyRefreshToken(refreshToken);

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=3.0.0
+versionName=3.0.1
 versionCode=0


### PR DESCRIPTION
### What
Cherry-picking change from #1571 (released in [2.2.3](https://github.com/AzureAD/microsoft-authentication-library-for-android/releases/tag/v2.2.3)) to be included in release/3.0.0