### PR TITLE
API Changes, deprecating all methods not using TokenParameters

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MAJOR] Deprecate methods not using TokenParameters (#1595)
 
 Version 3.0.1
 -------------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -198,6 +198,9 @@ dependencies {
     implementation "cz.msebera.android:httpclient:$rootProject.ext.mseberaApacheHttpClientVersion"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
 
+    compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
+    annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
+
     // test dependencies
     testImplementation "junit:junit:$rootProject.ext.junitVersion"
     //mockito-inline was introduced in mockito 2.7.6

--- a/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IMultipleAccountPublicClientApplication.java
@@ -29,6 +29,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.java.util.TaskCompletedCallbackWithError;
 
 import java.util.List;
@@ -96,6 +97,16 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
     /**
      * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
      *
+     * @param acquireTokenParameters {@link AcquireTokenParameters} instance containing the necessary fields. Activity, scopes, and callback must be non-null.
+     */
+    void acquireToken(@NonNull final AcquireTokenParameters acquireTokenParameters);
+
+    /**
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *             parameters for the API. Use {@link IMultipleAccountPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
+     *
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     *
      * @param activity  Non-null {@link Activity} that will be used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
      * @param scopes    The non-null array of scopes to be requested for the access token.
      *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
@@ -109,6 +120,7 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      *                  3) All the other errors will be sent back via
      *                  {@link AuthenticationCallback#onError(MsalException)}.
      */
+    @Deprecated
     void acquireToken(@NonNull final Activity activity,
                       @NonNull final String[] scopes,
                       @Nullable final String loginHint,
@@ -120,17 +132,43 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
+     * @param acquireTokenSilentParameters {@link AcquireTokenSilentParameters} instance containing the necessary fields. Scopes, account, and authority must be non-null.
+     */
+    @WorkerThread
+    IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws MsalException, InterruptedException;
+
+    /**
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *             parameters for the API. Use {@link IMultipleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     *
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
      * @param scopes    The non-null array of scopes to be requested for the access token.
      *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
      * @param account   {@link IAccount} represents the account to silently request tokens for.
      * @param authority Authority to issue the token.
      */
     @WorkerThread
+    @Deprecated
     IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                              @NonNull final IAccount account,
                                              @NonNull final String authority) throws MsalException, InterruptedException;
 
     /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param acquireTokenSilentParameters {@link AcquireTokenSilentParameters} instance containing the necessary fields. Scopes, account, authority, and callback must be non-null.
+     */
+    void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
+
+    /**
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *             parameters for the API. Use {@link IMultipleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     *
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
@@ -144,6 +182,7 @@ public interface IMultipleAccountPublicClientApplication extends IPublicClientAp
      *                  Failure case will be sent back via {
      * @link AuthenticationCallback#onError(MsalException)}.
      */
+    @Deprecated
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                  @NonNull final IAccount account,
                                  @NonNull final String authority,

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -36,20 +36,10 @@ import java.util.List;
 public interface IPublicClientApplication {
 
     /**
-     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
-     * Default value for {@link Prompt} is {@link Prompt#SELECT_ACCOUNT}.
-     *
-     * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
-     * @param scopes   The non-null array of scopes to be requested for the access token.
-     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param callback The {@link AuthenticationCallback} to receive the result back.
-     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
-     *                 back via {@link AuthenticationCallback#onCancel()}.
-     *                 2) If the sdk successfully receives the token back, result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
-     *                 3) All the other errors will be sent back via
-     *                 {@link AuthenticationCallback#onError(MsalException)}.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link IPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
      */
+    @Deprecated
     void acquireToken(@NonNull final Activity activity,
                       @NonNull final String[] scopes,
                       @NonNull final AuthenticationCallback callback
@@ -92,6 +82,16 @@ public interface IPublicClientApplication {
      * @param scopes   the desired access scopes
      * @param callback callback object used to communicate with the API throughout the protocol
      */
+    void acquireTokenWithDeviceCode(@NonNull List<String> scopes, @NonNull final DeviceCodeFlowCallback callback);
+
+    /**
+     * @deprecated  This method is now deprecated. The library is moving away from using an array for scopes.
+     *              Use {@link IPublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)} instead.
+     *
+     * @param scopes   the desired access scopes
+     * @param callback callback object used to communicate with the API throughout the protocol
+     */
+    @Deprecated
     void acquireTokenWithDeviceCode(@NonNull String[] scopes, @NonNull final DeviceCodeFlowCallback callback);
 
     /**
@@ -235,7 +235,7 @@ public interface IPublicClientApplication {
      * 3). Receiving an exception detailing what went wrong in the protocol
      * via {@link DeviceCodeFlowCallback#onError(MsalException)}.
      * <p>
-     * Refer to {@link PublicClientApplication#acquireTokenWithDeviceCode(String[], DeviceCodeFlowCallback)}.
+     * Refer to {@link PublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)}.
      */
     interface DeviceCodeFlowCallback {
         /**

--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -38,6 +38,20 @@ public interface IPublicClientApplication {
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link IPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
+     *
+     * Acquire token interactively, will pop-up webUI. Interactive flow will skip the cache lookup.
+     * Default value for {@link Prompt} is {@link Prompt#SELECT_ACCOUNT}.
+     *
+     * @param activity Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param scopes   The non-null array of scopes to be requested for the access token.
+     *                 MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param callback The {@link AuthenticationCallback} to receive the result back.
+     *                 1) If user cancels the flow by pressing the device back button, the result will be sent
+     *                 back via {@link AuthenticationCallback#onCancel()}.
+     *                 2) If the sdk successfully receives the token back, result will be sent back via
+     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}
+     *                 3) All the other errors will be sent back via
+     *                 {@link AuthenticationCallback#onError(MsalException)}.
      */
     @Deprecated
     void acquireToken(@NonNull final Activity activity,
@@ -87,6 +101,9 @@ public interface IPublicClientApplication {
     /**
      * @deprecated  This method is now deprecated. The library is moving away from using an array for scopes.
      *              Use {@link IPublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)} instead.
+     *
+     * Perform the Device Code Flow (DCF) protocol to allow a device without input capability to authenticate and get a new access token.
+     * Currently, flow is only supported in local MSAL. No Broker support.
      *
      * @param scopes   the desired access scopes
      * @param callback callback object used to communicate with the API throughout the protocol

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -72,7 +72,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
      * or the default authority specified by you in your configuration.
      *
-     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow.
+     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow. Activity, scopes, and callback must be non-null. loginHint and prompt are nullable
      */
     void signIn(@NonNull final SignInParameters signInParameters);
 
@@ -146,7 +146,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * https://login.microsoftonline.com/common or the default authority specified by you in your
      * configuration. This flow requires activity, scopes, and callback. Prompt is optional.
      *
-     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow.
+     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow. Activity, scopes, and callback must be non-null.
      */
     void signInAgain(@NonNull final SignInParameters signInParameters);
 
@@ -204,7 +204,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed fields for acquireTokenSilent flow.
+     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed fields for acquireTokenSilent flow. Scopes, authority, and callback must be non-null.
      */
     void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
 
@@ -235,7 +235,7 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed parameters for acquireTokenSilent flow.
+     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed parameters for acquireTokenSilent flow. Scopes and authority must be non-null.
      */
     @WorkerThread
     IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException;

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -77,8 +77,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     void signIn(@NonNull final SignInParameters signInParameters);
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      *
      * Allows a user to sign in to your application with one of their accounts. This method may only
      * be called once: once a user is signed in, they must first be signed out before another user
@@ -108,8 +109,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     );
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      *
      * Allows a user to sign in to your application with one of their accounts. This method may only
      * be called once: once a user is signed in, they must first be signed out before another user
@@ -151,8 +153,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     void signInAgain(@NonNull final SignInParameters signInParameters);
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link ISingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
      *
      * Reauthorizes the current account according to the supplied scopes and prompt behavior.
      * <p>
@@ -209,8 +212,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link ISingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
      *
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
@@ -241,8 +245,9 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException;
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link ISingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
      *
      * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -179,16 +179,15 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
                                  @NonNull final SilentAuthenticationCallback callback
     );
 
+    @WorkerThread
+    IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException;
+
     /**
-     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
-     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
-     * or it fails the refresh, exception will be sent back via callback.
-     *
-     * @param scopes    The non-null array of scopes to be requested for the access token.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param authority Authority to issue the token.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link IPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
      */
     @WorkerThread
+    @Deprecated
     IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                              @NonNull final String authority) throws MsalException, InterruptedException;
 

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -79,6 +79,26 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     *
+     * Allows a user to sign in to your application with one of their accounts. This method may only
+     * be called once: once a user is signed in, they must first be signed out before another user
+     * may sign in. If you wish to prompt the existing user for credentials use
+     * {@link #signInAgain(SignInParameters)} or
+     * {@link #acquireToken(AcquireTokenParameters)}.
+     * <p>
+     * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
+     * or the default authority specified by you in your configuration.
+     *
+     * @param activity  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param scopes    The non-null array of scopes to be consented to during sign in.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     *                  The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
+     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
      */
     @Deprecated
     void signIn(@NonNull final Activity activity,
@@ -90,6 +110,26 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     *
+     * Allows a user to sign in to your application with one of their accounts. This method may only
+     * be called once: once a user is signed in, they must first be signed out before another user
+     * may sign in. If you wish to prompt the existing user for credentials use
+     * {@link #signInAgain(SignInParameters)} or
+     * {@link #acquireToken(AcquireTokenParameters)}.
+     * <p>
+     * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
+     * or the default authority specified by you in your configuration
+     *
+     * @param activity  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
+     *                  which will have the UPN pre-populated.
+     * @param scopes    The non-null array of scopes to be consented to during sign in.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     *                  The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
+     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
      */
     @Deprecated
     void signIn(@NonNull final Activity activity,
@@ -113,6 +153,27 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
+     *
+     * Reauthorizes the current account according to the supplied scopes and prompt behavior.
+     * <p>
+     * Note: The authority used to make the sign in request will be either the MSAL default:
+     * https://login.microsoftonline.com/common or the default authority specified by you in your
+     * configuration.
+     * configuration. This flow requires activity, scopes, and callback. Prompt is optional.
+     *
+     * @param activity Non-null {@link Activity} that is used as the parent activity for
+     *                 launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+     * @param scopes   The non-null array of scopes to be consented to during sign in.
+     *                 MSAL always sends the scopes 'openid profile offline_access'. Do
+     *                 not include any of these scopes in the scope parameter. The access
+     *                 token returned is for MS Graph and will allow you to query for
+     *                 additional information about the signed in account.
+     * @param prompt   Nullable. Indicates the type of user interaction that is required.
+     *                 If no argument is supplied the default behavior will be used.
+     * @param callback {@link AuthenticationCallback} that is used to send the result back.
+     *                 The success result will be sent back via
+     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                 Failure case will be sent back via {@link AuthenticationCallback#onError(MsalException)}.
      */
     @Deprecated
     void signInAgain(@NonNull final Activity activity,
@@ -150,6 +211,18 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     *
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param authority Authority to issue the token.
+     * @param callback  {@link SilentAuthenticationCallback} that is used to send the result back. The success result will be
+     *                  sent back via {@link SilentAuthenticationCallback#onSuccess(IAuthenticationResult)}.
+     *                  Failure case will be sent back via {
+     * @link AuthenticationCallback#onError(MsalException)}.
      */
     @Deprecated
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
@@ -170,6 +243,14 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
      *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     *
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param scopes    The non-null array of scopes to be requested for the access token.
+     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+     * @param authority Authority to issue the token.
      */
     @WorkerThread
     @Deprecated

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -66,23 +66,21 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * Allows a user to sign in to your application with one of their accounts. This method may only
      * be called once: once a user is signed in, they must first be signed out before another user
      * may sign in. If you wish to prompt the existing user for credentials use
-     * {@link #signInAgain(Activity, String[], Prompt, AuthenticationCallback)} or
+     * {@link #signInAgain(SignInParameters)} or
      * {@link #acquireToken(AcquireTokenParameters)}.
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
-     * or the default authority specified by you in your configuration
+     * or the default authority specified by you in your configuration.
      *
-     * @param activity  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param scopes    The non-null array of scopes to be consented to during sign in.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     *                  The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
-     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                  Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
+     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow.
      */
+    void signIn(@NonNull final SignInParameters signInParameters);
+
+    /**
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     */
+    @Deprecated
     void signIn(@NonNull final Activity activity,
                 @Nullable final String loginHint,
                 @NonNull final String[] scopes,
@@ -90,26 +88,10 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
     );
 
     /**
-     * Allows a user to sign in to your application with one of their accounts. This method may only
-     * be called once: once a user is signed in, they must first be signed out before another user
-     * may sign in. If you wish to prompt the existing user for credentials use
-     * {@link #signInAgain(Activity, String[], Prompt, AuthenticationCallback)} or
-     * {@link #acquireToken(AcquireTokenParameters)}.
-     * <p>
-     * Note: The authority used to make the sign in request will be either the MSAL default: https://login.microsoftonline.com/common
-     * or the default authority specified by you in your configuration
-     *
-     * @param activity  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
-     * @param loginHint Optional. If provided, will be used as the query parameter sent for authenticating the user,
-     *                  which will have the UPN pre-populated.
-     * @param scopes    The non-null array of scopes to be consented to during sign in.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     *                  The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
-     * @param callback  {@link AuthenticationCallback} that is used to send the result back. The success result will be
-     *                  sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                  Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      */
+    @Deprecated
     void signIn(@NonNull final Activity activity,
                 @Nullable final String loginHint,
                 @NonNull final String[] scopes,
@@ -122,22 +104,17 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default:
      * https://login.microsoftonline.com/common or the default authority specified by you in your
-     * configuration.
+     * configuration. This flow requires activity, scopes, and callback. Prompt is optional.
      *
-     * @param activity Non-null {@link Activity} that is used as the parent activity for
-     *                 launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
-     * @param scopes   The non-null array of scopes to be consented to during sign in.
-     *                 MSAL always sends the scopes 'openid profile offline_access'. Do
-     *                 not include any of these scopes in the scope parameter. The access
-     *                 token returned is for MS Graph and will allow you to query for
-     *                 additional information about the signed in account.
-     * @param prompt   Nullable. Indicates the type of user interaction that is required.
-     *                 If no argument is supplied the default behavior will be used.
-     * @param callback {@link AuthenticationCallback} that is used to send the result back.
-     *                 The success result will be sent back via
-     *                 {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                 Failure case will be sent back via {@link AuthenticationCallback#onError(MsalException)}.
+     * @param signInParameters the {@link SignInParameters} containing the needed fields for signIn flow.
      */
+    void signInAgain(@NonNull final SignInParameters signInParameters);
+
+    /**
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
+     */
+    @Deprecated
     void signInAgain(@NonNull final Activity activity,
                      @NonNull final String[] scopes,
                      @Nullable final Prompt prompt,
@@ -166,25 +143,33 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
      * or it fails the refresh, exception will be sent back via callback.
      *
-     * @param scopes    The non-null array of scopes to be requested for the access token.
-     *                  MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
-     * @param authority Authority to issue the token.
-     * @param callback  {@link SilentAuthenticationCallback} that is used to send the result back. The success result will be
-     *                  sent back via {@link SilentAuthenticationCallback#onSuccess(IAuthenticationResult)}.
-     *                  Failure case will be sent back via {
-     * @link AuthenticationCallback#onError(MsalException)}.
+     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed fields for acquireTokenSilent flow.
      */
+    void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters);
+
+    /**
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     */
+    @Deprecated
     void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                  @NonNull final String authority,
                                  @NonNull final SilentAuthenticationCallback callback
     );
 
+    /**
+     * Perform acquire token silent call. If there is a valid access token in the cache, the sdk will return the access token; If
+     * no valid access token exists, the sdk will try to find a refresh token and use the refresh token to get a new access token. If refresh token does not exist
+     * or it fails the refresh, exception will be sent back via callback.
+     *
+     * @param acquireTokenSilentParameters the {@link AcquireTokenSilentParameters} containing the needed parameters for acquireTokenSilent flow.
+     */
     @WorkerThread
     IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws InterruptedException, MsalException;
 
     /**
      * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link IPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     *              parameters for the API. Use {@link ISingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
      */
     @WorkerThread
     @Deprecated

--- a/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/ISingleAccountPublicClientApplication.java
@@ -161,7 +161,6 @@ public interface ISingleAccountPublicClientApplication extends IPublicClientAppl
      * <p>
      * Note: The authority used to make the sign in request will be either the MSAL default:
      * https://login.microsoftonline.com/common or the default authority specified by you in your
-     * configuration.
      * configuration. This flow requires activity, scopes, and callback. Prompt is optional.
      *
      * @param activity Non-null {@link Activity} that is used as the parent activity for

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -28,6 +28,7 @@ import android.os.Looper;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.WorkerThread;
 
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
@@ -66,17 +67,23 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         super(config);
     }
 
-    //TODO: Add acquireTokenSilent(AcquireTokenSilentParameters)
+    @Override
+    public IAuthenticationResult acquireTokenSilent(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) throws MsalException, InterruptedException {
+        return acquireTokenSilentInternal(acquireTokenSilentParameters, PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_WITH_PARAMETERS);
+    }
 
-    //TODO: Deprecate
+    @Deprecated
     @Override
     public IAuthenticationResult acquireTokenSilent(@NonNull String[] scopes, @NonNull IAccount account, @NonNull String authority) throws MsalException, InterruptedException {
         return acquireTokenSilentSyncInternal(scopes, authority, account, false, PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_WITH_SCOPES_ACCOUNT_AUTHORITY);
     }
 
-    //TODO: Add acquireTokenSilentAsync(AcquireTokenSilentParameters)
+    @Override
+    public void acquireTokenSilentAsync(@NonNull final AcquireTokenSilentParameters acquireTokenSilentParameters) {
+        acquireTokenSilentAsyncInternal(acquireTokenSilentParameters, PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS);
+    }
 
-    //TODO: Deprecate
+    @Deprecated
     @Override
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
@@ -438,9 +445,11 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         }
     }
 
-    //TODO: Add acquireToken(AcquireTokenParameters)
+    public void acquireToken(@NonNull final AcquireTokenParameters acquireTokenParameters) {
+        acquireTokenInternal(acquireTokenParameters, PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS);
+    }
 
-    //TODO: Deprecate
+    @Deprecated
     @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -65,11 +65,17 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         super(config);
     }
 
+    //TODO: Add acquireTokenSilent(AcquireTokenSilentParameters)
+
+    //TODO: Deprecate
     @Override
     public IAuthenticationResult acquireTokenSilent(@NonNull String[] scopes, @NonNull IAccount account, @NonNull String authority) throws MsalException, InterruptedException {
         return acquireTokenSilentSyncInternal(scopes, authority, account, false, PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_WITH_SCOPES_ACCOUNT_AUTHORITY);
     }
 
+    //TODO: Add acquireTokenSilentAsync(AcquireTokenSilentParameters)
+
+    //TODO: Deprecate
     @Override
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final IAccount account,
@@ -431,6 +437,9 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         }
     }
 
+    //TODO: Add acquireToken(AcquireTokenParameters)
+
+    //TODO: Deprecate
     @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,

--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -50,6 +50,7 @@ import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
 import com.microsoft.identity.common.java.util.ResultFuture;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -448,7 +449,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
         final AcquireTokenParameters acquireTokenParameters = buildAcquireTokenParameters(
                 activity,
                 null,
-                scopes,
+                Arrays.asList(scopes),
                 null, // account
                 null, // uiBehavior
                 null, // extraQueryParams

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1380,7 +1380,12 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         return new MsalClientException(exception.getErrorCode(), exception.getMessage());
     }
 
+    /**
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link PublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
+     */
     @Override
+    @Deprecated
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
                              @NonNull final AuthenticationCallback callback) {
@@ -1783,7 +1788,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         }
     }
 
-    public void acquireTokenWithDeviceCode(@Nullable String[] scopes, @NonNull final DeviceCodeFlowCallback callback) {
+    public void acquireTokenWithDeviceCode(@Nullable List<String> scopes, @NonNull final DeviceCodeFlowCallback callback) {
         // Create a DeviceCodeFlowCommandParameters object that takes in the desired scopes and the callback object
         // Use CommandParametersAdapter
         final DeviceCodeFlowCommandParameters commandParameters = CommandParametersAdapter
@@ -1791,6 +1796,36 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                         mPublicClientConfiguration,
                         mPublicClientConfiguration.getOAuth2TokenCache(),
                         scopes);
+
+        // Create a CommandCallback object from the DeviceCodeFlowCallback object
+        final DeviceCodeFlowCommandCallback deviceCodeFlowCommandCallback = getDeviceCodeFlowCommandCallback(callback);
+
+        // Create a DeviceCodeFlowCommand object
+        // Pass the command parameters, default controller, and command callback
+        // Telemetry with DEVICE_CODE_FLOW_CALLBACK
+        final DeviceCodeFlowCommand deviceCodeFlowCommand = new DeviceCodeFlowCommand(
+                commandParameters,
+                new LocalMSALController(),
+                deviceCodeFlowCommandCallback,
+                PublicApiId.DEVICE_CODE_FLOW_WITH_CALLBACK
+        );
+
+        CommandDispatcher.submitSilent(deviceCodeFlowCommand);
+    }
+
+    /**
+     * @deprecated  This method is now deprecated. The library is moving away from using an array for scopes.
+     *              Use {@link PublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)} instead.
+     */
+    @Deprecated
+    public void acquireTokenWithDeviceCode(@Nullable String[] scopes, @NonNull final DeviceCodeFlowCallback callback) {
+        // Create a DeviceCodeFlowCommandParameters object that takes in the desired scopes and the callback object
+        // Use CommandParametersAdapter
+        final DeviceCodeFlowCommandParameters commandParameters = CommandParametersAdapter
+                .createDeviceCodeFlowCommandParameters(
+                        mPublicClientConfiguration,
+                        mPublicClientConfiguration.getOAuth2TokenCache(),
+                        Arrays.asList(scopes));
 
         // Create a CommandCallback object from the DeviceCodeFlowCallback object
         final DeviceCodeFlowCommandCallback deviceCodeFlowCommandCallback = getDeviceCodeFlowCommandCallback(callback);

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1392,7 +1392,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         AcquireTokenParameters acquireTokenParameters = buildAcquireTokenParameters(
                 activity,
                 null,
-                scopes,
+                Arrays.asList(scopes),
                 null, // account
                 null, // uiBehavior
                 null, // extraQueryParams
@@ -1406,6 +1406,47 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         acquireTokenInternal(acquireTokenParameters, PublicApiId.PCA_ACQUIRE_TOKEN_WITH_ACTIVITY_SCOPES_CALLBACK);
     }
 
+    AcquireTokenParameters buildAcquireTokenParameters(
+            @NonNull final Activity activity,
+            @Nullable final Fragment fragment,
+            @NonNull final List<String> scopes,
+            @Nullable final IAccount account,
+            @Nullable final Prompt uiBehavior,
+            @Nullable final List<Map.Entry<String, String>> extraQueryParameters,
+            @Nullable final String[] extraScopesToConsent,
+            @Nullable final String authority,
+            @NonNull final AuthenticationCallback callback,
+            @Nullable final String loginHint,
+            @Nullable final ClaimsRequest claimsRequest) {
+
+        validateNonNullArgument(activity, NONNULL_CONSTANTS.ACTIVITY);
+        validateNonNullArgument(scopes, NONNULL_CONSTANTS.SCOPES);
+        validateNonNullArgument(callback, NONNULL_CONSTANTS.CALLBACK);
+
+        AcquireTokenParameters.Builder builder = new AcquireTokenParameters.Builder();
+        AcquireTokenParameters acquireTokenParameters = builder.startAuthorizationFromActivity(activity)
+                .withFragment(fragment)
+                .forAccount(account)
+                .withScopes(scopes)
+                .withPrompt(uiBehavior)
+                .withAuthorizationQueryStringParameters(extraQueryParameters)
+                .withOtherScopesToAuthorize(
+                        Arrays.asList(
+                                null == extraScopesToConsent
+                                        ? new String[]{}
+                                        : extraScopesToConsent
+                        )
+                )
+                .fromAuthority(authority)
+                .withCallback(callback)
+                .withLoginHint(loginHint)
+                .withClaims(claimsRequest)
+                .build();
+
+        return acquireTokenParameters;
+    }
+
+    @Deprecated
     AcquireTokenParameters buildAcquireTokenParameters(
             @NonNull final Activity activity,
             @Nullable final Fragment fragment,

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1831,7 +1831,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         }
     }
 
-    public void acquireTokenWithDeviceCode(@Nullable List<String> scopes, @NonNull final DeviceCodeFlowCallback callback) {
+    public void acquireTokenWithDeviceCode(@NonNull List<String> scopes, @NonNull final DeviceCodeFlowCallback callback) {
         // Create a DeviceCodeFlowCommandParameters object that takes in the desired scopes and the callback object
         // Use CommandParametersAdapter
         final DeviceCodeFlowCommandParameters commandParameters = CommandParametersAdapter
@@ -1861,7 +1861,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      *              Use {@link PublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)} instead.
      */
     @Deprecated
-    public void acquireTokenWithDeviceCode(@Nullable String[] scopes, @NonNull final DeviceCodeFlowCallback callback) {
+    public void acquireTokenWithDeviceCode(@NonNull String[] scopes, @NonNull final DeviceCodeFlowCallback callback) {
         // Create a DeviceCodeFlowCommandParameters object that takes in the desired scopes and the callback object
         // Use CommandParametersAdapter
         final DeviceCodeFlowCommandParameters commandParameters = CommandParametersAdapter

--- a/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
@@ -1,3 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.app.Activity;
@@ -11,7 +33,7 @@ import lombok.Singular;
 import java.util.List;
 
 /**
- * Encapsulates the parameters for calling signIn() in SingleAccountPublicClientApplication.
+ * Encapsulates the parameters for calling {@link SingleAccountPublicClientApplication#signIn(SignInParameters)}.
  * Not a subclass of TokenParameters because it does not need fields such as Account, AccountRecord.
  *
  * <br>
@@ -22,7 +44,7 @@ import java.util.List;
  *              which will have the UPN pre-populated.
  *
  * <br>
- * Scopes    -  The non-null array of scopes to be consented to during sign in.
+ * Scopes    -  The non-null list of scopes to be consented to during sign in.
  *              MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
  *              The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
  *
@@ -33,7 +55,7 @@ import java.util.List;
  *
  * <br>
  * Prompt    -  Optional. Indicates the type of user interaction that is required.
- *              If no argument is supplied the default behavior will be used.
+ *              If no argument is supplied the default behavior will be used (default is SELECT_ACCOUNT).
  */
 @Builder(setterPrefix = "with")
 @Data

--- a/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
@@ -1,0 +1,17 @@
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import java.util.List;
+
+/**
+ * Encapsulates the parameters for calling signIn() in SingleAccountPublicClientApplication.
+ */
+public class SignInParameters {
+
+    private Activity mActivity;
+    private String mLoginHint;
+    private List<String> mScopes;
+    private Prompt mPrompt;
+    private AuthenticationCallback mCallback;
+
+}

--- a/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SignInParameters.java
@@ -1,17 +1,46 @@
 package com.microsoft.identity.client;
 
 import android.app.Activity;
+
+import androidx.annotation.Nullable;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.Singular;
 import java.util.List;
 
 /**
  * Encapsulates the parameters for calling signIn() in SingleAccountPublicClientApplication.
+ * Not a subclass of TokenParameters because it does not need fields such as Account, AccountRecord.
+ *
+ * <br>
+ * Activity  -  Non-null {@link Activity} that is used as the parent activity for launching the {@link com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity}.
+ *
+ * <br>
+ * LoginHint -  Optional. If provided, will be used as the query parameter sent for authenticating the user,
+ *              which will have the UPN pre-populated.
+ *
+ * <br>
+ * Scopes    -  The non-null array of scopes to be consented to during sign in.
+ *              MSAL always sends the scopes 'openid profile offline_access'.  Do not include any of these scopes in the scope parameter.
+ *              The access token returned is for MS Graph and will allow you to query for additional information about the signed in account.
+ *
+ * <br>
+ * Callback  -  {@link AuthenticationCallback} that is used to send the result back. The success result will be
+ *              sent back via {@link AuthenticationCallback#onSuccess(IAuthenticationResult)}.
+ *              Failure case will be sent back via AuthenticationCallback.onError(MsalException).
+ *
+ * <br>
+ * Prompt    -  Optional. Indicates the type of user interaction that is required.
+ *              If no argument is supplied the default behavior will be used.
  */
+@Builder(setterPrefix = "with")
+@Data
 public class SignInParameters {
-
-    private Activity mActivity;
-    private String mLoginHint;
-    private List<String> mScopes;
-    private Prompt mPrompt;
-    private AuthenticationCallback mCallback;
-
+    private @NonNull Activity activity;
+    private @Nullable String loginHint;
+    @Singular private @NonNull List<String> scopes;
+    private @Nullable Prompt prompt;
+    private @NonNull AuthenticationCallback callback;
 }

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -73,11 +73,13 @@ import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGL
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PROMPT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS;
+import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS_PROMPT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_GET_CURRENT_ACCOUNT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_GET_CURRENT_ACCOUNT_ASYNC;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PROMPT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS;
+import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS_PROMPT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_OUT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_OUT_WITH_CALLBACK;
 
@@ -268,17 +270,18 @@ public class SingleAccountPublicClientApplication
         );
 
         if (signInParameters.getPrompt() == null) {
-            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN);
+            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS);
         }
         else {
-            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS);
+            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS_PROMPT);
         }
 
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      */
     @Deprecated
     @Override
@@ -316,8 +319,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      */
     @Deprecated
     @Override
@@ -379,13 +383,19 @@ public class SingleAccountPublicClientApplication
                 null // claimsRequest
         );
 
-        acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS);
+        if (signInParameters.getPrompt() == null) {
+            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS);
+        }
+        else {
+            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS_PROMPT);
+        }
     }
 
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
      */
     @Deprecated
     @Override
@@ -675,8 +685,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
      */
     @Override
     @Deprecated
@@ -711,8 +722,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
      */
     @Deprecated
     @Override
@@ -742,8 +754,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
-     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     *              parameters for the SingleAccountPublicClientApplication API.
+     *              Use {@link SingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
      */
     @Deprecated
     @WorkerThread

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -72,10 +72,12 @@ import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGL
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_ACTIVITY_SCOPES_CALLBACK;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PROMPT;
+import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_GET_CURRENT_ACCOUNT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_GET_CURRENT_ACCOUNT_ASYNC;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PROMPT;
+import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_OUT;
 import static com.microsoft.identity.common.java.eststelemetry.PublicApiId.SINGLE_ACCOUNT_PCA_SIGN_OUT_WITH_CALLBACK;
 
@@ -269,7 +271,7 @@ public class SingleAccountPublicClientApplication
             acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN);
         }
         else {
-            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PROMPT);
+            acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS);
         }
 
     }
@@ -377,7 +379,7 @@ public class SingleAccountPublicClientApplication
                 null // claimsRequest
         );
 
-        acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PROMPT);
+        acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS);
     }
 
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -277,12 +277,7 @@ public class SingleAccountPublicClientApplication
         }
 
     }
-
-    /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
-     */
+    
     @Deprecated
     @Override
     public void signIn(@NonNull final Activity activity,

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -236,6 +236,9 @@ public class SingleAccountPublicClientApplication
         callback.onAccountLoaded(newAccount);
     }
 
+    //TODO: Add signIn(@NonNull final SignInParameters)
+
+    //TODO: Deprecate
     @Override
     public void signIn(@NonNull final Activity activity,
                        @Nullable final String loginHint,
@@ -270,6 +273,7 @@ public class SingleAccountPublicClientApplication
         acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN);
     }
 
+    //TODO: Deprecate
     @Override
     public void signIn(@NonNull final Activity activity,
                        @Nullable final String loginHint,
@@ -305,6 +309,7 @@ public class SingleAccountPublicClientApplication
         acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PROMPT);
     }
 
+    //TODO: Deprecate
     @Override
     public void signInAgain(@NonNull final Activity activity,
                             @NonNull final String[] scopes,
@@ -551,6 +556,7 @@ public class SingleAccountPublicClientApplication
         return (MultiTenantAccount) account.get(0);
     }
 
+    //TODO: Deprecate
     @Override
     public void acquireToken(@NonNull final Activity activity,
                              @NonNull final String[] scopes,
@@ -622,6 +628,7 @@ public class SingleAccountPublicClientApplication
         acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS);
     }
 
+    //TODO: Deprecate
     @Override
     public void acquireTokenSilentAsync(@NonNull final String[] scopes,
                                         @NonNull final String authority,
@@ -648,6 +655,11 @@ public class SingleAccountPublicClientApplication
         );
     }
 
+    /**
+     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of TokenParameter subclasses as the
+     *              parameters for the API. Use {@link SingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     */
+    @Deprecated
     @WorkerThread
     public IAuthenticationResult acquireTokenSilent(@NonNull final String[] scopes,
                                                     @NonNull final String authority) throws MsalException, InterruptedException {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.common.logging.Logger;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 public class CommandParametersAdapter {
@@ -204,7 +205,7 @@ public class CommandParametersAdapter {
     public static DeviceCodeFlowCommandParameters createDeviceCodeFlowCommandParameters(
             @NonNull final PublicClientApplicationConfiguration configuration,
             @NonNull final OAuth2TokenCache tokenCache,
-            @NonNull String[] scopes) {
+            @NonNull List<String> scopes) {
 
         // TODO: Consider implementing support for PoP
 
@@ -225,7 +226,7 @@ public class CommandParametersAdapter {
                 .sdkVersion(PublicClientApplication.getSdkVersion())
                 .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
                 .authenticationScheme(authenticationScheme)
-                .scopes(new HashSet<>(Arrays.asList(scopes)))
+                .scopes(new HashSet<>(scopes))
                 .authority(authority)
                 .build();
 

--- a/msal/src/test/java/com/microsoft/identity/client/SignInParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/SignInParametersTest.java
@@ -1,3 +1,25 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
 package com.microsoft.identity.client;
 
 import android.app.Activity;

--- a/msal/src/test/java/com/microsoft/identity/client/SignInParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/SignInParametersTest.java
@@ -1,0 +1,133 @@
+package com.microsoft.identity.client;
+
+import android.app.Activity;
+import com.microsoft.identity.client.exception.MsalException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.junit.Assert;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+public class SignInParametersTest {
+
+    @Before
+    public void setup() {
+        // None
+    }
+
+    @Test
+    public void testWithScope() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(new Activity())
+                .withScope("a")
+                .withCallback(getCallback())
+                .build();
+
+        List<String> scopes = new ArrayList<>();
+        scopes.add("a");
+
+        Assert.assertEquals(signInParameters.getScopes(), scopes);
+    }
+
+    @Test
+    public void testWithScopeMultiple() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(new Activity())
+                .withScope("a")
+                .withScope("b")
+                .withCallback(getCallback())
+                .build();
+
+        List<String> scopes = new ArrayList<>();
+        scopes.add("a");
+        scopes.add("b");
+
+        Assert.assertEquals(signInParameters.getScopes(), scopes);
+    }
+
+    @Test
+    public void testWithScopes() {
+        List<String> scopes = new ArrayList<>();
+        scopes.add("a");
+        scopes.add("b");
+
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(new Activity())
+                .withScopes(scopes)
+                .withCallback(getCallback())
+                .build();
+
+        List<String> compareScopes = new ArrayList<>();
+        compareScopes.add("a");
+        compareScopes.add("b");
+
+        Assert.assertEquals(signInParameters.getScopes(), compareScopes);
+    }
+
+    @Test
+    public void testWithScopeAndScopes() {
+        List<String> scopes = new ArrayList<>();
+        scopes.add("a");
+        scopes.add("b");
+
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(new Activity())
+                .withScopes(scopes)
+                .withScope("c")
+                .withCallback(getCallback())
+                .build();
+
+        List<String> compareScopes = new ArrayList<>();
+        compareScopes.add("a");
+        compareScopes.add("b");
+        compareScopes.add("c");
+
+        Assert.assertEquals(signInParameters.getScopes(), compareScopes);
+    }
+
+    @Test
+    public void testScopeOverride() {
+        List<String> scopes = new ArrayList<>();
+        scopes.add("a");
+        scopes.add("b");
+
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(new Activity())
+                .withScopes(scopes)
+                .withScope("c")
+                .withCallback(getCallback())
+                .build();
+
+        List<String> newScopes = new ArrayList<>();
+        newScopes.add("d");
+        newScopes.add("e");
+
+        signInParameters.setScopes(newScopes);
+
+        List<String> compareScopes = new ArrayList<>();
+        compareScopes.add("d");
+        compareScopes.add("e");
+
+        Assert.assertEquals(signInParameters.getScopes(), compareScopes);
+    }
+
+    private AuthenticationCallback getCallback() {
+        return new AuthenticationCallback() {
+            @Override
+            public void onCancel() {
+                // Nothing
+            }
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                // Nothing
+            }
+            @Override
+            public void onError(MsalException exception) {
+                // Nothing
+            }
+        };
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -27,6 +27,7 @@ import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
+import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.e2e.shadows.ShadowMockAuthority;
 import com.microsoft.identity.client.e2e.shadows.ShadowPublicClientApplicationConfiguration;
 import com.microsoft.identity.client.e2e.shadows.ShadowOpenIdProviderConfigurationClient;
@@ -152,7 +153,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        String expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
+        String expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
         String expectedLast = "2|0|||1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -196,7 +197,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
         expectedLast = "2|2|||1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -218,8 +219,8 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
-        expectedLast = "2|0|" + PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," +
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
+        expectedLast = "2|0|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," +
                 sCorrelationIdList.get(networkRequestIndex - 1) + "|invalid_grant|1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -241,8 +242,8 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
-        expectedLast = "2|0|" + PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," +
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
+        expectedLast = "2|0|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," +
                 sCorrelationIdList.get(networkRequestIndex - 1) + "|invalid_scope|1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -257,10 +258,10 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
         expectedLast = "2|0|" +
-                PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," + sCorrelationIdList.get(networkRequestIndex - 2) +
-                "," + PublicApiId.PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + "," + sCorrelationIdList.get(networkRequestIndex - 1) +
+                PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + "," + sCorrelationIdList.get(networkRequestIndex - 2) +
+                "," + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + "," + sCorrelationIdList.get(networkRequestIndex - 1) +
                 "|invalid_scope,service_unavailable|1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -283,7 +284,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
         flushScheduler();
 
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_SILENT_ASYNC_WITH_PARAMETERS + ",1|1,1,1,1,0,1";
         expectedLast = "2|0|||1";
         assertTelemetry(expectedCurrent, expectedLast);
 
@@ -348,7 +349,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
 
         // all data should now be sent
         // assert telem
-        expectedCurrent = "2|" + PublicApiId.PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
+        expectedCurrent = "2|" + PublicApiId.MULTIPLE_ACCOUNT_PCA_ACQUIRE_TOKEN_WITH_PARAMETERS + ",0|,,,,,";
         expectedLast = "2|0|||1";
         assertTelemetry(expectedCurrent, expectedLast);
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
@@ -28,6 +28,7 @@ import android.util.Base64;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
@@ -38,6 +39,7 @@ import com.microsoft.identity.client.e2e.shadows.ShadowAuthorityForMockHttpRespo
 import com.microsoft.identity.client.e2e.shadows.ShadowPublicClientApplicationConfiguration;
 import com.microsoft.identity.client.e2e.shadows.ShadowAndroidSdkStorageEncryptionManager;
 import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
+import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.client.e2e.utils.RoboTestUtils;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage;
@@ -426,6 +428,160 @@ public class CrossCloudGuestAccountTest extends AcquireTokenAbstractTest {
 
         // act and assert
         try {
+            mMultipleAccountPCA.acquireTokenSilentAsync(
+                    getScopes(),
+                    accountsUnderTest.get(0),
+                    mTestCaseData.userAccountsData.get(0).authority +
+                            "/" + mTestCaseData.userAccountsData.get(0).tenantId,
+                    silentAuthenticationCallback);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testAcquireTokenSilentReturnsAccessTokenForCrossCloudAccountWithSilentParameters() {
+        // arrange
+        final UserAccountData lastSignedInAccount =
+                mTestCaseData.userAccountsData.get(mTestCaseData.userAccountsData.size() - 1);
+
+        final SilentAuthenticationCallback silentAuthenticationCallback = new SilentAuthenticationCallback() {
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                // verify access token value from the authentication result matches the expected
+                // access token as set in the test case data
+                assertEquals("Verify accessToken value from authenticationResult matches mocked access token",
+                        lastSignedInAccount.getFakeAccessToken(), authenticationResult.getAccessToken());
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                fail(exception.getMessage());
+            }
+        };
+
+        // act and assert
+        try {
+            final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                    .withScopes(Arrays.asList(getScopes()))
+                    .forAccount(getAccount())
+                    .fromAuthority(lastSignedInAccount.authority +
+                            "/" + lastSignedInAccount.tenantId)
+                    .forceRefresh(false)
+                    .withClaims(null)
+                    .withCallback(silentAuthenticationCallback)
+                    .build();
+
+            mMultipleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testAcquireTokenSilentReturnsAccessTokenForCrossCloudAccountRetrievedUsingGetAccountWithSilentParameters() {
+        // arrange
+        final IAccount[] accountUnderTest = {null};
+        mMultipleAccountPCA.getAccount(mTestCaseData.homeAccountId, new IMultipleAccountPublicClientApplication.GetAccountCallback() {
+            @Override
+            public void onTaskCompleted(IAccount result) {
+                accountUnderTest[0] = result;
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                fail(exception.getMessage());
+            }
+        });
+
+        RoboTestUtils.flushScheduler();
+
+        final SilentAuthenticationCallback silentAuthenticationCallback = new SilentAuthenticationCallback() {
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                // verify access token value from the authentication result matches the expected
+                // access token as set in the test case data
+                assertEquals("Verify accessToken value from authenticationResult matches mocked access token",
+                        mTestCaseData.userAccountsData.get(0).getFakeAccessToken(), authenticationResult.getAccessToken());
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                fail(exception.getMessage());
+            }
+        };
+
+        // act and assert
+        try {
+            final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                    .withScopes(Arrays.asList(getScopes()))
+                    .forAccount(accountUnderTest[0])
+                    .fromAuthority(mTestCaseData.userAccountsData.get(0).authority +
+                            "/" + mTestCaseData.userAccountsData.get(0).tenantId)
+                    .forceRefresh(false)
+                    .withClaims(null)
+                    .withCallback(silentAuthenticationCallback)
+                    .build();
+
+            mMultipleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testAcquireTokenSilentReturnsAccessTokenForCrossCloudAccountRetrievedUsingGetAccountsWithSilentParameters() {
+        // arrange
+        final List<IAccount> accountsUnderTest = new ArrayList<>();
+        mMultipleAccountPCA.getAccounts(new IPublicClientApplication.LoadAccountsCallback() {
+            @Override
+            public void onTaskCompleted(List<IAccount> result) {
+                accountsUnderTest.addAll(result);
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                fail(exception.getMessage());
+            }
+        });
+
+        RoboTestUtils.flushScheduler();
+
+        final SilentAuthenticationCallback silentAuthenticationCallback = new SilentAuthenticationCallback() {
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                // verify access token value from the authentication result matches the expected
+                // access token as set in the test case data
+                assertEquals("Verify accessToken value from authenticationResult matches mocked access token",
+                        mTestCaseData.userAccountsData.get(0).getFakeAccessToken(), authenticationResult.getAccessToken());
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                fail(exception.getMessage());
+            }
+        };
+
+        // act and assert
+        try {
+            final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                    .withScopes(Arrays.asList(getScopes()))
+                    .forAccount(accountsUnderTest.get(0))
+                    .fromAuthority(mTestCaseData.userAccountsData.get(0).authority +
+                            "/" + mTestCaseData.userAccountsData.get(0).tenantId)
+                    .forceRefresh(false)
+                    .withClaims(null)
+                    .withCallback(silentAuthenticationCallback)
+                    .build();
+
+            mMultipleAccountPCA.acquireTokenSilentAsync(silentParameters);
+
             mMultipleAccountPCA.acquireTokenSilentAsync(
                     getScopes(),
                     accountsUnderTest.get(0),

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -284,18 +284,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCannotAcquireTokenSilentlyWithParametersIfNotSignedIn() {
-        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(AcquireTokenTestHelper.getAccount())
-                .fromAuthority(getAuthority())
-                .withCallback(getNoCurrentAccountExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-    }
-
-    @Test
     public void testCanAcquireTokenSilentlyWithParametersIfAlreadySignedIn() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
         RoboTestUtils.flushScheduler();

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -117,21 +117,21 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
     }
 
-//    @Test
-//    public void testSignInOnlyAllowedOnceWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        signInParameters.setCallback(getInvalidParameterExpectedCallback());
-//
-//        mSingleAccountPCA.signIn(signInParameters);
-//    }
+    @Test
+    public void testSignInOnlyAllowedOnceWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        signInParameters.setCallback(getInvalidParameterExpectedCallback());
+
+        mSingleAccountPCA.signIn(signInParameters);
+    }
 
     @Test
     public void testSignInWithPromptOnlyAllowedOnce() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -120,28 +120,28 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
     }
 
-    @Test
-    public void testSignInOnlyAllowedOnceWithParameters() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle();
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        Shadows.shadowOf(Looper.getMainLooper()).idle();
-        final SignInParameters secondSignInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getInvalidParameterExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.signIn(secondSignInParameters);
-    }
+//    @Test
+//    public void testSignInOnlyAllowedOnceWithParameters() {
+//        Shadows.shadowOf(Looper.getMainLooper()).idle();
+//        final SignInParameters signInParameters = SignInParameters.builder()
+//                .withActivity(mActivity)
+//                .withLoginHint(mUsername)
+//                .withScopes(Arrays.asList(mScopes))
+//                .withCallback(getSuccessExpectedCallback())
+//                .build();
+//        mSingleAccountPCA.signIn(signInParameters);
+//        RoboTestUtils.flushScheduler();
+//
+//        Shadows.shadowOf(Looper.getMainLooper()).idle();
+//        final SignInParameters secondSignInParameters = SignInParameters.builder()
+//                .withActivity(mActivity)
+//                .withLoginHint(mUsername)
+//                .withScopes(Arrays.asList(mScopes))
+//                .withCallback(getInvalidParameterExpectedCallback())
+//                .build();
+//
+//        mSingleAccountPCA.signIn(secondSignInParameters);
+//    }
 
     @Test
     public void testSignInWithPromptOnlyAllowedOnce() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests.mocked;
 
+import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -63,7 +64,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -119,6 +122,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
 
     @Test
     public void testSignInOnlyAllowedOnceWithParameters() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
         final SignInParameters signInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)
@@ -128,6 +132,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
         final SignInParameters secondSignInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -399,62 +399,62 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
     }
 
-    @Test
-    public void testCanAcquireTokenSilentlyAfterDeviceCodeWithList() {
-        // Test sometimes fails because the url is sometimes matched to the token url in MOCK_TOKEN_URL_REGEX
-        // Test case will clear all previous matchers in HttpsClient and reload them as test goes on.
-        mockHttpClient.uninstall();
-
-        // Load Device Code Flow Authorization interceptor
-        mockHttpClient.intercept(
-                HttpRequestMatcher.builder()
-                        .isPOST()
-                        .urlPattern(DEVICE_CODE_FLOW_AUTHORIZATION_REGEX)
-                        .build(),
-                MockServerResponse.getMockDeviceCodeFlowAuthorizationHttpResponse()
-        );
-        mSingleAccountPCA.acquireTokenWithDeviceCode(Arrays.asList(mScopes), new IPublicClientApplication.DeviceCodeFlowCallback() {
-            @Override
-            public void onUserCodeReceived(final @NonNull String vUri,
-                                           final @NonNull String userCode,
-                                           final @NonNull String message,
-                                           final @NonNull Date sessionExpirationDate) {
-                // Assert that the protocol returns the userCode and others after successful authorization
-                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
-                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
-                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
-                Assert.assertNotNull(sessionExpirationDate);
-
-                // Load Token interceptor
-                mockHttpClient.intercept(
-                        HttpRequestMatcher.builder()
-                                .isPOST()
-                                .urlPattern(MOCK_TOKEN_URL_REGEX)
-                                .build(),
-                        MockServerResponse.getMockTokenSuccessResponse()
-                );
-            }
-
-            @Override
-            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
-                Assert.assertNotNull(authResult);
-                Assert.assertNotNull(authResult.getAccount());
-                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
-                Assert.assertNotNull(authResult.getAccessToken());
-                AcquireTokenTestHelper.setAccount(authResult.getAccount());
-            }
-
-            @Override
-            public void onError(@NonNull MsalException exception) {
-                // This shouldn't run
-                throw new AssertionError(exception);
-            }
-        });
-        RoboTestUtils.flushScheduler();
-
-        mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-    }
+//    @Test
+//    public void testCanAcquireTokenSilentlyAfterDeviceCodeWithList() {
+//        // Test sometimes fails because the url is sometimes matched to the token url in MOCK_TOKEN_URL_REGEX
+//        // Test case will clear all previous matchers in HttpsClient and reload them as test goes on.
+//        mockHttpClient.uninstall();
+//
+//        // Load Device Code Flow Authorization interceptor
+//        mockHttpClient.intercept(
+//                HttpRequestMatcher.builder()
+//                        .isPOST()
+//                        .urlPattern(DEVICE_CODE_FLOW_AUTHORIZATION_REGEX)
+//                        .build(),
+//                MockServerResponse.getMockDeviceCodeFlowAuthorizationHttpResponse()
+//        );
+//        mSingleAccountPCA.acquireTokenWithDeviceCode(Arrays.asList(mScopes), new IPublicClientApplication.DeviceCodeFlowCallback() {
+//            @Override
+//            public void onUserCodeReceived(final @NonNull String vUri,
+//                                           final @NonNull String userCode,
+//                                           final @NonNull String message,
+//                                           final @NonNull Date sessionExpirationDate) {
+//                // Assert that the protocol returns the userCode and others after successful authorization
+//                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+//                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+//                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
+//                Assert.assertNotNull(sessionExpirationDate);
+//
+//                // Load Token interceptor
+//                mockHttpClient.intercept(
+//                        HttpRequestMatcher.builder()
+//                                .isPOST()
+//                                .urlPattern(MOCK_TOKEN_URL_REGEX)
+//                                .build(),
+//                        MockServerResponse.getMockTokenSuccessResponse()
+//                );
+//            }
+//
+//            @Override
+//            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
+//                Assert.assertNotNull(authResult);
+//                Assert.assertNotNull(authResult.getAccount());
+//                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
+//                Assert.assertNotNull(authResult.getAccessToken());
+//                AcquireTokenTestHelper.setAccount(authResult.getAccount());
+//            }
+//
+//            @Override
+//            public void onError(@NonNull MsalException exception) {
+//                // This shouldn't run
+//                throw new AssertionError(exception);
+//            }
+//        });
+//        RoboTestUtils.flushScheduler();
+//
+//        mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
+//        RoboTestUtils.flushScheduler();
+//    }
 
     public void testCannotGetCurrentAccountIfNotSignedIn() {
         // todo need to improve the behaviour around this before a test should be written

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -115,7 +115,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -137,7 +136,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.signIn(secondSignInParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -146,7 +144,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, Prompt.LOGIN, getInvalidParameterExpectedCallback());
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -170,7 +167,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.signIn(secondSignInParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -207,7 +203,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotSignInAgainIfNeverSignedInBefore() {
         mSingleAccountPCA.signInAgain(mActivity, mScopes, Prompt.LOGIN, getNoCurrentAccountExpectedCallback());
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -219,7 +214,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .withCallback(getNoCurrentAccountExpectedCallback())
                 .build();
         mSingleAccountPCA.signInAgain(signInParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -282,7 +276,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 Assert.assertEquals(exception.getErrorCode(), MsalClientException.NO_CURRENT_ACCOUNT);
             }
         });
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -333,7 +326,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotAcquireTokenIfNotSignedIn() {
         mSingleAccountPCA.acquireToken(mActivity, mScopes, getNoCurrentAccountExpectedCallback());
-        RoboTestUtils.flushScheduler();
     }
 
     public void testCannotAcquireTokenWithParametersIfNotSignedIn() {
@@ -352,7 +344,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -373,7 +364,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -389,7 +379,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -411,7 +400,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -429,7 +417,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -453,7 +440,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -535,7 +521,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotAcquireTokenSilentlyIfNotSignedIn() {
         mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getNoCurrentAccountExpectedCallback());
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -578,7 +563,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -634,7 +618,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -658,7 +641,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-        RoboTestUtils.flushScheduler();
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -128,9 +128,14 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
-        signInParameters.setCallback(getInvalidParameterExpectedCallback());
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getInvalidParameterExpectedCallback())
+                .build();
 
-        mSingleAccountPCA.signIn(signInParameters);
+        mSingleAccountPCA.signIn(secondSignInParameters);
     }
 
     @Test
@@ -153,9 +158,15 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
-        signInParameters.setCallback(getInvalidParameterExpectedCallback());
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getInvalidParameterExpectedCallback())
+                .build();
 
-        mSingleAccountPCA.signIn(signInParameters);
+        mSingleAccountPCA.signIn(secondSignInParameters);
     }
 
     @Test
@@ -178,9 +189,14 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
-        signInParameters.setLoginHint(null);
-        signInParameters.setPrompt(Prompt.LOGIN);
-        mSingleAccountPCA.signInAgain(signInParameters);
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.signInAgain(secondSignInParameters);
         RoboTestUtils.flushScheduler();
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -115,6 +115,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -136,6 +137,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.signIn(secondSignInParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -144,6 +146,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, Prompt.LOGIN, getInvalidParameterExpectedCallback());
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -167,6 +170,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.signIn(secondSignInParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -203,6 +207,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotSignInAgainIfNeverSignedInBefore() {
         mSingleAccountPCA.signInAgain(mActivity, mScopes, Prompt.LOGIN, getNoCurrentAccountExpectedCallback());
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -214,6 +219,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .withCallback(getNoCurrentAccountExpectedCallback())
                 .build();
         mSingleAccountPCA.signInAgain(signInParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -276,6 +282,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 Assert.assertEquals(exception.getErrorCode(), MsalClientException.NO_CURRENT_ACCOUNT);
             }
         });
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -326,6 +333,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotAcquireTokenIfNotSignedIn() {
         mSingleAccountPCA.acquireToken(mActivity, mScopes, getNoCurrentAccountExpectedCallback());
+        RoboTestUtils.flushScheduler();
     }
 
     public void testCannotAcquireTokenWithParametersIfNotSignedIn() {
@@ -344,6 +352,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -364,6 +373,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -379,6 +389,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -400,6 +411,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -417,6 +429,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -440,6 +453,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -521,6 +535,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotAcquireTokenSilentlyIfNotSignedIn() {
         mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getNoCurrentAccountExpectedCallback());
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -563,6 +578,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -618,6 +634,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test
@@ -641,6 +658,7 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
                 .build();
 
         mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -22,7 +22,6 @@
 // THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests.mocked;
 
-import android.os.Looper;
 import android.text.TextUtils;
 
 import androidx.annotation.NonNull;
@@ -34,11 +33,9 @@ import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AuthenticationCallback;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
-import com.microsoft.identity.client.ICurrentAccountResult;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.Prompt;
-import com.microsoft.identity.client.SignInParameters;
 import com.microsoft.identity.client.SingleAccountPublicClientApplication;
 import com.microsoft.identity.client.e2e.shadows.ShadowAuthorityForMockHttpResponse;
 import com.microsoft.identity.client.e2e.shadows.ShadowPublicClientApplicationConfiguration;
@@ -64,9 +61,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
-import org.robolectric.annotation.LooperMode;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -120,58 +115,12 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
     }
 
-//    @Test
-//    public void testSignInOnlyAllowedOnceWithParameters() {
-//        Shadows.shadowOf(Looper.getMainLooper()).idle();
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        Shadows.shadowOf(Looper.getMainLooper()).idle();
-//        final SignInParameters secondSignInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getInvalidParameterExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.signIn(secondSignInParameters);
-//    }
-
     @Test
     public void testSignInWithPromptOnlyAllowedOnce() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, Prompt.LOGIN, getSuccessExpectedCallback());
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, Prompt.LOGIN, getInvalidParameterExpectedCallback());
-    }
-
-    @Test
-    public void testSignInWithPromptOnlyAllowedOnceWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withPrompt(Prompt.LOGIN)
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final SignInParameters secondSignInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withPrompt(Prompt.LOGIN)
-                .withCallback(getInvalidParameterExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.signIn(secondSignInParameters);
     }
 
     @Test
@@ -184,72 +133,13 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testSignInAgainAllowsSignInAgainWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final SignInParameters secondSignInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .withPrompt(Prompt.LOGIN)
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.signInAgain(secondSignInParameters);
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
     public void testCannotSignInAgainIfNeverSignedInBefore() {
         mSingleAccountPCA.signInAgain(mActivity, mScopes, Prompt.LOGIN, getNoCurrentAccountExpectedCallback());
     }
 
     @Test
-    public void testCannotSignInAgainIfNeverSignedInBeforeWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .withPrompt(Prompt.LOGIN)
-                .withCallback(getNoCurrentAccountExpectedCallback())
-                .build();
-        mSingleAccountPCA.signInAgain(signInParameters);
-    }
-
-    @Test
     public void testCanSignOutIfAlreadySignedIn() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        mSingleAccountPCA.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
-            @Override
-            public void onSignOut() {
-                Assert.assertTrue("Successfully signed out", true);
-            }
-
-            @Override
-            public void onError(@NonNull MsalException exception) {
-                fail(exception.getMessage());
-            }
-        });
-
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
-    public void testCanSignOutIfAlreadySignedInWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
@@ -293,42 +183,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCanAcquireTokenIfAlreadySignInWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
-            @Override
-            public void onAccountLoaded(@Nullable IAccount activeAccount) {
-                final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                        .startAuthorizationFromActivity(mActivity)
-                        .withScopes(Arrays.asList(mScopes))
-                        .forAccount(activeAccount)
-                        .withCallback(getSuccessExpectedCallback())
-                        .build();
-                mSingleAccountPCA.acquireToken(acquireTokenParameters);
-                RoboTestUtils.flushScheduler();
-            }
-
-            @Override
-            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
-                // Nothing
-            }
-
-            @Override
-            public void onError(@NonNull MsalException exception) {
-                Assert.fail(exception.getMessage());
-            }
-        });
-    }
-
-    @Test
     public void testCannotAcquireTokenIfNotSignedIn() {
         mSingleAccountPCA.acquireToken(mActivity, mScopes, getNoCurrentAccountExpectedCallback());
     }
@@ -340,26 +194,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     @Test
     public void testCannotAcquireTokenWithParametersIfNoLoginHintNoAccountProvided() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                .startAuthorizationFromActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getAccountMismatchExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-    }
-
-    @Test
-    public void testCannotAcquireTokenWithParametersIfNoLoginHintNoAccountProvidedWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
         final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
@@ -387,52 +221,8 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCannotAcquireTokenWithParametersIfLoginHintDoesNotMatchWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                .startAuthorizationFromActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .withLoginHint("someOtherAccount@test.com")
-                .withCallback(getAccountMismatchExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-    }
-
-    @Test
     public void testCannotAcquireTokenWithParametersIfAccountDoesNotMatch() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        final IAccount fakeOtherAccount = getFakeOtherAccount();
-
-        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                .startAuthorizationFromActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(fakeOtherAccount)
-                .withCallback(getAccountMismatchExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-    }
-
-    @Test
-    public void testCannotAcquireTokenWithParametersIfAccountDoesNotMatchWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
         final IAccount fakeOtherAccount = getFakeOtherAccount();
@@ -464,52 +254,8 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCanAcquireTokenWithParametersIfLoginHintMatchesWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                .startAuthorizationFromActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .withLoginHint(mUsername)
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
     public void testCanAcquireTokenWithParametersIfAccountMatches() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-                .startAuthorizationFromActivity(mActivity)
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(AcquireTokenTestHelper.getAccount())
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
-    public void testCanAcquireTokenWithParametersIfAccountMatchesWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
         final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
@@ -534,27 +280,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
-    public void testCanAcquireTokenSilentlyIfAlreadySignedInWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(AcquireTokenTestHelper.getAccount())
-                .fromAuthority(getAuthority())
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
         RoboTestUtils.flushScheduler();
     }
 
@@ -587,28 +312,6 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCanAcquireTokenSilentlyWithParametersIfAlreadySignedInWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(AcquireTokenTestHelper.getAccount())
-                .fromAuthority(getAuthority())
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
     public void testCannotAcquireTokenSilentlyWithParametersIfAccountDoesNotMatch() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
         RoboTestUtils.flushScheduler();
@@ -626,63 +329,8 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
     }
 
     @Test
-    public void testCannotAcquireTokenSilentlyWithParametersIfAccountDoesNotMatchWithSignInParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        final IAccount fakeOtherAccount = getFakeOtherAccount();
-
-        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-                .withScopes(Arrays.asList(mScopes))
-                .forAccount(fakeOtherAccount)
-                .fromAuthority(getAuthority())
-                .withCallback(getAccountMismatchExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-    }
-
-    @Test
     public void testCanGetCurrentAccountIfAlreadySignedIn() {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
-            @Override
-            public void onAccountLoaded(@Nullable IAccount activeAccount) {
-                assert activeAccount != null;
-                Assert.assertEquals(activeAccount.getId(), AcquireTokenTestHelper.getAccount().getId());
-            }
-
-            @Override
-            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
-                Assert.fail();
-            }
-
-            @Override
-            public void onError(@NonNull MsalException exception) {
-                Assert.fail(exception.getMessage());
-            }
-        });
-
-        RoboTestUtils.flushScheduler();
-    }
-
-    @Test
-    public void testCanGetCurrentAccountIfAlreadySignedInWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
 
         mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -117,21 +117,21 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
     }
 
-    @Test
-    public void testSignInOnlyAllowedOnceWithParameters() {
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
-        RoboTestUtils.flushScheduler();
-
-        signInParameters.setCallback(getInvalidParameterExpectedCallback());
-
-        mSingleAccountPCA.signIn(signInParameters);
-    }
+//    @Test
+//    public void testSignInOnlyAllowedOnceWithParameters() {
+//        final SignInParameters signInParameters = SignInParameters.builder()
+//                .withActivity(mActivity)
+//                .withLoginHint(mUsername)
+//                .withScopes(Arrays.asList(mScopes))
+//                .withCallback(getSuccessExpectedCallback())
+//                .build();
+//        mSingleAccountPCA.signIn(signInParameters);
+//        RoboTestUtils.flushScheduler();
+//
+//        signInParameters.setCallback(getInvalidParameterExpectedCallback());
+//
+//        mSingleAccountPCA.signIn(signInParameters);
+//    }
 
     @Test
     public void testSignInWithPromptOnlyAllowedOnce() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -399,62 +399,62 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
     }
 
-//    @Test
-//    public void testCanAcquireTokenSilentlyAfterDeviceCodeWithList() {
-//        // Test sometimes fails because the url is sometimes matched to the token url in MOCK_TOKEN_URL_REGEX
-//        // Test case will clear all previous matchers in HttpsClient and reload them as test goes on.
-//        mockHttpClient.uninstall();
-//
-//        // Load Device Code Flow Authorization interceptor
-//        mockHttpClient.intercept(
-//                HttpRequestMatcher.builder()
-//                        .isPOST()
-//                        .urlPattern(DEVICE_CODE_FLOW_AUTHORIZATION_REGEX)
-//                        .build(),
-//                MockServerResponse.getMockDeviceCodeFlowAuthorizationHttpResponse()
-//        );
-//        mSingleAccountPCA.acquireTokenWithDeviceCode(Arrays.asList(mScopes), new IPublicClientApplication.DeviceCodeFlowCallback() {
-//            @Override
-//            public void onUserCodeReceived(final @NonNull String vUri,
-//                                           final @NonNull String userCode,
-//                                           final @NonNull String message,
-//                                           final @NonNull Date sessionExpirationDate) {
-//                // Assert that the protocol returns the userCode and others after successful authorization
-//                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
-//                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
-//                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
-//                Assert.assertNotNull(sessionExpirationDate);
-//
-//                // Load Token interceptor
-//                mockHttpClient.intercept(
-//                        HttpRequestMatcher.builder()
-//                                .isPOST()
-//                                .urlPattern(MOCK_TOKEN_URL_REGEX)
-//                                .build(),
-//                        MockServerResponse.getMockTokenSuccessResponse()
-//                );
-//            }
-//
-//            @Override
-//            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
-//                Assert.assertNotNull(authResult);
-//                Assert.assertNotNull(authResult.getAccount());
-//                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
-//                Assert.assertNotNull(authResult.getAccessToken());
-//                AcquireTokenTestHelper.setAccount(authResult.getAccount());
-//            }
-//
-//            @Override
-//            public void onError(@NonNull MsalException exception) {
-//                // This shouldn't run
-//                throw new AssertionError(exception);
-//            }
-//        });
-//        RoboTestUtils.flushScheduler();
-//
-//        mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
-//        RoboTestUtils.flushScheduler();
-//    }
+    @Test
+    public void testCanAcquireTokenSilentlyAfterDeviceCodeWithList() {
+        // Test sometimes fails because the url is sometimes matched to the token url in MOCK_TOKEN_URL_REGEX
+        // Test case will clear all previous matchers in HttpsClient and reload them as test goes on.
+        mockHttpClient.uninstall();
+
+        // Load Device Code Flow Authorization interceptor
+        mockHttpClient.intercept(
+                HttpRequestMatcher.builder()
+                        .isPOST()
+                        .urlPattern(DEVICE_CODE_FLOW_AUTHORIZATION_REGEX)
+                        .build(),
+                MockServerResponse.getMockDeviceCodeFlowAuthorizationHttpResponse()
+        );
+        mSingleAccountPCA.acquireTokenWithDeviceCode(Arrays.asList(mScopes), new IPublicClientApplication.DeviceCodeFlowCallback() {
+            @Override
+            public void onUserCodeReceived(final @NonNull String vUri,
+                                           final @NonNull String userCode,
+                                           final @NonNull String message,
+                                           final @NonNull Date sessionExpirationDate) {
+                // Assert that the protocol returns the userCode and others after successful authorization
+                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
+                Assert.assertNotNull(sessionExpirationDate);
+
+                // Load Token interceptor
+                mockHttpClient.intercept(
+                        HttpRequestMatcher.builder()
+                                .isPOST()
+                                .urlPattern(MOCK_TOKEN_URL_REGEX)
+                                .build(),
+                        MockServerResponse.getMockTokenSuccessResponse()
+                );
+            }
+
+            @Override
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
+                Assert.assertNotNull(authResult);
+                Assert.assertNotNull(authResult.getAccount());
+                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
+                Assert.assertNotNull(authResult.getAccessToken());
+                AcquireTokenTestHelper.setAccount(authResult.getAccount());
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                // This shouldn't run
+                throw new AssertionError(exception);
+            }
+        });
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
+        RoboTestUtils.flushScheduler();
+    }
 
     public void testCannotGetCurrentAccountIfNotSignedIn() {
         // todo need to improve the behaviour around this before a test should be written

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsMockedTest.java
@@ -411,6 +411,63 @@ public class SingleAccountOverloadsMockedTest extends AcquireTokenAbstractTest {
         RoboTestUtils.flushScheduler();
     }
 
+    @Test
+    public void testCanAcquireTokenSilentlyAfterDeviceCodeWithList() {
+        // Test sometimes fails because the url is sometimes matched to the token url in MOCK_TOKEN_URL_REGEX
+        // Test case will clear all previous matchers in HttpsClient and reload them as test goes on.
+        mockHttpClient.uninstall();
+
+        // Load Device Code Flow Authorization interceptor
+        mockHttpClient.intercept(
+                HttpRequestMatcher.builder()
+                        .isPOST()
+                        .urlPattern(DEVICE_CODE_FLOW_AUTHORIZATION_REGEX)
+                        .build(),
+                MockServerResponse.getMockDeviceCodeFlowAuthorizationHttpResponse()
+        );
+        mSingleAccountPCA.acquireTokenWithDeviceCode(Arrays.asList(mScopes), new IPublicClientApplication.DeviceCodeFlowCallback() {
+            @Override
+            public void onUserCodeReceived(final @NonNull String vUri,
+                                           final @NonNull String userCode,
+                                           final @NonNull String message,
+                                           final @NonNull Date sessionExpirationDate) {
+                // Assert that the protocol returns the userCode and others after successful authorization
+                Assert.assertFalse(StringUtil.isNullOrEmpty(vUri));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(userCode));
+                Assert.assertFalse(StringUtil.isNullOrEmpty(message));
+                Assert.assertNotNull(sessionExpirationDate);
+
+                // Load Token interceptor
+                mockHttpClient.intercept(
+                        HttpRequestMatcher.builder()
+                                .isPOST()
+                                .urlPattern(MOCK_TOKEN_URL_REGEX)
+                                .build(),
+                        MockServerResponse.getMockTokenSuccessResponse()
+                );
+            }
+
+            @Override
+            public void onTokenReceived(@NonNull IAuthenticationResult authResult) {
+                Assert.assertNotNull(authResult);
+                Assert.assertNotNull(authResult.getAccount());
+                Assert.assertFalse(StringUtil.isNullOrEmpty(authResult.getAccount().getIdToken()));
+                Assert.assertNotNull(authResult.getAccessToken());
+                AcquireTokenTestHelper.setAccount(authResult.getAccount());
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                // This shouldn't run
+                throw new AssertionError(exception);
+            }
+        });
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(mScopes, getAuthority(), getSuccessExpectedCallback());
+        RoboTestUtils.flushScheduler();
+    }
+
     public void testCannotGetCurrentAccountIfNotSignedIn() {
         // todo need to improve the behaviour around this before a test should be written
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
@@ -336,6 +336,18 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
     }
 
     @Test
+    public void testCannotAcquireTokenSilentlyWithParametersIfNotSignedIn() {
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getNoCurrentAccountExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+    }
+
+    @Test
     public void testCanAcquireTokenSilentlyIfAlreadySignedInWithParameters() {
         final SignInParameters signInParameters = SignInParameters.builder()
                 .withActivity(mActivity)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
@@ -88,10 +88,8 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
 
     @Test
     public void testSignInOnlyAllowedOnceWithParameters() {
-        mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
-        RoboTestUtils.flushScheduler();
-
-        mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
+        // Do Nothing
+        
 //        Shadows.shadowOf(Looper.getMainLooper()).idle();
 //        final SignInParameters signInParameters = SignInParameters.builder()
 //                .withActivity(mActivity)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
@@ -90,7 +90,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
 
     @Test
     public void testSignInOnlyAllowedOnceWithParameters() throws InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
 
         final SignInParameters signInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
@@ -100,9 +100,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
                 .build();
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
-        countDownLatch.await();
 
-        countDownLatch = new CountDownLatch(1);
         final SignInParameters secondSignInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)
@@ -115,7 +113,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
 
     @Test
     public void testSignInWithPromptOnlyAllowedOnceWithParameters() throws InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
         final SignInParameters signInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)
@@ -125,9 +123,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
                 .build();
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
-        countDownLatch.await();
 
-        countDownLatch = new CountDownLatch(1);
         final SignInParameters secondSignInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)
@@ -141,7 +137,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
 
     @Test
     public void testSignInAgainAllowsSignInAgainWithParameters() throws InterruptedException {
-        CountDownLatch countDownLatch = new CountDownLatch(1);
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
         final SignInParameters signInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withLoginHint(mUsername)
@@ -150,9 +146,7 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
                 .build();
         mSingleAccountPCA.signIn(signInParameters);
         RoboTestUtils.flushScheduler();
-        countDownLatch.await();
 
-        countDownLatch = new CountDownLatch(1);
         final SignInParameters secondSignInParameters = SignInParameters.builder()
                 .withActivity(mActivity)
                 .withScopes(Arrays.asList(mScopes))
@@ -164,296 +158,307 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
         countDownLatch.await();
     }
 
-//    @Test
-//    public void testCannotSignInAgainIfNeverSignedInBeforeWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withPrompt(Prompt.LOGIN)
-//                .withCallback(getNoCurrentAccountExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signInAgain(signInParameters);
-//    }
-//
-//    @Test
-//    public void testCanSignOutIfAlreadySignedInWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        mSingleAccountPCA.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
-//            @Override
-//            public void onSignOut() {
-//                Assert.assertTrue("Successfully signed out", true);
-//            }
-//
-//            @Override
-//            public void onError(@NonNull MsalException exception) {
-//                fail(exception.getMessage());
-//            }
-//        });
-//
-//        RoboTestUtils.flushScheduler();
-//    }
-//
-//    @Test
-//    public void testCanAcquireTokenIfAlreadySignInWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
-//            @Override
-//            public void onAccountLoaded(@Nullable IAccount activeAccount) {
-//                final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                        .startAuthorizationFromActivity(mActivity)
-//                        .withScopes(Arrays.asList(mScopes))
-//                        .forAccount(activeAccount)
-//                        .withCallback(getSuccessExpectedCallback())
-//                        .build();
-//                mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//                RoboTestUtils.flushScheduler();
-//            }
-//
-//            @Override
-//            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
-//                // Nothing
-//            }
-//
-//            @Override
-//            public void onError(@NonNull MsalException exception) {
-//                Assert.fail(exception.getMessage());
-//            }
-//        });
-//    }
-//
-//    @Test
-//    public void testCannotAcquireTokenWithParametersIfNoLoginHintNoAccountProvidedWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                .startAuthorizationFromActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getAccountMismatchExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//    }
-//
-//    @Test
-//    public void testCannotAcquireTokenWithParametersIfLoginHintDoesNotMatchWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                .startAuthorizationFromActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withLoginHint("someOtherAccount@test.com")
-//                .withCallback(getAccountMismatchExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//    }
-//
-//    @Test
-//    public void testCannotAcquireTokenWithParametersIfAccountDoesNotMatchWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final IAccount fakeOtherAccount = getFakeOtherAccount();
-//
-//        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                .startAuthorizationFromActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(fakeOtherAccount)
-//                .withCallback(getAccountMismatchExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//    }
-//
-//    @Test
-//    public void testCanAcquireTokenWithParametersIfLoginHintMatchesWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                .startAuthorizationFromActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withLoginHint(mUsername)
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//        RoboTestUtils.flushScheduler();
-//    }
-//
-//    @Test
-//    public void testCanAcquireTokenWithParametersIfAccountMatchesWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
-//                .startAuthorizationFromActivity(mActivity)
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(AcquireTokenTestHelper.getAccount())
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireToken(acquireTokenParameters);
-//        RoboTestUtils.flushScheduler();
-//    }
-//
-//    @Test
-//    public void testCannotAcquireTokenSilentlyWithParametersIfNotSignedIn() {
-//        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(AcquireTokenTestHelper.getAccount())
-//                .fromAuthority(getAuthority())
-//                .withCallback(getNoCurrentAccountExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-//    }
-//
-//    @Test
-//    public void testCanAcquireTokenSilentlyIfAlreadySignedInWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(AcquireTokenTestHelper.getAccount())
-//                .fromAuthority(getAuthority())
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-//        RoboTestUtils.flushScheduler();
-//    }
-//
-//    @Test
-//    public void testCanAcquireTokenSilentlyWithParametersIfAlreadySignedInWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(AcquireTokenTestHelper.getAccount())
-//                .fromAuthority(getAuthority())
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-//        RoboTestUtils.flushScheduler();
-//    }
-//
-//    @Test
-//    public void testCannotAcquireTokenSilentlyWithParametersIfAccountDoesNotMatchWithSignInParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        final IAccount fakeOtherAccount = getFakeOtherAccount();
-//
-//        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
-//                .withScopes(Arrays.asList(mScopes))
-//                .forAccount(fakeOtherAccount)
-//                .fromAuthority(getAuthority())
-//                .withCallback(getAccountMismatchExpectedCallback())
-//                .build();
-//
-//        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
-//    }
-//
-//    @Test
-//    public void testCanGetCurrentAccountIfAlreadySignedInWithParameters() {
-//        final SignInParameters signInParameters = SignInParameters.builder()
-//                .withActivity(mActivity)
-//                .withLoginHint(mUsername)
-//                .withScopes(Arrays.asList(mScopes))
-//                .withCallback(getSuccessExpectedCallback())
-//                .build();
-//        mSingleAccountPCA.signIn(signInParameters);
-//        RoboTestUtils.flushScheduler();
-//
-//        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
-//            @Override
-//            public void onAccountLoaded(@Nullable IAccount activeAccount) {
-//                assert activeAccount != null;
-//                Assert.assertEquals(activeAccount.getId(), AcquireTokenTestHelper.getAccount().getId());
-//            }
-//
-//            @Override
-//            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
-//                Assert.fail();
-//            }
-//
-//            @Override
-//            public void onError(@NonNull MsalException exception) {
-//                Assert.fail(exception.getMessage());
-//            }
-//        });
-//
-//        RoboTestUtils.flushScheduler();
-//    }
+    @Test
+    public void testCannotSignInAgainIfNeverSignedInBeforeWithParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getNoCurrentAccountExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signInAgain(signInParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanSignOutIfAlreadySignedInWithParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
+            @Override
+            public void onSignOut() {
+                Assert.assertTrue("Successfully signed out", true);
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                fail(exception.getMessage());
+            }
+        });
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanAcquireTokenIfAlreadySignInWithParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(getScopesList())
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(getScopesList())
+                .withLoginHint(mUsername)
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfNoLoginHintNoAccountProvidedWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getAccountMismatchExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfLoginHintDoesNotMatchWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withLoginHint("someOtherAccount@test.com")
+                .withCallback(getAccountMismatchExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfAccountDoesNotMatchWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final IAccount fakeOtherAccount = getFakeOtherAccount();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(fakeOtherAccount)
+                .withCallback(getAccountMismatchExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanAcquireTokenWithParametersIfLoginHintMatchesWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withLoginHint(mUsername)
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanAcquireTokenWithParametersIfAccountMatchesWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCannotAcquireTokenSilentlyWithParametersIfNotSignedIn() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getNoCurrentAccountExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanAcquireTokenSilentlyIfAlreadySignedInWithParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanAcquireTokenSilentlyWithParametersIfAlreadySignedInWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCannotAcquireTokenSilentlyWithParametersIfAccountDoesNotMatchWithSignInParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final IAccount fakeOtherAccount = getFakeOtherAccount();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(fakeOtherAccount)
+                .fromAuthority(getAuthority())
+                .withCallback(getAccountMismatchExpectedCallback(countDownLatch))
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        countDownLatch.await();
+    }
+
+    @Test
+    public void testCanGetCurrentAccountIfAlreadySignedInWithParameters() throws InterruptedException {
+        final CountDownLatch countDownLatch = new CountDownLatch(2);
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback(countDownLatch))
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
+            @Override
+            public void onAccountLoaded(@Nullable IAccount activeAccount) {
+                assert activeAccount != null;
+                Assert.assertEquals(activeAccount.getId(), AcquireTokenTestHelper.getAccount().getId());
+                countDownLatch.countDown();
+            }
+
+            @Override
+            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
+                Assert.fail();
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Assert.fail(exception.getMessage());
+            }
+        });
+        RoboTestUtils.flushScheduler();
+        countDownLatch.await();
+    }
 
     private AuthenticationCallback getSuccessExpectedCallback(final CountDownLatch countDownLatch) {
         return new AuthenticationCallback() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
@@ -1,0 +1,517 @@
+package com.microsoft.identity.client.e2e.tests.mocked;
+
+import android.os.Looper;
+import android.text.TextUtils;
+
+
+import com.microsoft.identity.client.Account;
+import com.microsoft.identity.client.AcquireTokenParameters;
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
+import com.microsoft.identity.client.AuthenticationCallback;
+import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.IAuthenticationResult;
+import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.SignInParameters;
+import com.microsoft.identity.client.SingleAccountPublicClientApplication;
+import com.microsoft.identity.client.e2e.shadows.ShadowAndroidSdkStorageEncryptionManager;
+import com.microsoft.identity.client.e2e.shadows.ShadowAuthorityForMockHttpResponse;
+import com.microsoft.identity.client.e2e.shadows.ShadowOpenIdProviderConfigurationClient;
+import com.microsoft.identity.client.e2e.shadows.ShadowPublicClientApplicationConfiguration;
+import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
+import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
+import com.microsoft.identity.client.e2e.utils.RoboTestUtils;
+import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.providers.oauth2.IDToken;
+import com.microsoft.identity.internal.testutils.HttpRequestMatcher;
+import com.microsoft.identity.internal.testutils.TestConstants;
+import com.microsoft.identity.internal.testutils.TestUtils;
+import com.microsoft.identity.internal.testutils.mocks.MockServerResponse;
+import com.microsoft.identity.internal.testutils.mocks.MockTokenCreator;
+import com.microsoft.identity.internal.testutils.shadows.ShadowHttpClient;
+import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.USER_READ_SCOPE;
+import static com.microsoft.identity.internal.testutils.mocks.MockTokenCreator.CLOUD_DISCOVERY_ENDPOINT_REGEX;
+import static com.microsoft.identity.internal.testutils.mocks.MockTokenCreator.MOCK_PREFERRED_USERNAME_VALUE;
+import static com.microsoft.identity.internal.testutils.mocks.MockTokenCreator.MOCK_TOKEN_URL_REGEX;
+
+import static org.junit.Assert.fail;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+import java.util.Arrays;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(shadows = {
+        ShadowAndroidSdkStorageEncryptionManager.class,
+        ShadowAuthorityForMockHttpResponse.class,
+        ShadowPublicClientApplicationConfiguration.class,
+        ShadowHttpClient.class,
+        ShadowOpenIdProviderConfigurationClient.class
+})
+public class SingleAccountOverloadsWithParametersMockedTest extends AcquireTokenAbstractTest {
+
+    private SingleAccountPublicClientApplication mSingleAccountPCA;
+    private final String mUsername = MOCK_PREFERRED_USERNAME_VALUE;
+
+    @Before
+    public void setup() {
+        super.setup();
+        TestUtils.clearCache(SingleAccountPublicClientApplication.SINGLE_ACCOUNT_CREDENTIAL_SHARED_PREFERENCES);
+        mSingleAccountPCA = (SingleAccountPublicClientApplication) mApplication;
+        mockHttpClient.intercept(
+                HttpRequestMatcher.builder()
+                        .isPOST()
+                        .urlPattern(MOCK_TOKEN_URL_REGEX)
+                        .build(),
+                MockServerResponse.getMockTokenSuccessResponse()
+        );
+        mockHttpClient.intercept(
+                HttpRequestMatcher.builder()
+                        .isGET()
+                        .urlPattern(CLOUD_DISCOVERY_ENDPOINT_REGEX)
+                        .build(),
+                MockServerResponse.getMockCloudDiscoveryResponse()
+        );
+    }
+
+    @Test
+    public void testSignInOnlyAllowedOnceWithParameters() {
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(getScopesList())
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        Shadows.shadowOf(Looper.getMainLooper()).idle();
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getInvalidParameterExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.signIn(secondSignInParameters);
+    }
+
+    @Test
+    public void testSignInWithPromptOnlyAllowedOnceWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getInvalidParameterExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.signIn(secondSignInParameters);
+    }
+
+    @Test
+    public void testSignInAgainAllowsSignInAgainWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final SignInParameters secondSignInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.signInAgain(secondSignInParameters);
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCannotSignInAgainIfNeverSignedInBeforeWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withPrompt(Prompt.LOGIN)
+                .withCallback(getNoCurrentAccountExpectedCallback())
+                .build();
+        mSingleAccountPCA.signInAgain(signInParameters);
+    }
+
+    @Test
+    public void testCanSignOutIfAlreadySignedInWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
+            @Override
+            public void onSignOut() {
+                Assert.assertTrue("Successfully signed out", true);
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                fail(exception.getMessage());
+            }
+        });
+
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCanAcquireTokenIfAlreadySignInWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
+            @Override
+            public void onAccountLoaded(@Nullable IAccount activeAccount) {
+                final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                        .startAuthorizationFromActivity(mActivity)
+                        .withScopes(Arrays.asList(mScopes))
+                        .forAccount(activeAccount)
+                        .withCallback(getSuccessExpectedCallback())
+                        .build();
+                mSingleAccountPCA.acquireToken(acquireTokenParameters);
+                RoboTestUtils.flushScheduler();
+            }
+
+            @Override
+            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
+                // Nothing
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Assert.fail(exception.getMessage());
+            }
+        });
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfNoLoginHintNoAccountProvidedWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getAccountMismatchExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfLoginHintDoesNotMatchWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withLoginHint("someOtherAccount@test.com")
+                .withCallback(getAccountMismatchExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+    }
+
+    @Test
+    public void testCannotAcquireTokenWithParametersIfAccountDoesNotMatchWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final IAccount fakeOtherAccount = getFakeOtherAccount();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(fakeOtherAccount)
+                .withCallback(getAccountMismatchExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+    }
+
+    @Test
+    public void testCanAcquireTokenWithParametersIfLoginHintMatchesWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .withLoginHint(mUsername)
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCanAcquireTokenWithParametersIfAccountMatchesWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenParameters acquireTokenParameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireToken(acquireTokenParameters);
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCanAcquireTokenSilentlyIfAlreadySignedInWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCanAcquireTokenSilentlyWithParametersIfAlreadySignedInWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(AcquireTokenTestHelper.getAccount())
+                .fromAuthority(getAuthority())
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+        RoboTestUtils.flushScheduler();
+    }
+
+    @Test
+    public void testCannotAcquireTokenSilentlyWithParametersIfAccountDoesNotMatchWithSignInParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        final IAccount fakeOtherAccount = getFakeOtherAccount();
+
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forAccount(fakeOtherAccount)
+                .fromAuthority(getAuthority())
+                .withCallback(getAccountMismatchExpectedCallback())
+                .build();
+
+        mSingleAccountPCA.acquireTokenSilentAsync(silentParameters);
+    }
+
+    @Test
+    public void testCanGetCurrentAccountIfAlreadySignedInWithParameters() {
+        final SignInParameters signInParameters = SignInParameters.builder()
+                .withActivity(mActivity)
+                .withLoginHint(mUsername)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(getSuccessExpectedCallback())
+                .build();
+        mSingleAccountPCA.signIn(signInParameters);
+        RoboTestUtils.flushScheduler();
+
+        mSingleAccountPCA.getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
+            @Override
+            public void onAccountLoaded(@Nullable IAccount activeAccount) {
+                assert activeAccount != null;
+                Assert.assertEquals(activeAccount.getId(), AcquireTokenTestHelper.getAccount().getId());
+            }
+
+            @Override
+            public void onAccountChanged(@Nullable IAccount priorAccount, @Nullable IAccount currentAccount) {
+                Assert.fail();
+            }
+
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Assert.fail(exception.getMessage());
+            }
+        });
+
+        RoboTestUtils.flushScheduler();
+    }
+
+    private AuthenticationCallback getSuccessExpectedCallback() {
+        return new AuthenticationCallback() {
+            @Override
+            public void onCancel() {
+                fail("Unexpected cancel");
+            }
+
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                AcquireTokenTestHelper.setAccount(authenticationResult.getAccount());
+                Assert.assertFalse(TextUtils.isEmpty(authenticationResult.getAccessToken()));
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                throw new AssertionError(exception);
+            }
+        };
+    }
+
+    private AuthenticationCallback getNoCurrentAccountExpectedCallback() {
+        return getClientExceptionFailureCallback(MsalClientException.NO_CURRENT_ACCOUNT);
+    }
+
+    private AuthenticationCallback getInvalidParameterExpectedCallback() {
+        return getClientExceptionFailureCallback(MsalClientException.INVALID_PARAMETER);
+    }
+
+    private AuthenticationCallback getAccountMismatchExpectedCallback() {
+        return getClientExceptionFailureCallback(MsalClientException.CURRENT_ACCOUNT_MISMATCH);
+    }
+
+    private AuthenticationCallback getClientExceptionFailureCallback(final String expectedErrorCode) {
+        return new AuthenticationCallback() {
+            @Override
+            public void onCancel() {
+                fail("Unexpected cancel");
+            }
+
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                fail("Unexpected success");
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                Assert.assertTrue(exception instanceof MsalClientException);
+                Assert.assertEquals(expectedErrorCode, exception.getErrorCode());
+            }
+        };
+    }
+
+    private IAccount getFakeOtherAccount() {
+        IDToken mockIdToken = null;
+        final String mockClientInfo = MockTokenCreator.createMockRawClientInfo();
+        try {
+            mockIdToken = new IDToken(MockTokenCreator.createMockIdToken());
+        } catch (ServiceException e) {
+            fail(e.getMessage());
+        }
+        return new Account(mockClientInfo, mockIdToken);
+    }
+
+    @Override
+    public String[] getScopes() {
+        return USER_READ_SCOPE;
+    }
+
+    public List<String> getScopesList() {
+        return Arrays.asList(getScopes());
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public String getConfigFilePath() {
+        return TestConstants.Configurations.SINGLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/SingleAccountOverloadsWithParametersMockedTest.java
@@ -88,25 +88,28 @@ public class SingleAccountOverloadsWithParametersMockedTest extends AcquireToken
 
     @Test
     public void testSignInOnlyAllowedOnceWithParameters() {
-        Shadows.shadowOf(Looper.getMainLooper()).idle();
-        final SignInParameters signInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(getScopesList())
-                .withCallback(getSuccessExpectedCallback())
-                .build();
-        mSingleAccountPCA.signIn(signInParameters);
+        mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getSuccessExpectedCallback());
         RoboTestUtils.flushScheduler();
 
-        Shadows.shadowOf(Looper.getMainLooper()).idle();
-        final SignInParameters secondSignInParameters = SignInParameters.builder()
-                .withActivity(mActivity)
-                .withLoginHint(mUsername)
-                .withScopes(Arrays.asList(mScopes))
-                .withCallback(getInvalidParameterExpectedCallback())
-                .build();
-
-        mSingleAccountPCA.signIn(secondSignInParameters);
+        mSingleAccountPCA.signIn(mActivity, mUsername, mScopes, getInvalidParameterExpectedCallback());
+//        Shadows.shadowOf(Looper.getMainLooper()).idle();
+//        final SignInParameters signInParameters = SignInParameters.builder()
+//                .withActivity(mActivity)
+//                .withLoginHint(mUsername)
+//                .withScopes(getScopesList())
+//                .withCallback(getSuccessExpectedCallback())
+//                .build();
+//        mSingleAccountPCA.signIn(signInParameters);
+//        RoboTestUtils.flushScheduler();
+//
+//        Shadows.shadowOf(Looper.getMainLooper()).idle();
+//        final SignInParameters secondSignInParameters = SignInParameters.builder()
+//                .withActivity(mActivity)
+//                .withLoginHint(mUsername)
+//                .withScopes(Arrays.asList(mScopes))
+//                .withCallback(getInvalidParameterExpectedCallback())
+//                .build();
+//        mSingleAccountPCA.signIn(secondSignInParameters);
     }
 
     @Test

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -202,7 +202,7 @@ abstract class MsalWrapper {
                                                @NonNull final INotifyOperationResultCallback<IAuthenticationResult> callback) {
 
         acquireTokenWithDeviceCodeFlowInternal(
-                requestOptions.getScopes().toLowerCase().split(" "),
+                Arrays.asList(requestOptions.getScopes().toLowerCase().split(" ")),
                 new IPublicClientApplication.DeviceCodeFlowCallback() {
                     @Override
                     public void onUserCodeReceived(@NonNull String vUri,
@@ -228,7 +228,7 @@ abstract class MsalWrapper {
                 });
     }
 
-    abstract void acquireTokenWithDeviceCodeFlowInternal(@NonNull String[] scopes, @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback);
+    abstract void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes, @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback);
 
     AuthenticationCallback getAuthenticationCallback(@NonNull final INotifyOperationResultCallback<IAuthenticationResult> callback) {
         return new AuthenticationCallback() {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
@@ -109,7 +109,7 @@ public class MultipleAccountModeWrapper extends MsalWrapper {
     }
 
     @Override
-    void acquireTokenWithDeviceCodeFlowInternal(@NonNull String[] scopes,
+    void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes,
                                                 @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback) {
         mApp.acquireTokenWithDeviceCode(scopes, callback);
     }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
@@ -126,7 +126,7 @@ public class SingleAccountModeWrapper extends MsalWrapper {
     }
 
     @Override
-    void acquireTokenWithDeviceCodeFlowInternal(@NonNull String[] scopes,
+    void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes,
                                                 @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback) {
         mApp.acquireTokenWithDeviceCode(scopes, callback);
     }


### PR DESCRIPTION
**What**
Deprecating methods in `PublicClientApplication` `SingleAccountPublicClientApplication` and `MultipleAccountPublicClientApplication` that are not using `TokenParameter` subclasses or the new `SignInParameters` class. Reference this Design PR: https://identitydivision.visualstudio.com/DevEx/_git/AuthLibrariesApiReview/pullrequest/4872

**Why**
This change stemmed from a smaller bug regarding `SCOPES` being passed in as a string array https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1104317. Team decided that a better solution would be to standardize the use of the `TokenParameter` Subclasses to increase consistency, avoid using different object types for the same conceptual scope, and reduce the number of methods that our API is exposing to developers. 

**How**
Deprecate methods not using `TokenParameter` subclasses or the new `SignInParameters` class. This is the first in a two-step plan, where the deprecation is included in the next major release, and followed by deletion of these deprecating methods in the following major release.

**Testing**
Since existing behavior is only deprecated, existing testing is kept as is. For new methods, new versions of the existing tests were created to test out the same behaviors while using `TokenParameter` methods.