### PR TITLE
Add UI test for "is_remote_login_required=true" showing DCF option (MSAL)

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
@@ -36,12 +36,12 @@ import org.junit.Test;
 // Check DCF Option UI (Join Tenant)
 // Currently, other broker apps do not have a way to call AcquireToken with the "is_remote_login_allowed=true" parameter
 // BrokerHost got a new button to facilitate this particular flow.
-// TODO: Tentative name, will update once an ADO Test Case is created
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2110359
 @SupportedBrokers(brokers = BrokerHost.class)
-public class TestCaseDcfUi extends AbstractMsalBrokerTest{
+public class TestCase2110359 extends AbstractMsalBrokerTest{
 
     @Test
-    public void test_dcfui() {
+    public void test_2110359() {
         BrokerHost brokerHost = (BrokerHost) mBroker;
 
         brokerHost.checkForDcfOption(null);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCaseDcfUi.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCaseDcfUi.java
@@ -1,0 +1,76 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.brokerapi;
+
+
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Test;
+
+// Check DCF Option UI (Join Tenant)
+// Currently, other broker apps do not have a way to call AcquireToken with the "is_remote_login_allowed=true" parameter
+// BrokerHost got a new button to facilitate this particular flow.
+// TODO: Tentative name, will update once an ADO Test Case is created
+@SupportedBrokers(brokers = BrokerHost.class)
+public class TestCaseDcfUi extends AbstractMsalBrokerTest{
+
+    @Test
+    public void test_dcfui() {
+        BrokerHost brokerHost = (BrokerHost) mBroker;
+
+        brokerHost.checkForDcfOption(null);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}


### PR DESCRIPTION
Work Item: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2096386

I created this Test Case: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2110359

Work to create an automated UI test to check that the "Sign in from another device" option shows up when we call acquire token with "is_remote_login_required=true" parameter.

MSAL PR is to add the new test case to check for the DCF option.

Related PRs
Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1862
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2023