### PR TITLE
Add separate pipeline yml for MSAL with and without broker automation

### DIFF
--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -9,7 +9,7 @@ pr: none
 
 schedules:
   - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Auth Client Android SDK dev build
+    displayName: Daily Local MSAL UI Automation with Broker Run
     branches:
       include:
         - dev

--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -24,7 +24,7 @@ variables:
   azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
   firebaseTimeout: 45m
-  resultsHistoryName: Dev MSAL with Broker
+  resultsHistoryName: Dev MSAL with Dev BrokerHost
 
 parameters:
   - name: firebaseDeviceId

--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -1,4 +1,4 @@
-# run MSAL UI automation testcases
+# run MSAL with Broker UI automation testcases
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
 # Variable: 'mvnAccessToken' was defined in the Variables tab
@@ -24,7 +24,7 @@ variables:
   azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
   firebaseTimeout: 45m
-  resultsHistoryName: MSAL dev w/ dev BrokerHost
+  resultsHistoryName: Dev MSAL with Broker
 
 parameters:
   - name: firebaseDeviceId
@@ -120,7 +120,7 @@ stages:
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL Complete Test UI Test Suite
+    displayName: Running MSAL with Broker Test UI Test Suite
     jobs:
       - job: 'msal_with_broker'
         displayName: Running MSAL with Broker Test Plan
@@ -161,7 +161,7 @@ stages:
                   --use-orchestrator \
                   --environment-variables "clearPackageData=true" \
                   --results-history-name "$(resultsHistoryName)" \
-                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf"
+                  --test-targets "package com.microsoft.identity.client.msal.automationapp.testpass.broker"
           - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/$(resultsDir)/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
             displayName: Download Test Result File
             condition: succeededOrFailed()

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -101,11 +101,11 @@ stages:
           - publish: $(Build.ArtifactStagingDirectory)/azureSample
             displayName: 'Publish Azure Sample apk for later use'
             artifact: azureSample
-  # MSAL with Broker Test Plan stage
-  - stage: 'msal_with_broker'
+  # MSAL without Broker Test UI stage
+  - stage: 'msal_without_broker'
     dependsOn:
       - msalautomationapp
-      - brokers
+      - azuresample
     displayName: Running MSAL without Broker Test UI Test Suite
     jobs:
       - job: 'msal_with_broker'

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -1,0 +1,160 @@
+# run MSAL UI automation testcases
+# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
+# Variable: 'gCloudProjectId' was defined in the Variables tab
+# Variable: 'mvnAccessToken' was defined in the Variables tab
+name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
+    displayName: Auth Client Android SDK dev build
+    branches:
+      include:
+        - dev
+    always: true
+
+variables:
+  engineeringProjectId: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'
+  azureSamplePipelineId: 1458
+  msalAutomationAppApk: msalautomationapp-local-BrokerHost-debug.apk
+  msalAutomationAppTestApk: msalautomationapp-local-BrokerHost-debug-androidTest.apk
+  azureSampleApk: AzureSample-local-debug.apk
+  firebaseTimeout: 45m
+  resultsHistoryName: Dev MSAL without Broker
+
+parameters:
+  - name: firebaseDeviceId
+    displayName: Firebase Device Id
+    type: string
+    default: blueline
+  - name: firebaseDeviceAndroidVersion
+    displayName: Firebase Device Android Version
+    type: number
+    default: 28
+
+stages:
+  # msalautomationapp
+  - stage: 'msalautomationapp'
+    displayName: Build MSAL Automation APKs
+    jobs:
+      - job: 'msalautomationapp'
+        displayName: Build and Publish MSAL Automation app
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: self
+            clean: true
+            submodules: recursive
+            persistCredentials: True
+          - bash: |
+              echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(mvnAccessToken)"
+            displayName: Set MVN Access Token in Environment
+          - task: AzureKeyVault@2
+            displayName: 'Get Key vault AndroidAutomationRunnerAppSecret'
+            inputs:
+              azureSubscription: 'MSIDLABS_ANDROID_KV'
+              KeyVaultName: 'ADALTestInfo'
+              SecretsFilter: 'AndroidAutomationRunnerAppSecret'
+              RunAsPreJob: false
+          - task: Gradle@2
+            displayName: 'Assemble MSAL Automation App'
+            inputs:
+              tasks: clean msalautomationapp:assembleLocalBrokerHostDebug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=LocalApk
+              publishJUnitResults: false
+          - task: Gradle@2
+            displayName: 'Assemble MSAL Automation App Instrumented Tests'
+            inputs:
+              tasks: msalautomationapp:assembleLocalBrokerHostDebugAndroidTest -PlabSecret=$(AndroidAutomationRunnerAppSecret)
+              publishJUnitResults: false
+          - task: CopyFiles@2
+            displayName: 'Copy apks for later use in the pipeline'
+            inputs:
+              flattenFolders: true
+              contents: '$(Build.SourcesDirectory)/msalautomationapp/build/outputs/apk/**/*.apk'
+              targetFolder: '$(Build.ArtifactStagingDirectory)/msal'
+          - publish: '$(Build.ArtifactStagingDirectory)/msal'
+            displayName: 'Publish apks for later use'
+            artifact: msalautomationapks
+  # Brokers
+  - stage: 'brokers'
+    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+    displayName: Brokers and Azure Sample APKs
+    jobs:
+      - job: 'download_brokers'
+        displayName: Download Brokers
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download latest Azure Sample'
+            inputs:
+              buildType: 'specific'
+              project: '$(engineeringProjectId)'
+              definition: '$(azureSamplePipelineId)'
+              artifactName: AzureSample
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+              buildVersionToDownload: 'latest'
+          - publish: $(Build.ArtifactStagingDirectory)/azureSample
+            displayName: 'Publish Azure Sample apk for later use'
+            artifact: azureSample
+  # MSAL with Broker Test Plan stage
+  - stage: 'msal_with_broker'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL without Broker Test UI Test Suite
+    jobs:
+      - job: 'msal_with_broker'
+        displayName: Running MSAL without Broker Test Plan
+        timeoutInMinutes: 90
+        pool:
+          vmImage: ubuntu-latest
+        variables:
+          resultsDir: "msal-BrokerHost-$(Build.BuildId)-$(Build.BuildNumber)"
+        steps:
+          - checkout: none
+          - task: DownloadSecureFile@1
+            displayName: 'Download Firebase Service Account Key File'
+            name: gcServiceAccountKey
+            inputs:
+              secureFile: AndroidFirebaseServiceAccountKey.json
+              retryCount: 5
+          - download: current
+          - script: gcloud version
+            displayName: 'Check gcloud version'
+          - task: Bash@3
+            displayName: Run UI Automation on Firebase
+            inputs:
+              targetType: inline
+              script: |
+                gcloud auth activate-service-account --key-file "$(gcServiceAccountKey.secureFilePath)"
+                gcloud config set project "$(gCloudProjectId)"
+                gcloud firebase test android run \
+                  --type instrumentation \
+                  --app "$(Pipeline.Workspace)/msalautomationapks/$(msalAutomationAppApk)" \
+                  --test "$(Pipeline.Workspace)/msalautomationapks/$(msalAutomationAppTestApk)" \
+                  --device "model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }}" \
+                  --timeout "$(firebaseTimeout)" \
+                  --other-files \
+                  "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)" \
+                  --results-dir "$(resultsDir)" \
+                  --directories-to-pull "/sdcard" \
+                  --use-orchestrator \
+                  --environment-variables "clearPackageData=true" \
+                  --results-history-name "$(resultsHistoryName)" \
+                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf"
+                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.broker"
+          - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/$(resultsDir)/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
+            displayName: Download Test Result File
+            condition: succeededOrFailed()
+          - task: PublishTestResults@2
+            displayName: Publish Test Results to ADO
+            condition: succeededOrFailed()
+            inputs:
+              testResultsFiles: '*test_result*.xml'
+              searchFolder: $(Build.SourcesDirectory)
+              testRunTitle: 'MSAL UI Automation - Build # $(Build.BuildNumber)'

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -146,7 +146,7 @@ stages:
                   --use-orchestrator \
                   --environment-variables "clearPackageData=true" \
                   --results-history-name "$(resultsHistoryName)" \
-                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf,com.microsoft.identity.client.msal.automationapp.testpass.broker"
+                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf, notPackage com.microsoft.identity.client.msal.automationapp.testpass.broker"
           - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/$(resultsDir)/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
             displayName: Download Test Result File
             condition: succeededOrFailed()

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -61,7 +61,7 @@ stages:
           - task: Gradle@2
             displayName: 'Assemble MSAL Automation App'
             inputs:
-              tasks: clean msalautomationapp:assembleLocalBrokerHostDebug -PlabSecret=$(AndroidAutomationRunnerAppSecret) -PbrokerSource=LocalApk
+              tasks: clean msalautomationapp:assembleLocalBrokerHostDebug -PlabSecret=$(AndroidAutomationRunnerAppSecret)
               publishJUnitResults: false
           - task: Gradle@2
             displayName: 'Assemble MSAL Automation App Instrumented Tests'
@@ -157,4 +157,3 @@ stages:
               testResultsFiles: '*test_result*.xml'
               searchFolder: $(Build.SourcesDirectory)
               testRunTitle: 'MSAL UI Automation - Build # $(Build.BuildNumber)'
-              

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -146,8 +146,7 @@ stages:
                   --use-orchestrator \
                   --environment-variables "clearPackageData=true" \
                   --results-history-name "$(resultsHistoryName)" \
-                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf,
-                                  notPackage com.microsoft.identity.client.msal.automationapp.testpass.broker"
+                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf,com.microsoft.identity.client.msal.automationapp.testpass.broker"
           - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/$(resultsDir)/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
             displayName: Download Test Result File
             condition: succeededOrFailed()

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -80,10 +80,10 @@ stages:
   # Brokers
   - stage: 'brokers'
     dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Brokers and Azure Sample APKs
+    displayName: Azure Sample APKs
     jobs:
       - job: 'download_brokers'
-        displayName: Download Brokers
+        displayName: Download Azure Sample
         pool:
           vmImage: ubuntu-latest
         steps:

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -1,4 +1,4 @@
-# run MSAL UI automation testcases
+# run MSAL without Broker UI automation testcases
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
 # Variable: 'mvnAccessToken' was defined in the Variables tab
@@ -9,7 +9,7 @@ pr: none
 
 schedules:
   - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Auth Client Android SDK dev build
+    displayName: Daily Local MSAL UI Automation without Broker Run
     branches:
       include:
         - dev

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -157,3 +157,4 @@ stages:
               testResultsFiles: '*test_result*.xml'
               searchFolder: $(Build.SourcesDirectory)
               testRunTitle: 'MSAL UI Automation - Build # $(Build.BuildNumber)'
+              

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -146,8 +146,8 @@ stages:
                   --use-orchestrator \
                   --environment-variables "clearPackageData=true" \
                   --results-history-name "$(resultsHistoryName)" \
-                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf"
-                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.broker"
+                  --test-targets "notPackage com.microsoft.identity.client.msal.automationapp.testpass.perf,
+                                  notPackage com.microsoft.identity.client.msal.automationapp.testpass.broker"
           - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/$(resultsDir)/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
             displayName: Download Test Result File
             condition: succeededOrFailed()

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -77,12 +77,12 @@ stages:
           - publish: '$(Build.ArtifactStagingDirectory)/msal'
             displayName: 'Publish apks for later use'
             artifact: msalautomationapks
-  # Brokers
-  - stage: 'brokers'
+  # Azure Sample
+  - stage: 'azuresample'
     dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Azure Sample APKs
+    displayName: Dowload Azure Sample APK
     jobs:
-      - job: 'download_brokers'
+      - job: 'download_azure_sample'
         displayName: Download Azure Sample
         pool:
           vmImage: ubuntu-latest


### PR DESCRIPTION
Currently one UI Automation pipeline is running nightly validation for MSAL (both with and without broker). We're separating that here so that with and without broker tests are running on separate pipelines.

This helps measure the reliability of broker and broker-less MSAL separately, and it also lowers the execution time of the pipeline by running these tests in separate pipelines.