### PR TITLE
Added automation tests for AT-PoP scenarios

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "com.google.code.gson:gson:$rootProject.ext.gsonVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
+    implementation 'junit:junit:4.13'
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
     implementation "com.google.android.material:material:$rootProject.ext.materialVersion"
     androidTestImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
@@ -22,8 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.atpop;
 
-import androidx.annotation.NonNull;
-
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
@@ -36,17 +34,13 @@ import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequ
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
-import com.microsoft.identity.common.java.exception.ServiceException;
-import com.microsoft.identity.common.java.providers.oauth2.IDToken;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Map;
 
 // [Non-Joined] Acquire PoP token interactive followed by Silent
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922511
@@ -86,7 +80,7 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authResult.getAccessToken());
 
         // start silent token request in MSAL
         final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
@@ -100,7 +94,7 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
 
         final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.MEDIUM);
         authSilentResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authSilentResult.verifyATForPop(authSilentResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authSilentResult.getAccessToken());
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
@@ -86,7 +86,7 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        verifyATForPop(authResult);
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
 
         // start silent token request in MSAL
         final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
@@ -100,30 +100,7 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
 
         final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.MEDIUM);
         authSilentResult.assertSuccess();
-        verifyATForPop(authSilentResult);
-    }
-
-    private void verifyATForPop(@NonNull final MsalAuthResult authResult) throws ServiceException {
-        String rawIdToken = authResult.getAccessToken();
-        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
-        // check for url
-        if (tokens.containsKey("u")) {
-            Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the PoPResourceUri");
-        }
-        // check for path
-        if (tokens.containsKey("p")) {
-            Assert.assertEquals("/api/validateSHR", tokens.get("p"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the PoPResource path");
-        }
-        // check for the http method
-        if (tokens.containsKey("m")) {
-            Assert.assertEquals("GET", tokens.get("m"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the specified HTTP method");
-        }
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authSilentResult.verifyATForPop(authSilentResult.getAccessToken()));
     }
 
     @Override
@@ -153,3 +130,4 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
+

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
@@ -130,4 +130,3 @@ public class TestCase1922511 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
-

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
@@ -1,0 +1,153 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.atpop;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.providers.oauth2.IDToken;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+public class TestCase1922511 extends AbstractMsalBrokerTest {
+    @Test
+    public void test_1922511() throws Throwable {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        final MsalSdk msalSdk = new MsalSdk();
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.LOGIN)
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                        .prompt(PromptParameter.LOGIN)
+                        .loginHint(username)
+                        .sessionExpected(false)
+                        .consentPageExpected(false)
+                        .speedBumpExpected(false)
+                        .broker(mBroker)
+                        .expectingBrokerAccountChooserActivity(false)
+                        .build();
+
+                new AadPromptHandler(promptHandlerParameters)
+                        .handlePrompt(username, password);
+            }
+        }, TokenRequestTimeout.MEDIUM);
+
+        authResult.assertSuccess();
+        verifyATForPop(authResult);
+
+        // start silent token request in MSAL
+        final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .authority(getAuthority())
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.MEDIUM);
+        authSilentResult.assertSuccess();
+        verifyATForPop(authSilentResult);
+    }
+
+    private void verifyATForPop(@NonNull final MsalAuthResult authResult) throws ServiceException {
+        String rawIdToken = authResult.getAccessToken();
+        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
+        // check for url
+        if (tokens.containsKey("u")) {
+            Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the PoPResourceUri");
+        }
+        // check for path
+        if (tokens.containsKey("p")) {
+            Assert.assertEquals("/api/validateSHR", tokens.get("p"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the PoPResource path");
+        }
+        // check for the http method
+        if (tokens.containsKey("m")) {
+            Assert.assertEquals("GET", tokens.get("m"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the specified HTTP method");
+        }
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922511.java
@@ -48,6 +48,8 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Map;
 
+// [Non-Joined] Acquire PoP token interactive followed by Silent
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922511
 public class TestCase1922511 extends AbstractMsalBrokerTest {
     @Test
     public void test_1922511() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
@@ -81,9 +81,11 @@ public class TestCase1922527 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
 
         String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
         Assert.assertNotNull(shr);
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(shr));
     }
     @Override
     public LabQuery getLabQuery() {
@@ -111,5 +113,5 @@ public class TestCase1922527 extends AbstractMsalBrokerTest {
     public int getConfigFileResourceId() {
         return R.raw.msal_config_default;
     }
-
 }
+

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
@@ -81,11 +81,11 @@ public class TestCase1922527 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authResult.getAccessToken());
 
         String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
         Assert.assertNotNull(shr);
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(shr));
+        MsalAuthResult.verifyATForPop(shr);
     }
     @Override
     public LabQuery getLabQuery() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
@@ -114,4 +114,3 @@ public class TestCase1922527 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
-

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/atpop/TestCase1922527.java
@@ -1,0 +1,115 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.atpop;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// [Non-Joined] Generate SHR
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922527
+public class TestCase1922527 extends AbstractMsalBrokerTest {
+    @Test
+    public void test_1922527() throws Throwable {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        final MsalSdk msalSdk = new MsalSdk();
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.LOGIN)
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                        .prompt(PromptParameter.LOGIN)
+                        .loginHint(username)
+                        .sessionExpected(false)
+                        .consentPageExpected(false)
+                        .speedBumpExpected(false)
+                        .broker(mBroker)
+                        .expectingBrokerAccountChooserActivity(false)
+                        .build();
+
+                new AadPromptHandler(promptHandlerParameters)
+                        .handlePrompt(username, password);
+            }
+        }, TokenRequestTimeout.MEDIUM);
+
+        authResult.assertSuccess();
+
+        String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
+        Assert.assertNotNull(shr);
+    }
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
@@ -22,8 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.atpop;
 
-import androidx.annotation.NonNull;
-
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
@@ -36,17 +34,13 @@ import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequ
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
-import com.microsoft.identity.common.java.exception.ServiceException;
-import com.microsoft.identity.common.java.providers.oauth2.IDToken;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Map;
 
 // [Joined] Acquire PoP token interactive followed by Silent
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922513
@@ -87,7 +81,7 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authResult.getAccessToken());
 
         // start silent token request in MSAL
         final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
@@ -101,7 +95,7 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
 
         final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT);
         authSilentResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authSilentResult.verifyATForPop(authSilentResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authSilentResult.getAccessToken());
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
@@ -131,4 +131,3 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
-

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
@@ -1,0 +1,153 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.atpop;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.providers.oauth2.IDToken;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Map;
+
+// [Joined] Acquire PoP token interactive followed by Silent
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922513
+public class TestCase1922513 extends AbstractMsalBrokerTest {
+    @Test
+    public void test_1922513() throws Throwable {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        mBroker.performDeviceRegistration(username, password);
+        final MsalSdk msalSdk = new MsalSdk();
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.LOGIN)
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                        .prompt(PromptParameter.LOGIN)
+                        .loginHint(username)
+                        .sessionExpected(false)
+                        .consentPageExpected(false)
+                        .speedBumpExpected(false)
+                        .broker(mBroker)
+                        .expectingBrokerAccountChooserActivity(false)
+                        .build();
+
+                new AadPromptHandler(promptHandlerParameters)
+                        .handlePrompt(username, password);
+            }
+        }, TokenRequestTimeout.MEDIUM);
+
+        authResult.assertSuccess();
+        verifyATForPop(authResult);
+
+        // start silent token request in MSAL
+        final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .authority(getAuthority())
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT);
+        authSilentResult.assertSuccess();
+        verifyATForPop(authSilentResult);
+    }
+
+    private void verifyATForPop(@NonNull final MsalAuthResult authResult) throws ServiceException {
+        String rawIdToken = authResult.getAccessToken();
+        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
+        if (tokens.containsKey("u")) {
+            Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the PoPResourceUri");
+        }
+        if (tokens.containsKey("p")) {
+            Assert.assertEquals("/api/validateSHR", tokens.get("p"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the PoPResource path");
+        }
+        if (tokens.containsKey("m")) {
+            Assert.assertEquals("GET", tokens.get("m"));
+        } else {
+            Assert.fail("decoded AccessToken does not contain the specified HTTP method");
+        }
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922513.java
@@ -87,7 +87,7 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        verifyATForPop(authResult);
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
 
         // start silent token request in MSAL
         final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
@@ -101,27 +101,7 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
 
         final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT);
         authSilentResult.assertSuccess();
-        verifyATForPop(authSilentResult);
-    }
-
-    private void verifyATForPop(@NonNull final MsalAuthResult authResult) throws ServiceException {
-        String rawIdToken = authResult.getAccessToken();
-        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
-        if (tokens.containsKey("u")) {
-            Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the PoPResourceUri");
-        }
-        if (tokens.containsKey("p")) {
-            Assert.assertEquals("/api/validateSHR", tokens.get("p"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the PoPResource path");
-        }
-        if (tokens.containsKey("m")) {
-            Assert.assertEquals("GET", tokens.get("m"));
-        } else {
-            Assert.fail("decoded AccessToken does not contain the specified HTTP method");
-        }
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authSilentResult.verifyATForPop(authSilentResult.getAccessToken()));
     }
 
     @Override
@@ -151,3 +131,4 @@ public class TestCase1922513 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
+

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
@@ -83,11 +83,11 @@ public class TestCase1922515 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
+        MsalAuthResult.verifyATForPop(authResult.getAccessToken());
 
         String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
         Assert.assertNotNull(shr);
-        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(shr));
+        MsalAuthResult.verifyATForPop(shr);
     }
     @Override
     public LabQuery getLabQuery() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
@@ -1,0 +1,117 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.atpop;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// [Joined] Generate SHR
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922515
+public class TestCase1922515 extends AbstractMsalBrokerTest {
+    @Test
+    public void test_1922515() throws Throwable {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        mBroker.performDeviceRegistration(username, password);
+
+        final MsalSdk msalSdk = new MsalSdk();
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.LOGIN)
+                .authScheme(AuthScheme.POP)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                        .prompt(PromptParameter.LOGIN)
+                        .loginHint(username)
+                        .sessionExpected(false)
+                        .consentPageExpected(false)
+                        .speedBumpExpected(false)
+                        .broker(mBroker)
+                        .expectingBrokerAccountChooserActivity(false)
+                        .build();
+
+                new AadPromptHandler(promptHandlerParameters)
+                        .handlePrompt(username, password);
+            }
+        }, TokenRequestTimeout.MEDIUM);
+
+        authResult.assertSuccess();
+
+        String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
+        Assert.assertNotNull(shr);
+    }
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
@@ -89,6 +89,7 @@ public class TestCase1922515 extends AbstractMsalBrokerTest {
         Assert.assertNotNull(shr);
         MsalAuthResult.verifyATForPop(shr);
     }
+
     @Override
     public LabQuery getLabQuery() {
         return LabQuery.builder()

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
@@ -116,4 +116,3 @@ public class TestCase1922515 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 }
-

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/TestCase1922515.java
@@ -83,9 +83,11 @@ public class TestCase1922515 extends AbstractMsalBrokerTest {
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(authResult.getAccessToken()));
 
         String shr = msalSdk.generateSHR(authTestParams, TokenRequestTimeout.SHORT);
         Assert.assertNotNull(shr);
+        Assert.assertEquals(MsalAuthResult.atPopSuccessMsg, authResult.verifyATForPop(shr));
     }
     @Override
     public LabQuery getLabQuery() {
@@ -113,5 +115,5 @@ public class TestCase1922515 extends AbstractMsalBrokerTest {
     public int getConfigFileResourceId() {
         return R.raw.msal_config_default;
     }
-
 }
+

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/Constants.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/Constants.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.microsoft.identity.client.msal.automationapp.sdk;
+
+public class Constants {
+    /**
+     * AT-PoP strings.
+     */
+    public static final String PoP_DOMAIN = "signedhttprequest.azurewebsites.net";
+
+    public static final String PoP_URL_PATH = "/api/validateSHR";
+
+    public static final String PoP_FULL_URL = "https://signedhttprequest.azurewebsites.net/api/validateSHR";
+
+    public static final String HTTP_GET_METHOD = "GET";
+
+    public static final String TOKEN_URL = "u";
+
+    public static final String TOKEN_URL_PATH = "p";
+
+    public static final String TOKEN_HTTP_METHOD = "m";
+}

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
@@ -22,6 +22,13 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.sdk;
 
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.HTTP_GET_METHOD;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.PoP_DOMAIN;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.PoP_URL_PATH;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.TOKEN_HTTP_METHOD;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.TOKEN_URL;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.TOKEN_URL_PATH;
+
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.IAuthenticationResult;
@@ -50,8 +57,8 @@ public class MsalAuthResult extends AuthResult {
     public static void verifyATForPop(@NonNull final String shr) throws ServiceException {
         Map<String, ?> tokens = IDToken.parseJWT(shr);
         // Verify if the url, path and http method are as expected
-        Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
-        Assert.assertEquals("/api/validateSHR", tokens.get("p"));
-        Assert.assertEquals("GET", tokens.get("m"));
+        Assert.assertEquals(PoP_DOMAIN, tokens.get(TOKEN_URL));
+        Assert.assertEquals(PoP_URL_PATH, tokens.get(TOKEN_URL_PATH));
+        Assert.assertEquals(HTTP_GET_METHOD, tokens.get(TOKEN_HTTP_METHOD));
     }
 }

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
@@ -29,13 +29,14 @@ import com.microsoft.identity.client.ui.automation.sdk.AuthResult;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.providers.oauth2.IDToken;
 
+import org.junit.Assert;
+
 import java.util.Map;
 
 // MSAL Result Class to handle asserting success or failure on execution of Automated Test Cases
 public class MsalAuthResult extends AuthResult {
 
     private Map<String, ?> claims;
-    public static final String atPopSuccessMsg = "successfully verified at-pop";
 
     public MsalAuthResult(@NonNull final IAuthenticationResult authenticationResult) {
         super(authenticationResult.getAccessToken(), authenticationResult.getAccount().getIdToken(), authenticationResult.getAccount().getId(), authenticationResult.getAccount().getUsername(), authenticationResult.getAccount().getAuthority());
@@ -46,19 +47,11 @@ public class MsalAuthResult extends AuthResult {
         super(exception);
     }
 
-    public String verifyATForPop(@NonNull final String rawIdToken) throws ServiceException {
-        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
-
+    public static void verifyATForPop(@NonNull final String shr) throws ServiceException {
+        Map<String, ?> tokens = IDToken.parseJWT(shr);
         // Verify if the url, path and http method are as expected
-        if (!tokens.get("u").equals("signedhttprequest.azurewebsites.net"))
-            return "Decoded AccessToken does not contain the PoPResourceUri";
-
-        if (!tokens.get("p").equals("/api/validateSHR"))
-            return "Decoded AccessToken does not contain the PoPResource path";
-
-        if (!tokens.get("m").equals("GET"))
-            return "Decoded AccessToken does not contain the expected HTTP method";
-
-        return "successfully verified at-pop";
+        Assert.assertEquals("signedhttprequest.azurewebsites.net", tokens.get("u"));
+        Assert.assertEquals("/api/validateSHR", tokens.get("p"));
+        Assert.assertEquals("GET", tokens.get("m"));
     }
 }

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalAuthResult.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.ui.automation.sdk.AuthResult;
+import com.microsoft.identity.common.java.exception.ServiceException;
+import com.microsoft.identity.common.java.providers.oauth2.IDToken;
 
 import java.util.Map;
 
@@ -33,6 +35,7 @@ import java.util.Map;
 public class MsalAuthResult extends AuthResult {
 
     private Map<String, ?> claims;
+    public static final String atPopSuccessMsg = "successfully verified at-pop";
 
     public MsalAuthResult(@NonNull final IAuthenticationResult authenticationResult) {
         super(authenticationResult.getAccessToken(), authenticationResult.getAccount().getIdToken(), authenticationResult.getAccount().getId(), authenticationResult.getAccount().getUsername(), authenticationResult.getAccount().getAuthority());
@@ -41,5 +44,21 @@ public class MsalAuthResult extends AuthResult {
 
     public MsalAuthResult(@NonNull final Exception exception) {
         super(exception);
+    }
+
+    public String verifyATForPop(@NonNull final String rawIdToken) throws ServiceException {
+        Map<String, ?> tokens = IDToken.parseJWT(rawIdToken);
+
+        // Verify if the url, path and http method are as expected
+        if (!tokens.get("u").equals("signedhttprequest.azurewebsites.net"))
+            return "Decoded AccessToken does not contain the PoPResourceUri";
+
+        if (!tokens.get("p").equals("/api/validateSHR"))
+            return "Decoded AccessToken does not contain the PoPResource path";
+
+        if (!tokens.get("m").equals("GET"))
+            return "Decoded AccessToken does not contain the expected HTTP method";
+
+        return "successfully verified at-pop";
     }
 }

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
@@ -93,7 +93,6 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
             acquireTokenParametersBuilder.withAuthenticationScheme(
                     PoPAuthenticationScheme.builder()
                             .withHttpMethod(HttpMethod.valueOf("GET"))
-                            .withClientClaims("")
                             .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
                             .build()
             );
@@ -164,7 +163,6 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
             acquireTokenParametersBuilder.withAuthenticationScheme(
                     PoPAuthenticationScheme.builder()
                             .withHttpMethod(HttpMethod.valueOf("GET"))
-                            .withClientClaims("")
                             .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
                             .build()
             );
@@ -321,18 +319,15 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
 
         };
 
-        if (authTestParams.getAuthScheme() == AuthScheme.POP) {
-            pca.generateSignedHttpRequest(account, PoPAuthenticationScheme.builder()
-                    .withHttpMethod(HttpMethod.valueOf("GET"))
-                    .withClientClaims("")
-                    .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
-                    .build(), callback);
+        pca.generateSignedHttpRequest(account, PoPAuthenticationScheme.builder()
+                .withHttpMethod(HttpMethod.valueOf("GET"))
+                .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                .build(), callback);
 
-        }
         try {
             return future.get(tokenRequestTimeout.getTime(), tokenRequestTimeout.getTimeUnit());
         } catch (final Exception exception) {
-           throw exception;
+            throw exception;
         }
     }
 }

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
@@ -31,23 +31,27 @@ import androidx.annotation.Nullable;
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
 import com.microsoft.identity.client.AuthenticationCallback;
+import com.microsoft.identity.client.HttpMethod;
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
+import com.microsoft.identity.client.PoPAuthenticationScheme;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SingleAccountPublicClientApplication;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.exception.MsalUserCancelException;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.sdk.ResultFuture;
 import com.microsoft.identity.client.ui.automation.sdk.IAuthSdk;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryB2CAuthority;
 
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,7 +62,7 @@ import java.util.List;
  * parameters and get back the final result.
  */
 public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
-    
+
     @Override
     public MsalAuthResult acquireTokenInteractive(@NonNull MsalAuthTestParams authTestParams, final OnInteractionRequired interactionRequiredCallback, @NonNull final TokenRequestTimeout tokenRequestTimeout) throws Throwable {
         final IPublicClientApplication pca = setupPCA(
@@ -85,6 +89,17 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
             acquireTokenParametersBuilder.withClaims(authTestParams.getClaims());
         }
 
+        if (authTestParams.getAuthScheme() == AuthScheme.POP) {
+            acquireTokenParametersBuilder.withAuthenticationScheme(
+                    PoPAuthenticationScheme.builder()
+                            .withHttpMethod(HttpMethod.valueOf("GET"))
+                            .withClientClaims("")
+                            .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                            .build()
+            );
+        }
+
+
         final AcquireTokenParameters acquireTokenParameters = acquireTokenParametersBuilder.build();
 
         pca.acquireToken(acquireTokenParameters);
@@ -102,8 +117,8 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
     @Override
     public MsalAuthResult acquireTokenSilent(@NonNull MsalAuthTestParams authTestParams, @NonNull final TokenRequestTimeout tokenRequestTimeout) throws Throwable {
         final IPublicClientApplication pca = setupPCA(
-            authTestParams.getActivity(),
-            authTestParams.getMsalConfigResourceId()
+                authTestParams.getActivity(),
+                authTestParams.getMsalConfigResourceId()
         );
 
         final ResultFuture<IAuthenticationResult, Exception> future = new ResultFuture<>();
@@ -143,6 +158,16 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
 
         if (authTestParams.getClaims() != null) {
             acquireTokenParametersBuilder.withClaims(authTestParams.getClaims());
+        }
+
+        if (authTestParams.getAuthScheme() == AuthScheme.POP) {
+            acquireTokenParametersBuilder.withAuthenticationScheme(
+                    PoPAuthenticationScheme.builder()
+                            .withHttpMethod(HttpMethod.valueOf("GET"))
+                            .withClientClaims("")
+                            .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                            .build()
+            );
         }
 
         final AcquireTokenSilentParameters acquireTokenParameters = acquireTokenParametersBuilder.build();
@@ -186,8 +211,8 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
     }
 
     public IAccount getAccount(@NonNull final Activity activity,
-                                final int msalConfigResourceId,
-                                @NonNull final String username) {
+                               final int msalConfigResourceId,
+                               @NonNull final String username) {
         final IPublicClientApplication pca = setupPCA(
                 activity,
                 msalConfigResourceId
@@ -252,14 +277,11 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
         }
     }
 
-    private IAccount getAccountForPolicyName(@NonNull final MultipleAccountPublicClientApplication pca, @NonNull final String policyName)
-    {
+    private IAccount getAccountForPolicyName(@NonNull final MultipleAccountPublicClientApplication pca, @NonNull final String policyName) {
         try {
             List<IAccount> accounts = pca.getAccounts();
-            for(IAccount account : accounts)
-            {
-                if (policyName.equals(account.getClaims().get("tfp")))
-                {
+            for (IAccount account : accounts) {
+                if (policyName.equals(account.getClaims().get("tfp"))) {
                     return account;
                 }
             }
@@ -267,5 +289,50 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
             throw new AssertionError(exception);
         }
         return null;
+    }
+
+    public String generateSHR(@NonNull MsalAuthTestParams authTestParams, TokenRequestTimeout tokenRequestTimeout) throws Throwable {
+        final IPublicClientApplication pca = setupPCA(
+                authTestParams.getActivity(),
+                authTestParams.getMsalConfigResourceId()
+        );
+
+        final IAccount account = getAccount(
+                authTestParams.getActivity(),
+                authTestParams.getMsalConfigResourceId(),
+                authTestParams.getLoginHint()
+        );
+
+        if (null == account) {
+            // User must first sign-in
+            return null;
+        }
+        final ResultFuture<String, Exception> future = new ResultFuture<>();
+        final IPublicClientApplication.SignedHttpRequestRequestCallback callback = new IPublicClientApplication.SignedHttpRequestRequestCallback() {
+            @Override
+            public void onTaskCompleted(String result) {
+                future.setResult(result);
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                future.setException(exception);
+            }
+
+        };
+
+        if (authTestParams.getAuthScheme() == AuthScheme.POP) {
+            pca.generateSignedHttpRequest(account, PoPAuthenticationScheme.builder()
+                    .withHttpMethod(HttpMethod.valueOf("GET"))
+                    .withClientClaims("")
+                    .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                    .build(), callback);
+
+        }
+        try {
+            return future.get(tokenRequestTimeout.getTime(), tokenRequestTimeout.getTimeUnit());
+        } catch (final Exception exception) {
+           throw exception;
+        }
     }
 }

--- a/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
+++ b/msalautomationapp/src/main/java/com/microsoft/identity/client/msal/automationapp/sdk/MsalSdk.java
@@ -22,6 +22,9 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.sdk;
 
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.HTTP_GET_METHOD;
+import static com.microsoft.identity.client.msal.automationapp.sdk.Constants.PoP_FULL_URL;
+
 import android.app.Activity;
 import android.content.Context;
 
@@ -162,8 +165,8 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
         if (authTestParams.getAuthScheme() == AuthScheme.POP) {
             acquireTokenParametersBuilder.withAuthenticationScheme(
                     PoPAuthenticationScheme.builder()
-                            .withHttpMethod(HttpMethod.valueOf("GET"))
-                            .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                            .withHttpMethod(HttpMethod.valueOf(HTTP_GET_METHOD))
+                            .withUrl(new URL(PoP_FULL_URL))
                             .build()
             );
         }
@@ -320,8 +323,8 @@ public class MsalSdk implements IAuthSdk<MsalAuthTestParams> {
         };
 
         pca.generateSignedHttpRequest(account, PoPAuthenticationScheme.builder()
-                .withHttpMethod(HttpMethod.valueOf("GET"))
-                .withUrl(new URL("https://signedhttprequest.azurewebsites.net/api/validateSHR"))
+                .withHttpMethod(HttpMethod.valueOf(HTTP_GET_METHOD))
+                .withUrl(new URL(PoP_FULL_URL))
                 .build(), callback);
 
         try {


### PR DESCRIPTION
What: Adding Ui automation test cases for AT-PoP scenarios under the test plan for AT-PoP  folder in the following link https://identitydivision.visualstudio.com/Engineering/_testPlans/execute?planId=1905195&suiteId=1905209

Testing: Tested by running these testcases on Pixel 4 emulator

Related PR : This PR consists of some utility functions added to support AT-PoP scenarios https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1756