### PR TITLE
Adding intune app SDK, gradle plugin to MSAL project and updated MSAL…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,10 +8,21 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsMavenAccessToken
+            }
+        }
     }
 
     dependencies {
         classpath "com.android.tools.build:gradle:$rootProject.ext.gradleVersion"
+        classpath "org.javassist:javassist:${rootProject.ext.javaAssistVersion}"
+        classpath "com.microsoft.intune.mam:android-build-plugin:${rootProject.ext.intuneAppSdkVersion}"
     }
 }
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -43,6 +43,8 @@ ext {
     uiAutomatorVersion = "2.2.0"
     mseberaApacheHttpClientVersion = "4.5.8"
     msal4jVersion = "1.10.0"
+    intuneAppSdkVersion = "8.6.3"
+    javaAssistVersion = "3.27.0-GA"
 
     // TODO: adal automation test app.
     supportLibraryVersion = "27.1.+"

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,15 @@ pluginManagement {
          google()
          mavenCentral()
          gradlePluginPortal()
+         maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username vstsUsername
+                password vstsMavenAccessToken
+            }
+        }
      }
  }
 include ':msal', ':common', ':keyvault', ':labapi', ':testutils', ':pop-benchmarker',

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -23,7 +23,11 @@
  * // THE SOFTWARE.
  */
 
-apply plugin: 'com.android.application'
+
+plugins {
+    id "com.android.application"
+    id "com.microsoft.intune.mam"
+}
 
 def msalVersion = "4.+"
 
@@ -108,7 +112,14 @@ dependencies {
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
     implementation "com.google.android.material:material:$rootProject.ext.materialVersion"
+    implementation "com.microsoft.intune.mam:android-sdk:$rootProject.ext.intuneAppSdkVersion"
 
     compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
+}
+
+//https://docs.microsoft.com/en-us/mem/intune/developer/app-sdk-android
+intunemam {
+    verify = true
+    incremental = true //Experimental
 }

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
 
     <application
         android:networkSecurityConfig="@xml/network_security_config"
-        android:name="com.microsoft.identity.client.testapp.MsalSampleApp"
+        android:name="com.microsoft.intune.mam.client.app.MAMApplication"
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"


### PR DESCRIPTION
First step in adding Intune App Protection SDK to the MSAL Test app is adding the references for it and the supporting gradle plugin to the MSAL root project and the MSAL test app project.  

To read more about how Intune App SDK is integrated with an Android App please refer to: https://docs.microsoft.com/en-us/mem/intune/developer/app-sdk-android