### PR TITLE
Update androidx appcompat version from 1.0.2 -> 1.1.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Update androidx appcompat version from 1.0.2 -> 1.1.0 (#1629)
 - [MINOR] Add prompt=create support. (#1611)
 - [PATCH] Ensure consistent TAGs in the logger (#1612)
 - [MAJOR] Deprecate methods not using TokenParameters (#1595)

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -21,7 +21,7 @@ ext {
     androidxTestCoreVersion = "1.2.0"
     androidxJunitVersion = "1.1.1"
     annotationVersion = "1.0.0"
-    appCompatVersion = "1.0.2"
+    appCompatVersion = "1.1.0"
     browserVersion = "1.0.0"
     constraintLayoutVersion = "1.1.3"
     dexmakerMockitoVersion = "2.19.0"


### PR DESCRIPTION
Upgrading androidx appcompat version from 1.0.2 -> [1.1.0](https://developer.android.com/jetpack/androidx/releases/appcompat#version_110_3).
This dependency was updated in the [common repo](https://github.com/AzureAD/microsoft-authentication-library-common-for-android) as part of this [PR:#1725](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1725)
Which broke the [consumers of common pipeline](https://identitydivision.visualstudio.com/Engineering/_build?definitionId=1393&_a=summary); as the consumer of commons are still referring to older versions and need to be upgraded as well.
- Also updating the common submodule to point to latest dev.