### PR TITLE
Update MSAL Version on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Add to your app's build.gradle:
 
 ```gradle
 dependencies {
-    implementation 'com.microsoft.identity.client:msal:2.0.+'
+    implementation 'com.microsoft.identity.client:msal:2.3.+'
 }
 ```
 


### PR DESCRIPTION
A client pointed out a mistake we have on our documentation regarding the msal version being 2.0.+ instead of 2.3.+