### PR TITLE
Add new exception type for broker protocol not supported exception during msal-broker handshake

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
+- [MINOR] Add new exception type for broker protocol not supported exception during msal-broker handshake (#1703)
 
 Version 4.0.2
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -200,6 +200,8 @@ dependencies {
     implementation "cz.msebera.android:httpclient:$rootProject.ext.mseberaApacheHttpClientVersion"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
 
+    compileOnly 'com.github.spotbugs:spotbugs-annotations:4.3.0'
+
     compileOnly "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
     annotationProcessor "org.projectlombok:lombok:$rootProject.ext.lombokVersion"
 

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUnsupportedBrokerException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUnsupportedBrokerException.java
@@ -1,0 +1,46 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.client.exception;
+
+import com.microsoft.identity.common.java.exception.UnsupportedBrokerException;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
+
+/**
+ * Representing all exceptions that occur due to unsupported/incompatible broker.
+ */
+@Getter
+@Accessors(prefix = "m")
+public class MsalUnsupportedBrokerException extends MsalException {
+
+    @NonNull
+    private final String mActiveBrokerPackageName;
+
+    public MsalUnsupportedBrokerException(@NonNull final UnsupportedBrokerException exception){
+        super(exception.getErrorCode(), exception.getMessage());
+        mActiveBrokerPackageName = exception.getActiveBrokerPackageName();
+    }
+}

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUnsupportedBrokerException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUnsupportedBrokerException.java
@@ -23,8 +23,10 @@
 
 package com.microsoft.identity.client.exception;
 
+import com.microsoft.identity.common.java.constants.SpotbugsWarning;
 import com.microsoft.identity.common.java.exception.UnsupportedBrokerException;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
@@ -39,6 +41,8 @@ public class MsalUnsupportedBrokerException extends MsalException {
     @NonNull
     private final String mActiveBrokerPackageName;
 
+    @SuppressFBWarnings(value = SpotbugsWarning.RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE,
+            justification = "Lombok inserts more null checks than we need")
     public MsalUnsupportedBrokerException(@NonNull final UnsupportedBrokerException exception){
         super(exception.getErrorCode(), exception.getMessage());
         mActiveBrokerPackageName = exception.getActiveBrokerPackageName();

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
@@ -22,12 +22,15 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.internal.controllers;
 
+import static com.microsoft.identity.common.java.exception.ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE;
+
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.exception.MsalIntuneAppProtectionPolicyRequiredException;
 import com.microsoft.identity.client.exception.MsalServiceException;
 import com.microsoft.identity.client.exception.MsalUiRequiredException;
+import com.microsoft.identity.client.exception.MsalUnsupportedBrokerException;
 import com.microsoft.identity.client.exception.MsalUserCancelException;
 import com.microsoft.identity.common.java.exception.ArgumentException;
 import com.microsoft.identity.common.java.exception.BaseException;
@@ -35,54 +38,64 @@ import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.exception.IntuneAppProtectionPolicyRequiredException;
 import com.microsoft.identity.common.java.exception.ServiceException;
 import com.microsoft.identity.common.java.exception.UiRequiredException;
+import com.microsoft.identity.common.java.exception.UnsupportedBrokerException;
 import com.microsoft.identity.common.java.exception.UserCancelException;
 
 public class MsalExceptionAdapter {
 
     public static MsalException msalExceptionFromBaseException(final BaseException e) {
-        MsalException msalException = null;
-
         if (e instanceof MsalException) {
-            msalException = (MsalException) e;
-        } else if (e instanceof ClientException) {
+            return  (MsalException) e;
+        }
+
+        if (e instanceof ClientException) {
             final ClientException clientException = ((ClientException) e);
-            msalException = new MsalClientException(
+            return new MsalClientException(
                     clientException.getErrorCode(),
                     clientException.getMessage(),
                     clientException
             );
-        } else if (e instanceof ArgumentException) {
+        }
+
+        if (e instanceof ArgumentException) {
             final ArgumentException argumentException = ((ArgumentException) e);
-            msalException = new MsalArgumentException(
+            return new MsalArgumentException(
                     argumentException.getArgumentName(),
                     argumentException.getOperationName(),
                     argumentException.getMessage(),
                     argumentException
             );
-        } else if (e instanceof UiRequiredException) {
+        }
+
+        if (e instanceof UiRequiredException) {
             final UiRequiredException uiRequiredException = ((UiRequiredException) e);
-            msalException = new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
-        } else if (e instanceof IntuneAppProtectionPolicyRequiredException) {
-            msalException = new MsalIntuneAppProtectionPolicyRequiredException(
+            return new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
+        }
+
+        if (e instanceof IntuneAppProtectionPolicyRequiredException) {
+            return new MsalIntuneAppProtectionPolicyRequiredException(
                     (IntuneAppProtectionPolicyRequiredException) e
             );
-        } else if (e instanceof ServiceException) {
+        }
+
+        if (e instanceof UnsupportedBrokerException){
+            return new MsalUnsupportedBrokerException((UnsupportedBrokerException) e);
+        }
+
+        if (e instanceof ServiceException) {
             final ServiceException serviceException = ((ServiceException) e);
-            msalException = new MsalServiceException(
+            return new MsalServiceException(
                     serviceException.getErrorCode(),
                     serviceException.getMessage(),
                     serviceException.getHttpStatusCode(),
                     serviceException
             );
-        } else if (e instanceof UserCancelException) {
-            msalException = new MsalUserCancelException();
         }
 
-        if (msalException == null) {
-            msalException = new MsalClientException(MsalClientException.UNKNOWN_ERROR, e.getMessage(), e);
+        if (e instanceof UserCancelException) {
+            return new MsalUserCancelException();
         }
 
-        return msalException;
-
+        return new MsalClientException(MsalClientException.UNKNOWN_ERROR, e.getMessage(), e);
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/ShadowBrokerMsalControllerWithMockIpcStrategyReturningHandshakeFailure.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/ShadowBrokerMsalControllerWithMockIpcStrategyReturningHandshakeFailure.java
@@ -1,0 +1,53 @@
+package com.microsoft.identity.client.e2e.tests.mocked;
+
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.HELLO_ERROR_CODE;
+import static com.microsoft.identity.common.adal.internal.AuthenticationConstants.Broker.HELLO_ERROR_MESSAGE;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+
+import com.microsoft.identity.common.exception.BrokerCommunicationException;
+import com.microsoft.identity.common.internal.broker.ipc.BrokerOperationBundle;
+import com.microsoft.identity.common.internal.broker.ipc.IIpcStrategy;
+import com.microsoft.identity.common.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.common.java.exception.ErrorStrings;
+
+import org.robolectric.annotation.Implements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Implements(BrokerMsalController.class)
+public class ShadowBrokerMsalControllerWithMockIpcStrategyReturningHandshakeFailure {
+
+    public static final String MOCK_ACTIVE_BROKER_NAME = "MOCK_BROKER";
+
+    @VisibleForTesting
+    public String getActiveBrokerPackageName() {
+        return MOCK_ACTIVE_BROKER_NAME;
+    }
+
+    @NonNull
+    protected List<IIpcStrategy> getIpcStrategies(final Context applicationContext, final String activeBrokerPackageName) {
+        final List<IIpcStrategy> strategies = new ArrayList<>();
+        strategies.add(new IIpcStrategy() {
+            @Override
+            public Bundle communicateToBroker(@NonNull BrokerOperationBundle bundle) throws BrokerCommunicationException {
+                final Bundle errorBundle = new Bundle();
+                errorBundle.putString(HELLO_ERROR_CODE, ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE);
+                errorBundle.putString(HELLO_ERROR_MESSAGE, ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_MESSAGE);
+                return errorBundle;
+            }
+
+            @Override
+            public Type getType() {
+                return Type.CONTENT_PROVIDER;
+            }
+        });
+
+        return strategies;
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/ShadowMockMsalControllerFactory.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/ShadowMockMsalControllerFactory.java
@@ -1,0 +1,32 @@
+package com.microsoft.identity.client.e2e.tests.mocked;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.PublicClientApplicationConfiguration;
+import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.client.internal.controllers.MSALControllerFactory;
+import com.microsoft.identity.common.internal.controllers.BrokerMsalController;
+import com.microsoft.identity.common.internal.controllers.LocalMSALController;
+import com.microsoft.identity.common.java.authorities.Authority;
+import com.microsoft.identity.common.java.controllers.BaseController;
+
+import org.robolectric.annotation.Implements;
+
+@Implements(MSALControllerFactory.class)
+public class ShadowMockMsalControllerFactory {
+
+    public static boolean sRouteRequestToBrokerMsalController = false;
+
+    public static BaseController getDefaultController(@NonNull final Context applicationContext,
+                                                      @NonNull final Authority authority,
+                                                      @NonNull final PublicClientApplicationConfiguration applicationConfiguration)
+            throws MsalClientException {
+        if (sRouteRequestToBrokerMsalController){
+            return new BrokerMsalController(applicationContext);
+        } else {
+            return new LocalMSALController();
+        }
+    }
+}


### PR DESCRIPTION
When MSAL initialization fails due to a protocol handshake error, we will be returning an exception with enough info for the client app to show an actionable prompt to the customer. (i.e. update app XXXX)