### PR TITLE
Move MSAL Tests, bring back some tests too

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1600592.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1600592.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.nonjoin
 
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.exception.MsalServiceException;
+import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase796049.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase796049.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
@@ -39,43 +40,37 @@ import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Test;
 
-import java.util.Arrays;
-
-// [USGOV][Broker][Joined] Acquire token with USGov Authority
-// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938447
-public class TestCase938447 extends AbstractMsalBrokerTest {
+// [USGOV][Broker][Non-Joined] Acquire Token with Resource
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/796049
+public class TestCase796049 extends AbstractMsalBrokerTest {
 
     @Test
-    public void test_938447() throws Throwable {
+    public void test_796049() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
         final MsalSdk msalSdk = new MsalSdk();
 
-        // perform device registration (will obtain PRT in Broker for supplied account)
-        mBroker.performDeviceRegistration(username, password);
-
+        // Interactive Call W/ Resource
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
                 .loginHint(username)
-                .scopes(Arrays.asList(mScopes))
+                .resource(mScopes[0])
                 .promptParameter(Prompt.SELECT_ACCOUNT)
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
-        // start interactive acquire token request in MSAL (should succeed)
-        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
             @Override
             public void handleUserInteraction() {
                 final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                         .prompt(PromptParameter.SELECT_ACCOUNT)
                         .loginHint(username)
-                        .sessionExpected(true)
+                        .sessionExpected(false)
                         .consentPageExpected(false)
                         .speedBumpExpected(false)
                         .broker(mBroker)
-                        .expectingBrokerAccountChooserActivity(true)
-                        .expectingLoginPageAccountPicker(false)
+                        .expectingBrokerAccountChooserActivity(false)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)
@@ -101,16 +96,16 @@ public class TestCase938447 extends AbstractMsalBrokerTest {
 
     @Override
     public String[] getScopes() {
-        return new String[]{"User.read"};
+        return new String[]{"00000002-0000-0000-c000-000000000000"};
     }
 
     @Override
     public String getAuthority() {
-        return mApplication.getConfiguration().getDefaultAuthority().toString();
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
     }
 
     @Override
     public int getConfigFileResourceId() {
-        return R.raw.msal_config_arlington;
+        return R.raw.msal_config_instance_aware_common;
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase940421.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase940421.java
@@ -51,7 +51,8 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Map;
 
-// [USGOV][Joined] In-line WPJ/MSAL - acquire token with deviceid claim request, and instance_aware=true
+// [USGOV][Broker][Joined] In-line WPJ/MSAL - acquire token with deviceid claim request,
+// and instance_aware=true
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/940421
 public class TestCase940421 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase948676.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/usgov/TestCase948676.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [USGOV][Joined] Acquire token with USGov account, with instance_aware=true
+// [USGOV][Broker][Joined] Acquire token with instance_aware=true
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/948676
 public class TestCase948676 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
@@ -20,41 +20,40 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.testpass.broker.usgov;
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.basic;
 
 import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.exception.MsalServiceException;
+import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
-import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
-import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
-import com.microsoft.identity.labapi.utilities.constants.UserType;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
 
-// [USGOV][Broker][Joined] Acquire token with USGov Authority
-// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938447
-public class TestCase938447 extends AbstractMsalBrokerTest {
+// [MSAL-Only] A single-tenant app makes a silent request with common authority. It should fail..
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/2016158
+public class TestCase2016158 extends AbstractMsalUiTest {
 
     @Test
-    public void test_938447() throws Throwable {
+    public void test_2016158() throws Throwable{
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
         final MsalSdk msalSdk = new MsalSdk();
 
-        // perform device registration (will obtain PRT in Broker for supplied account)
-        mBroker.performDeviceRegistration(username, password);
-
+        // Interactive call
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
                 .loginHint(username)
@@ -63,19 +62,16 @@ public class TestCase938447 extends AbstractMsalBrokerTest {
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
-        // start interactive acquire token request in MSAL (should succeed)
-        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
+        final MsalAuthResult authResult1 = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
             @Override
             public void handleUserInteraction() {
                 final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                         .prompt(PromptParameter.SELECT_ACCOUNT)
                         .loginHint(username)
-                        .sessionExpected(true)
-                        .consentPageExpected(false)
+                        .sessionExpected(false)
+                        .consentPageExpected(true)
                         .speedBumpExpected(false)
-                        .broker(mBroker)
-                        .expectingBrokerAccountChooserActivity(true)
-                        .expectingLoginPageAccountPicker(false)
+                        .expectingBrokerAccountChooserActivity(false)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)
@@ -83,34 +79,46 @@ public class TestCase938447 extends AbstractMsalBrokerTest {
             }
         }, TokenRequestTimeout.MEDIUM);
 
-        authResult.assertSuccess();
+        authResult1.assertSuccess();
+
+        // Silent with https://login.microsoftonline.com/common
+        final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .authority(getAuthority())
+                .resource(mScopes[0])
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult2 = msalSdk.acquireTokenSilent(silentParams, TokenRequestTimeout.MEDIUM);
+
+        // Should fail with an MsalServiceException
+        authResult2.assertFailure();
+        Assert.assertTrue(authResult2.getException() instanceof MsalServiceException);
     }
 
     @Override
     public LabQuery getLabQuery() {
-        return LabQuery.builder()
-                .userType(UserType.CLOUD)
-                .azureEnvironment(AzureEnvironment.AZURE_US_GOVERNMENT)
-                .build();
-    }
-
-    @Override
-    public TempUserType getTempUserType() {
         return null;
     }
 
     @Override
+    public TempUserType getTempUserType() {
+        return TempUserType.BASIC;
+    }
+
+    @Override
     public String[] getScopes() {
-        return new String[]{"User.read"};
+        return new String[]{"https://graph.windows.net/user.read"};
     }
 
     @Override
     public String getAuthority() {
-        return mApplication.getConfiguration().getDefaultAuthority().toString();
+        return "https://login.microsoftonline.com/common";
     }
 
     @Override
     public int getConfigFileResourceId() {
-        return R.raw.msal_config_arlington;
+        return R.raw.msal_config_no_admin_consent;
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938365.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938365.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.testpass.broker.usgov;
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.usgov;
 
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
@@ -42,12 +42,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// Interactive token acquisition with instance_aware=false and USGov authority
-// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938384
-public class TestCase938384 extends AbstractMsalUiTest {
+// [USGOV][MSAL-ONLY] Acquire token with instance_aware=true, no login hint, and cloud account,
+// and WW common authority
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938365
+public class TestCase938365 extends AbstractMsalUiTest {
 
     @Test
-    public void test_938384() throws Throwable {
+    public void test_938365() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
@@ -57,7 +58,6 @@ public class TestCase938384 extends AbstractMsalUiTest {
                 .activity(mActivity)
                 .scopes(Arrays.asList(mScopes))
                 .promptParameter(Prompt.SELECT_ACCOUNT)
-                .authority(getAuthority())
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
@@ -67,11 +67,11 @@ public class TestCase938384 extends AbstractMsalUiTest {
                 ((IApp) mBrowser).handleFirstRun();
 
                 final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
-                        .prompt(PromptParameter.SELECT_ACCOUNT)
                         .loginHint(null)
                         .sessionExpected(false)
                         .consentPageExpected(false)
                         .speedBumpExpected(false)
+                        .prompt(PromptParameter.SELECT_ACCOUNT)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)
@@ -101,11 +101,11 @@ public class TestCase938384 extends AbstractMsalUiTest {
 
     @Override
     public String getAuthority() {
-        return "https://login.microsoftonline.us/common";
+        return mApplication.getConfiguration().getDefaultAuthority().toString();
     }
 
     @Override
     public int getConfigFileResourceId() {
-        return R.raw.msal_config_default;
+        return R.raw.msal_config_instance_aware_common;
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938384.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938384.java
@@ -20,16 +20,14 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.testpass.broker.usgov;
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.usgov;
 
-import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
-import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.app.IApp;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
@@ -44,12 +42,12 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// Silent token acquisition with unexpired RT with USGov authority
-// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938383
-public class TestCase938383 extends AbstractMsalUiTest {
+// [USGOV][MSAL-ONLY] Acquire token with USGov Authority
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938384
+public class TestCase938384 extends AbstractMsalUiTest {
 
     @Test
-    public void test_938383() throws Throwable {
+    public void test_938384() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
@@ -59,10 +57,10 @@ public class TestCase938383 extends AbstractMsalUiTest {
                 .activity(mActivity)
                 .scopes(Arrays.asList(mScopes))
                 .promptParameter(Prompt.SELECT_ACCOUNT)
+                .authority(getAuthority())
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
-        // Start interactive token request in MSAL (should succeed)
         final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
             @Override
             public void handleUserInteraction() {
@@ -82,23 +80,6 @@ public class TestCase938383 extends AbstractMsalUiTest {
         },TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
-
-        // change the time on the device
-        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
-
-        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
-
-        // start silent token request in MSAL
-        final MsalAuthTestParams authTestSilentParams = MsalAuthTestParams.builder()
-                .activity(mActivity)
-                .loginHint(username)
-                .scopes(Arrays.asList(mScopes))
-                .authority(account.getAuthority())
-                .msalConfigResourceId(getConfigFileResourceId())
-                .build();
-
-        final MsalAuthResult authSilentResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT);
-        authSilentResult.assertSuccess();
     }
 
     @Override
@@ -120,11 +101,11 @@ public class TestCase938383 extends AbstractMsalUiTest {
 
     @Override
     public String getAuthority() {
-        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+        return "https://login.microsoftonline.us/common";
     }
 
     @Override
     public int getConfigFileResourceId() {
-        return R.raw.msal_config_instance_aware_common;
+        return R.raw.msal_config_default;
     }
 }


### PR DESCRIPTION
Added back the previously removed tests. I thought it was redundant, but it's not.  (796048, 796049)
They're the same tests, but one is with broker, and the others are without.

After adding back, I moved MSAL-Only USGov tests to testpass/msalonly/usgov

Added 2016158 as we'll need that test on both brokered and non-brokered scenario.