### PR TITLE
Cleaning up the CodeOwners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,29 +4,14 @@
 # Repo Code Owners
 #--------------------
 
-*       @AdamBJohnsonx @AzureAD/androidleads @rpdome @shahzaibj @shoatman
+*       @AzureAD/androididentity
 
 
 # Area Owners
 #---------------------
 
-# Automation
-/msalautomationapp/                                                                 @shahzaibj @rpdome
-/msal/src/test/                                                                     @shahzaibj @rpdome
-/msal/src/androidTest/                                                              @shahzaibj @rpdome
-
-# Build
-*.gradle                                                                            @shoatman @AdamBJohnsonx @shahzaibj
-
-# Docs
-/docs                                                                               @shahzaibj @AdamBJohnsonx 
-
-# PackageInspector
-/package-inspector                                                                  @AdamBJohnsonx @shahzaibj
-
-# Pipelines
-/azure-pipelines/                                                                   @shoatman @shahzaibj @p3dr0rv
-
-# PoP Benchmarker
-/pop-benchmarker                                                                    @shoatman @AdamBJohnsonx 
+# If you are interested in reviewing or getting notified of changes in a particular area
+# Please add your alias against that specific path below
+# Example:
+# /msalautomationapp/                                                                 @iamgusain 
 


### PR DESCRIPTION
Cleaning up the code owners and making @AzureAD/androididentity group as default code owner.