### PR TITLE
Updating the single account cache before notifying the caller of account change/load via callback.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
+- [PATCH] Updating the single account cache before notifying the caller of account change/load via callback. (#1688)
 - [MINOR] Added keyboard flag to configChanges in Manifest for YubiKey compatibility. (#1685)
 
 Version 4.0.1


### PR DESCRIPTION
### What
Updating the single account cache before notifying the caller of account change/load via callback.

### Why
We should update the single account cache, before calling the call back, as we don't own the callback code so it might fail/throw, which might result in we not able to update the cache. Another example is if the callback executes some code that assuming the current account has been updated, that might fail. So, it is best to first update the cache and then notify the caller via callbacks in the end.

### How
Moving the code to persist current account to cache before the notification via callback to the caller

### Testing
Verified using Azure Sample app locally by mimicking both cases as described in the why section.