### PR TITLE
Add multi cloud DCF test to cover ICM

### DIFF
--- a/msal/src/test/res/raw/msal_arlington_config.json
+++ b/msal/src/test/res/raw/msal_arlington_config.json
@@ -1,0 +1,14 @@
+{
+  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "multiple_clouds_supported": true,
+  "broker_redirect_uri_registered": true,
+  "account_mode": "MULTIPLE",
+  "authorities" : [
+    {
+      "type": "AAD",
+      "authority_url": "https://login.microsoftonline.us/common"
+    }
+  ]
+}


### PR DESCRIPTION
Adding 2 cases 

First Case
1. Init PCA in WW
2. Init PCA in USGov
3. both PCA should return URL from its own cloud.

Second Case (gets from the latest IcM update)
1. Init PCA in USGov
2. perform DCF
3. Init another PCA in USGov
4. the 2nd PCA should return USGov URI (but it returns WW. This is fixed in
 https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1820

----
https://portal.microsofticm.com/imp/v3/incidents/details/325344544/home