### PR TITLE
Revert Azure Sample APK Name Change

### DIFF
--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -57,7 +57,7 @@ variables:
   brokerHostPipelineId: 1432
   msazureServiceConnection: AndroidBroker-CI
   msazureFeedName: Android-Broker
-  azureSampleApk: AzureSample-external-release.apk
+  azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
   oldBrokerHostApk: brokerHost-local-debug.apk
   firebaseTimeout: 45m

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -57,7 +57,7 @@ variables:
   brokerHostPipelineId: 1432
   msazureServiceConnection: AndroidBroker-CI
   msazureFeedName: Android-Broker
-  azureSampleApk: AzureSample-external-release.apk
+  azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
   oldBrokerHostApk: brokerHost-local-debug.apk
   firebaseTimeout: 45m

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -52,7 +52,7 @@ variables:
   azureSamplePipelineId: 1458
   msalAutomationAppApk: msalautomationapp-local-BrokerHost-debug.apk
   msalAutomationAppTestApk: msalautomationapp-local-BrokerHost-debug-androidTest.apk
-  azureSampleApk: AzureSample-external-release.apk
+  azureSampleApk: AzureSample-local-debug.apk
   firebaseTimeout: 45m
   resultsHistoryName: Dev MSAL without Broker
 


### PR DESCRIPTION
Test app pipelines were recently fixed, which caused the azure sample apk name to return to AzureSample-local-debug.apk. For a while it was AzureSample-external-release.apk due to a band-aid fix we did to get test app pipelines temporarily working.

Also update common.