### PR TITLE
Single Tenant Application Test

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/tenants/TestSingleTenantApplication.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/tenants/TestSingleTenantApplication.java
@@ -1,0 +1,123 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.tenants;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.AbstractGuestAccountMsalUiTest;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.internal.testutils.labutils.LabConstants;
+import com.microsoft.identity.internal.testutils.labutils.LabGuestAccountHelper;
+import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class TestSingleTenantApplication extends AbstractGuestAccountMsalUiTest {
+
+    private final String mGuestHomeAzureEnvironment;
+
+    public TestSingleTenantApplication(final String name, final String guestHomeAzureEnvironment) {
+        mGuestHomeAzureEnvironment = guestHomeAzureEnvironment;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection guestHomeAzureEnvironment() {
+        return Arrays.asList(new Object[][]{
+                {"AZURE_US_GOV", LabConstants.GuestHomeAzureEnvironment.AZURE_US_GOV},
+                {"AZURE_CHINA_CLOUD", LabConstants.GuestHomeAzureEnvironment.AZURE_CHINA_CLOUD},
+        });
+    }
+
+    @Test
+    public void test_singleTenantApplication() throws Throwable {
+        final String username = mGuestUser.getHomeUpn();
+        final String password = LabGuestAccountHelper.getPasswordForGuestUser(mGuestUser);
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(getScopes()))
+                .authority(getAuthority())
+                .promptParameter(Prompt.SELECT_ACCOUNT)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalSdk msalSdk = new MsalSdk();
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, () -> {
+            final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                    .prompt(PromptParameter.SELECT_ACCOUNT)
+                    .loginHint(username)
+                    .sessionExpected(false)
+                    .consentPageExpected(false)
+                    .speedBumpExpected(false)
+                    .build();
+
+            new AadPromptHandler(promptHandlerParameters)
+                    .handlePrompt(username, password);
+        }, TokenRequestTimeout.LONG);
+
+        authResult.assertSuccess();
+    }
+
+    @Override
+    public LabUserQuery getLabUserQuery() {
+        final LabUserQuery query = new LabUserQuery();
+        query.userType = LabConstants.UserType.GUEST;
+        query.guestHomeAzureEnvironment = mGuestHomeAzureEnvironment;
+        query.guestHomedIn = LabConstants.GuestHomedIn.HOST_AZURE_AD;
+        query.azureEnvironment = LabConstants.AzureEnvironment.AZURE_CLOUD;
+        return query;
+    }
+
+    @Override
+    public String getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return "https://login.microsoftonline.com/" + mGuestUser.getGuestLabTenants().get(0);
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_webview;
+    }
+}


### PR DESCRIPTION
Add test coverage for Single Tenant Application

**Why?:**
We recently introduced a bug in the broker that broke only single-tenant application.
Our test plans/test apps doesn't have coverage on it, otherwise it should have been caught.

[Single and multi-tenant apps in Azure AD - Microsoft identity platform | Microsoft Docs](https://docs.microsoft.com/en-us/azure/active-directory/develop/single-and-multi-tenant-apps)