### PR TITLE
Added config changes back  in MSAL AndroidManifest file

### DIFF
--- a/msal/src/main/AndroidManifest.xml
+++ b/msal/src/main/AndroidManifest.xml
@@ -9,11 +9,13 @@
         <!-- MSAL activity that will be used to process all the auth related logic  -->
         <activity
             android:name="com.microsoft.identity.common.internal.providers.oauth2.AuthorizationActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
             android:exported="false"
             android:launchMode="singleTask" />
 
         <activity
             android:name="com.microsoft.identity.common.internal.providers.oauth2.CurrentTaskAuthorizationActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
             android:exported="false"
             android:launchMode="standard" />
 
@@ -26,6 +28,7 @@
         <!-- MSAL will use system webview (custom tab) to render the sign-in page, BrowserTabActivity is to get response back from System Webview. Multiple apps on the device could integrate MSAL, OS will check which BrowserTabActivity can handle the intent based on the intent filter declared, so this activity has to be exported.-->
         <activity
             android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|screenLayout"
             android:exported="true" />
 
         <activity

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -61,7 +61,6 @@
         <activity
             android:name="com.microsoft.identity.client.testapp.MainActivity"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden"
             android:taskAffinity=""
             android:documentLaunchMode="always"
             android:configChanges="keyboardHidden|keyboard">


### PR DESCRIPTION
What : Accidentally changed AndroidManifest file during a merge conflict resolution and merged that PR. The config changes added in the manifest file were removed. Since merge conflicts resolution commit was pushed after all signoffs and I missed verifying the final changes.

Prev PR in which the config property was removed : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1643

Fix : Added the config changes back. 

Note : Confirmed that these changes were not taken in release branch. Hence reverting it in dev should be sufficient