### PR TITLE
Adding support for prompt=create

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MINOR] Add prompt=create support. (#1611)
 - [MAJOR] Deprecate methods not using TokenParameters (#1595)
 - [PATCH] Update gson version to 2.8.9
 

--- a/msal/src/main/java/com/microsoft/identity/client/Prompt.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Prompt.java
@@ -50,7 +50,10 @@ public enum Prompt {
     CONSENT,
 
     /**
-     * acquireToken will send prompt=create to the authorize endpoint.  The use will be prompted to create a new account.
+     * acquireToken will send prompt=create to the /authorize endpoint.  The user will be prompted to create a new account.
+     * Requires configuring authority as type "AzureADMyOrg" with a tenant_id.
+     * <p>
+     * Prerequisite: https://docs.microsoft.com/en-us/azure/active-directory/external-identities/self-service-sign-up-user-flow
      */
     CREATE,
 

--- a/msal/src/main/java/com/microsoft/identity/client/Prompt.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Prompt.java
@@ -50,6 +50,11 @@ public enum Prompt {
     CONSENT,
 
     /**
+     * acquireToken will send prompt=create to the authorize endpoint.  The use will be prompted to create a new account.
+     */
+    CREATE,
+
+    /**
      * acquireToken will not send the prompt parameter to the authorize endpoint.  The user may be prompted to login or to consent as required by the request.
      */
     WHEN_REQUIRED;
@@ -65,6 +70,8 @@ public enum Prompt {
                 return CONSENT.name().toLowerCase(Locale.ROOT);
             case WHEN_REQUIRED:
                 return WHEN_REQUIRED.name().toLowerCase(Locale.ROOT);
+            case CREATE:
+                return CREATE.name().toLowerCase(Locale.ROOT);
             default:
                 throw new IllegalArgumentException();
         }
@@ -78,6 +85,8 @@ public enum Prompt {
                 return OpenIdConnectPromptParameter.CONSENT;
             case WHEN_REQUIRED:
                 return OpenIdConnectPromptParameter.UNSET;
+            case CREATE:
+                return OpenIdConnectPromptParameter.CREATE;
             case SELECT_ACCOUNT:
             default:
                 return OpenIdConnectPromptParameter.SELECT_ACCOUNT;

--- a/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
@@ -55,6 +55,13 @@ public class PromptTest {
     }
 
     @Test
+    public void testOpenIdConnectParameterCreate() {
+        prompt = Prompt.CREATE;
+        final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
+        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.CREATE);
+    }
+
+    @Test
     public void testOpenIdConnectParameterWhenRequired() {
         prompt = Prompt.WHEN_REQUIRED;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();

--- a/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/PromptTest.java
@@ -37,35 +37,34 @@ public class PromptTest {
     public void testOpenIdConnectParameterSelectAccount() {
         prompt = Prompt.SELECT_ACCOUNT;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
-        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.SELECT_ACCOUNT);
+        Assert.assertEquals(OpenIdConnectPromptParameter.SELECT_ACCOUNT, promptValue);
     }
 
     @Test
     public void testOpenIdConnectParameterLogin() {
         prompt = Prompt.LOGIN;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
-        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.LOGIN);
+        Assert.assertEquals(OpenIdConnectPromptParameter.LOGIN, promptValue);
     }
 
     @Test
     public void testOpenIdConnectParameterConsent() {
         prompt = Prompt.CONSENT;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
-        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.CONSENT);
+        Assert.assertEquals(OpenIdConnectPromptParameter.CONSENT, promptValue);
     }
 
     @Test
     public void testOpenIdConnectParameterCreate() {
         prompt = Prompt.CREATE;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
-        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.CREATE);
+        Assert.assertEquals(OpenIdConnectPromptParameter.CREATE, promptValue);
     }
 
     @Test
     public void testOpenIdConnectParameterWhenRequired() {
         prompt = Prompt.WHEN_REQUIRED;
         final OpenIdConnectPromptParameter promptValue = prompt.toOpenIdConnectPromptParameter();
-        Assert.assertEquals(promptValue, OpenIdConnectPromptParameter.UNSET);
+        Assert.assertEquals(OpenIdConnectPromptParameter.UNSET, promptValue);
     }
-
 }

--- a/msal/src/test/java/com/microsoft/identity/client/UIBehaviorTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/UIBehaviorTest.java
@@ -31,6 +31,7 @@ public final class UIBehaviorTest {
     public final static String LOGIN = "login";
     public final static String CONSENT = "consent";
     public final static String SELECT_ACCOUNT = "select_account";
+    public final static String CREATE = "create";
 
 
     @Test
@@ -49,5 +50,11 @@ public final class UIBehaviorTest {
     public void testToStringSelectAccount() {
         Prompt behavior = Prompt.SELECT_ACCOUNT;
         Assert.assertEquals(behavior.toString(), SELECT_ACCOUNT);
+    }
+
+    @Test
+    public void testToStringCreate() {
+        Prompt behavior = Prompt.CREATE;
+        Assert.assertEquals(behavior.toString(), CREATE);
     }
 }


### PR DESCRIPTION
**What**
Adding support for prompt=create in MSAL, where user is prompted to create a new account. Requires https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1707.

Example URL:
https://login.microsoftonline.com/d014fd44-d398-4813-a3a9-8cd725f7f356/oauth2/authorize?
client_id=da53de5a-636b-425f-ad57-0f62d6f974c7
&response_type=id_token
&resource=da53de5a-636b-425f-ad57-0f62d6f974c7
&scope=openid
&nonce=default_nonce
&redirect_uri=https://jwt.ms/
&prompt=create

![image](https://user-images.githubusercontent.com/88730756/160764005-41b8c936-a61a-47fd-993b-7874413b163e.png)

The draft OIDC spec for this is here: https://openid.net/specs/openid-connect-prompt-create-1_0.html

**Why**
Other MSAL Libraries also adding support: https://identitydivision.visualstudio.com/Engineering/_boards/board/t/Auth%20Client%20-%20Android/Backlog%20items/?workitem=1233365

**How**
Adding `CREATE` field to `Prompt.java` and support for that field.

https://docs.microsoft.com/en-us/azure/active-directory/external-identities/self-service-sign-up-user-flow#:~:text=Enable%20self-service%20sign-up%20for%20your%20tenant,-Before%20you%20can&text=Under%20Azure%20services%2C%20select%20Azure,Select%20Save.

Finish this checklist from MSAL.NET page: https://github.com/AzureAD/microsoft-authentication-library-for-python/issues/356.

- [x] Expose a new Create property in Prompt.
- [x] Wire-up the prompt so that 'prompt=create' is sent to the authorize endpoint when this prompt is used.
- [ ] Update the [wiki page](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/Acquiring-tokens-interactively#withprompt), or better redirect it to the docs.ms page, which would, however need to be synced
Update after release
- [x] ~~Update the docs.ms [AcquireToken desktop scenario page](https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-desktop-acquire-token?tabs=dotnet#withprompt).~~ We are here https://docs.microsoft.com/en-us/azure/active-directory/develop/scenario-mobile-acquire-token


**Test**
Tested this end-to-end on local device in a tenant with a specified sign-up user flow. Added some unit tests.