### PR TITLE
Broker CI Pipeline: Add RetryOnFailure, RunOnApi29Minus, DoNotRunOnPipeline annotations, fix update scenario (MSAL)

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
@@ -54,7 +54,6 @@ import static com.microsoft.identity.client.e2e.utils.RoboTestUtils.flushSchedul
 
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowAndroidSdkStorageEncryptionManager.class, ShadowAuthority.class, ShadowPublicClientApplicationConfiguration.class})
-@Ignore("Ignoring this for now, unknown external error in B2C")
 public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest implements IAcquireTokenNetworkTest {
 
     private String mUsername;
@@ -71,6 +70,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
+    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSuccess() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -85,6 +85,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
+    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSuccessFollowedBySilentSuccess() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -109,6 +110,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
+    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentSuccessForceRefresh() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -133,6 +135,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
+    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentFailureEmptyCache() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -160,6 +163,7 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
+    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentSuccessCacheWithNoAccessToken() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.internal.testutils.labutils.LabUserHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -53,6 +54,7 @@ import static com.microsoft.identity.client.e2e.utils.RoboTestUtils.flushSchedul
 
 @RunWith(RobolectricTestRunner.class)
 @Config(shadows = {ShadowAndroidSdkStorageEncryptionManager.class, ShadowAuthority.class, ShadowPublicClientApplicationConfiguration.class})
+@Ignore("Ignoring this for now, unknown external error in B2C")
 public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest implements IAcquireTokenNetworkTest {
 
     private String mUsername;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561136.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561136.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.List;
 
-// TODO: This is sometime failing at the registration step (DRS Device Registration Failed)
 // Get Broker Accounts
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561136
 @SupportedBrokers(brokers = BrokerHost.class)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
@@ -27,18 +27,18 @@ import androidx.test.uiautomator.UiObject;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 // Invoke each API from non-allowed apps. the request should be blocked.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1600567
-@Ignore("Calling App Not Verified error is not showing up on pipeline (works locally)")
+@UnreliableOnPipeline("'Calling App Not Verified' error only on pipeline")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1600567 extends AbstractMsalBrokerTest {
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
@@ -27,18 +27,17 @@ import androidx.test.uiautomator.UiObject;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Test;
 
 // Invoke each API from non-allowed apps. the request should be blocked.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1600567
-@UnreliableOnPipeline("'Calling App Not Verified' error only on pipeline")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1600567 extends AbstractMsalBrokerTest {
     @Test
@@ -48,6 +47,7 @@ public class TestCase1600567 extends AbstractMsalBrokerTest {
         brokerHost.launch();
 
         // verify getAccounts call gives calling app not verified
+        UiAutomatorUtils.obtainChildInScrollable("Get Accounts");
         UiAutomatorUtils.handleButtonClick("com.microsoft.identity.testuserapp:id/buttonGetAccounts");
         brokerHost.confirmCallingAppNotVerified();
 
@@ -84,12 +84,14 @@ public class TestCase1600567 extends AbstractMsalBrokerTest {
 
     @Override
     public LabQuery getLabQuery() {
-        return null;
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return TempUserType.BASIC;
+        return null;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -33,8 +33,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -59,7 +59,7 @@ import java.util.Collection;
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420494
 @RetryOnFailure(retryCount = 2)
 @RunWith(Parameterized.class)
-@UnreliableOnPipeline
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.client.msal.automationapp.testpass.broker.Abstract
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -47,7 +48,6 @@ import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.json.JSONObject;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -59,7 +59,7 @@ import java.util.Collection;
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420494
 @RetryOnFailure(retryCount = 2)
 @RunWith(Parameterized.class)
-@Ignore("This test case seems to be inconsistent on pipeline")
+@UnreliableOnPipeline
 public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.json.JSONObject;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,6 +59,7 @@ import java.util.Collection;
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420494
 @RetryOnFailure(retryCount = 2)
 @RunWith(Parameterized.class)
+@Ignore("This test case seems to be pretty inconsistent")
 public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
@@ -115,9 +117,9 @@ public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
         // Acquire token silently
         MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);
-        Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
+        Assert.assertFalse("Verify accessToken is empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
 
-        Assert.assertNotEquals("Silent request gets new access token", acquireTokenSilentResult.getAccessToken(), acquireTokenResult.getAccessToken());
+        Assert.assertNotEquals("Silent request does not return a new access token", acquireTokenSilentResult.getAccessToken(), acquireTokenResult.getAccessToken());
 
         final JSONObject profileObject = getProfileObjectFromMSGraph(acquireTokenSilentResult.getAccessToken());
         Assert.assertEquals(userName, profileObject.get("mail"));

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -114,7 +114,7 @@ public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenResult.getAccessToken()));
 
         // change the time on the device (without resetting to automatic time zone)
-        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTime(TimeUnit.DAYS.toSeconds(1), false);
+        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
 
         // Acquire token silently
         MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -59,7 +59,7 @@ import java.util.Collection;
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420494
 @RetryOnFailure(retryCount = 2)
 @RunWith(Parameterized.class)
-@Ignore("This test case seems to be pretty inconsistent")
+@Ignore("This test case seems to be inconsistent on pipeline")
 public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
@@ -117,7 +117,7 @@ public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
         // Acquire token silently
         MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);
-        Assert.assertFalse("Verify accessToken is empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
+        Assert.assertFalse("AccessToken is empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
 
         Assert.assertNotEquals("Silent request does not return a new access token", acquireTokenSilentResult.getAccessToken(), acquireTokenResult.getAccessToken());
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1420494.java
@@ -54,6 +54,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.concurrent.TimeUnit;
 
 // Acquire token for cross cloud guest account (with broker)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420494
@@ -112,8 +113,8 @@ public class TestCase1420494 extends AbstractGuestAccountMsalBrokerUiTest {
 
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenResult.getAccessToken()));
 
-        // change the time on the device
-        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
+        // change the time on the device (without resetting to automatic time zone)
+        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTime(TimeUnit.DAYS.toSeconds(1), false);
 
         // Acquire token silently
         MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
@@ -56,7 +56,8 @@ import java.util.Collection;
 // Acquire Token from Cross Cloud after acquiring token from home cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592465
 @RunWith(Parameterized.class)
-@RetryOnFailure(retryCount = 2)
+// This test case is still unreliable, but it's quick. Adding more retries.
+@RetryOnFailure(retryCount = 5)
 public class TestCase1592465 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
@@ -122,12 +123,12 @@ public class TestCase1592465 extends AbstractGuestAccountMsalBrokerUiTest {
         Assert.assertNotNull("Verify Exception is returned", exception);
         Assert.assertEquals("Verify Exception operation name", "authority", exception.getOperationName());
 
-        ThreadUtils.sleepSafely(3000, "Sleep failed", "Interrrupted");
+        ThreadUtils.sleepSafely(3000, "Sleep failed", "Interrupted");
 
         // Acquire token interactively from cross cloud, expected to get a new access token
         // TODO: Is it expected for this to not ask for credentials?
         final OnInteractionRequired crossCloudInteractionHandler = () -> { };
-        final MsalAuthResult acquireTokenCrossCloudResult = msalSdk.acquireTokenInteractive(acquireTokenCrossCloudAuthParams, crossCloudInteractionHandler, TokenRequestTimeout.SHORT);
+        final MsalAuthResult acquireTokenCrossCloudResult = msalSdk.acquireTokenInteractive(acquireTokenCrossCloudAuthParams, crossCloudInteractionHandler, TokenRequestTimeout.SILENT);
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenCrossCloudResult.getAccessToken()));
 
         Assert.assertNotEquals("CrossCloud request gets new access token", acquireTokenCrossCloudResult.getAccessToken(), acquireTokenHomeCloudResult.getAccessToken());

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
@@ -56,8 +56,7 @@ import java.util.Collection;
 // Acquire Token from Cross Cloud after acquiring token from home cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592465
 @RunWith(Parameterized.class)
-// This test case is still unreliable, but it's quick. Adding more retries.
-@RetryOnFailure(retryCount = 5)
+@RetryOnFailure(retryCount = 2)
 public class TestCase1592465 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
@@ -126,7 +125,7 @@ public class TestCase1592465 extends AbstractGuestAccountMsalBrokerUiTest {
         ThreadUtils.sleepSafely(3000, "Sleep failed", "Interrupted");
 
         // Acquire token interactively from cross cloud, expected to get a new access token
-        // TODO: Is it expected for this to not ask for credentials?
+        // We expect that this does not prompt for credentials
         final OnInteractionRequired crossCloudInteractionHandler = () -> { };
         final MsalAuthResult acquireTokenCrossCloudResult = msalSdk.acquireTokenInteractive(acquireTokenCrossCloudAuthParams, crossCloudInteractionHandler, TokenRequestTimeout.SILENT);
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenCrossCloudResult.getAccessToken()));

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592465.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -46,7 +47,6 @@ import com.microsoft.identity.labapi.utilities.constants.SignInAudience;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -57,7 +57,7 @@ import java.util.Collection;
 // Acquire Token from Cross Cloud after acquiring token from home cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592465
 @RunWith(Parameterized.class)
-@Ignore("Ignoring this as device on pipeline is not prompting for credentials in the second request")
+@UnreliableOnPipeline("Device on pipeline is not prompting for credentials in the second request")
 public class TestCase1592465 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592468.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592468.java
@@ -24,8 +24,6 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.crosscl
 
 import android.text.TextUtils;
 
-import com.microsoft.identity.client.ITenantProfile;
-import com.microsoft.identity.client.MultiTenantAccount;
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
@@ -33,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -45,7 +44,6 @@ import com.microsoft.identity.labapi.utilities.constants.GuestHomeAzureEnvironme
 import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -60,6 +58,7 @@ import androidx.annotation.NonNull;
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592468
 @RetryOnFailure(retryCount = 2)
 @RunWith(Parameterized.class)
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1592468 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
@@ -124,8 +124,8 @@ public class TestCase1592510 extends AbstractGuestAccountMsalBrokerUiTest {
         Assert.assertNotNull("Verify Exception is returned", exception);
         Assert.assertEquals("Verify Exception operation name", "authority", exception.getOperationName());
 
-        // TODO: This is now not prompting for ui, what is the expected behavior???
         // Acquire token interactively from home cloud, expected to get a different access token
+        // We are expecting that this does not prompt for credentials
         final OnInteractionRequired homeCloudInteractionHandler = () -> { };
         final MsalAuthResult acquireTokenHOmeCloudResult = msalSdk.acquireTokenInteractive(acquireTokenHomeCloudAuthParams, homeCloudInteractionHandler, TokenRequestTimeout.SHORT);
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenHOmeCloudResult.getAccessToken()));

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -45,7 +46,6 @@ import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -56,7 +56,7 @@ import java.util.Collection;
 // Acquire Token from home cloud after acquiring token from cross cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592510
 @RunWith(Parameterized.class)
-@Ignore("Ignoring this as device on pipeline is not prompting for credentials in the second request")
+@UnreliableOnPipeline("Device on pipeline is not prompting for credentials in the second request")
 public class TestCase1592510 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
@@ -56,6 +57,7 @@ import java.util.Collection;
 // Acquire Token from home cloud after acquiring token from cross cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592510
 @RunWith(Parameterized.class)
+@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Keep me signed in")
 public class TestCase1592510 extends AbstractGuestAccountMsalBrokerUiTest {
 
@@ -122,17 +124,9 @@ public class TestCase1592510 extends AbstractGuestAccountMsalBrokerUiTest {
         Assert.assertNotNull("Verify Exception is returned", exception);
         Assert.assertEquals("Verify Exception operation name", "authority", exception.getOperationName());
 
+        // TODO: This is now not prompting for ui, what is the expected behavior???
         // Acquire token interactively from home cloud, expected to get a different access token
-        final OnInteractionRequired homeCloudInteractionHandler = () -> {
-            final PromptHandlerParameters promptHandlerParameters =
-                    PromptHandlerParameters.builder()
-                    .prompt(PromptParameter.SELECT_ACCOUNT)
-                    .loginHint(userName)
-                    .broker(mBroker)
-                    .build();
-            final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
-            promptHandler.handlePrompt(userName, password);
-        };
+        final OnInteractionRequired homeCloudInteractionHandler = () -> { };
         final MsalAuthResult acquireTokenHOmeCloudResult = msalSdk.acquireTokenInteractive(acquireTokenHomeCloudAuthParams, homeCloudInteractionHandler, TokenRequestTimeout.SHORT);
         Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenHOmeCloudResult.getAccessToken()));
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1592510.java
@@ -33,7 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -56,7 +56,7 @@ import java.util.Collection;
 // Acquire Token from home cloud after acquiring token from cross cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1592510
 @RunWith(Parameterized.class)
-@UnreliableOnPipeline("Device on pipeline is not prompting for credentials in the second request")
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1592510 extends AbstractGuestAccountMsalBrokerUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833513
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
 @RetryOnFailure(retryCount = 2)
+@RunOnAPI29Minus("Checking for text error in WebView")
 public class TestCase833513 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, only account from the same tenant should be able to acquire token.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833513
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 @RunOnAPI29Minus("Checking for text error in WebView")
 public class TestCase833513 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, an account signed in through App A can be used by App B.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833514
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 @RunOnAPI29Minus("Azure Sample App")
 public class TestCase833514 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.client.msal.automationapp.testpass.broker.Abstract
 import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
@@ -60,6 +61,7 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833514
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
 @RetryOnFailure(retryCount = 2)
+@RunOnAPI29Minus("Azure Sample App")
 public class TestCase833514 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, global sign out should work.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-//@RetryOnFailure(retryCount = 2)
+@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Azure Sample App")
 public class TestCase833515 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
@@ -61,6 +62,7 @@ import java.util.concurrent.TimeUnit;
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
 @RetryOnFailure
 @RunOnAPI29Minus("Azure Sample App")
+@DoNotRunOnPipeline("This test is failing on pipeline at various points. Most commonly, getting 'an account is already signed in' when calling SAPCA.signIn()")
 public class TestCase833515 extends AbstractMsalBrokerTest {
 
     final static String MY_APPS_URL = "myapps.microsoft.com";

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -59,7 +59,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, global sign out should work.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 @RunOnAPI29Minus("Azure Sample App")
 public class TestCase833515 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -47,6 +47,7 @@ import com.microsoft.identity.labapi.utilities.client.ILabAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserRole;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
 import com.microsoft.identity.labapi.utilities.exception.LabApiException;
 
 import org.junit.Assert;
@@ -58,7 +59,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, global sign out should work.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+//@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Azure Sample App")
 public class TestCase833515 extends AbstractMsalBrokerTest {
 
@@ -90,9 +91,14 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         Assert.assertTrue(mApplication.isSharedDevice());
 
         // fetching a new temp user from lab account
-        final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
+        final LabQuery labQuery = LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .build();
+
+        final ILabAccount labAccount = mLabClient.getLabAccount(labQuery);
         final String username2 = labAccount.getUsername();
         final String password2 = labAccount.getPassword();
+        Thread.sleep(TimeUnit.SECONDS.toMillis(30));
 
         Assert.assertNotEquals(username1, username2);
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -22,7 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.flw;
 
-import androidx.test.uiautomator.UiObject;
 import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SignInParameters;
@@ -33,6 +32,7 @@ import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
@@ -59,6 +59,7 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
 @RetryOnFailure(retryCount = 2)
+@RunOnAPI29Minus("Azure Sample App")
 public class TestCase833515 extends AbstractMsalBrokerTest {
 
     final static String MY_APPS_URL = "myapps.microsoft.com";
@@ -92,7 +93,6 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
         final String username2 = labAccount.getUsername();
         final String password2 = labAccount.getPassword();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(30));
 
         Assert.assertNotEquals(username1, username2);
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833516.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833516.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
@@ -54,6 +55,7 @@ import java.util.Arrays;
 // End My Shift - In Shared device mode, there can be only one sign-in account.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833516
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
+@RetryOnFailure(retryCount = 2)
 public class TestCase833516 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Joined][MSAL] Password Change
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561151
 @RetryOnFailure(retryCount = 2)
+@Ignore("Password reset case, This test is inconsistent and takes very long")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Joined][MSAL] Password Change
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561151
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is inconsistent and takes very long")
+@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.client.msal.automationapp.testpass.broker.Abstract
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -40,7 +41,6 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Joined][MSAL] Password Change
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561151
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
+@UnreliableOnPipeline("Password reset case, This test is pipeline inconsistent and takes very long")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -31,13 +31,12 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
-import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
@@ -49,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 // [Joined][MSAL] Password Change
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561151
 @RetryOnFailure(retryCount = 2)
-@UnreliableOnPipeline("Password reset case, This test is pipeline inconsistent and takes very long")
+@DoNotRunOnPipeline("Password reset case, this test takes very long")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151() throws Throwable {
@@ -149,14 +148,12 @@ public class TestCase1561151 extends AbstractMsalBrokerTest {
 
     @Override
     public LabQuery getLabQuery() {
-        return LabQuery.builder()
-                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
-                .build();
+        return null;
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return null;
+        return TempUserType.BASIC;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -31,7 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
+import com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -47,8 +47,8 @@ import java.util.concurrent.TimeUnit;
 
 // [Joined][MSAL] Password Change
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561151
-@RetryOnFailure(retryCount = 2)
-@DoNotRunOnPipeline("Password reset case, this test takes very long")
+@RetryOnFailure
+@LongUIAutomationTest("Password reset test")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561171.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561171.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -42,6 +43,7 @@ import java.util.Arrays;
 
 // [Joined][MSAL] Prompt.LOGIN
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561171
+@RetryOnFailure(retryCount = 2)
 public class TestCase1561171 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561171() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase796050.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase796050.java
@@ -41,7 +41,9 @@ import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadP
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import com.microsoft.identity.labapi.utilities.client.ILabAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -57,7 +59,6 @@ public class TestCase796050 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_796050() throws Throwable {
-        // already created test user
         final String username1 = mLabAccount.getUsername();
         final String password1 = mLabAccount.getPassword();
 
@@ -151,12 +152,15 @@ public class TestCase796050 extends AbstractMsalBrokerTest {
 
     @Override
     public LabQuery getLabQuery() {
-        return null;
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .protectionPolicy(ProtectionPolicy.MAM_CA)
+                .build();
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return TempUserType.MAM_CA;
+        return null;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
@@ -104,7 +104,6 @@ public class TestCase832430 extends AbstractMsalBrokerTest {
 
         //forwarding time 1 day
         TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(30));
 
         // acquiring token silently after expiring AT
         final MsalAuthTestParams refreshTokenParams = MsalAuthTestParams.builder()

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 
 // [Joined][MSAL] Acquire Token + Acquire Token Silent with resource (Prompt.SELECT_ACCOUNT)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/832430
+@RetryOnFailure(retryCount = 2)
 public class TestCase832430 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -30,7 +30,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
+import com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -46,8 +46,8 @@ import java.util.concurrent.TimeUnit;
 
 // [MSAL] password reset for MAM_CA account
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850457
-@RetryOnFailure(retryCount = 2)
-@DoNotRunOnPipeline("Password reset case, this test takes very long")
+@RetryOnFailure
+@LongUIAutomationTest("Password reset test")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 // [MSAL] password reset for MAM_CA account
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850457
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is inconsistent and takes very long")
+@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.testpass.broker.Abstract
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -38,7 +39,6 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 // [MSAL] password reset for MAM_CA account
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850457
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
+@UnreliableOnPipeline("Password reset case, This test is pipeline inconsistent and takes very long")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -30,8 +30,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 // [MSAL] password reset for MAM_CA account
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850457
 @RetryOnFailure(retryCount = 2)
-@UnreliableOnPipeline("Password reset case, This test is pipeline inconsistent and takes very long")
+@DoNotRunOnPipeline("Password reset case, this test takes very long")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -46,6 +47,7 @@ import java.util.concurrent.TimeUnit;
 // [MSAL] password reset for MAM_CA account
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850457
 @RetryOnFailure(retryCount = 2)
+@Ignore("Password reset case, This test is inconsistent and takes very long")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.testpass.broker.Abstract
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -41,7 +42,6 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-Joined][MSAL] Password Change (bad_token)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1561152
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
+@UnreliableOnPipeline("Password reset case, this test is pipeline inconsistent and takes very long")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -32,8 +32,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.annotations.UnreliableOnPipeline;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-Joined][MSAL] Password Change (bad_token)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1561152
 @RetryOnFailure(retryCount = 2)
-@UnreliableOnPipeline("Password reset case, this test is pipeline inconsistent and takes very long")
+@DoNotRunOnPipeline("Password reset case, this test takes very long")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -49,7 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-Joined][MSAL] Password Change (bad_token)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1561152
 @RetryOnFailure(retryCount = 2)
-@Ignore("Password reset case, This test is inconsistent and takes very long")
+@Ignore("Password reset case, This test is pipeline inconsistent and takes very long")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -48,6 +49,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-Joined][MSAL] Password Change (bad_token)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1561152
 @RetryOnFailure(retryCount = 2)
+@Ignore("Password reset case, This test is inconsistent and takes very long")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -32,7 +32,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
+import com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -48,8 +48,8 @@ import java.util.concurrent.TimeUnit;
 
 // [Non-Joined][MSAL] Password Change (bad_token)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1561152
-@RetryOnFailure(retryCount = 2)
-@DoNotRunOnPipeline("Password reset case, this test takes very long")
+@RetryOnFailure
+@LongUIAutomationTest("Password reset test")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561169.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561169.java
@@ -36,6 +36,7 @@ import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Test;
 
@@ -112,12 +113,14 @@ public class TestCase1561169 extends AbstractMsalBrokerTest {
 
     @Override
     public LabQuery getLabQuery() {
-        return null;
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .build();
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return TempUserType.BASIC;
+        return null;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1600592.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1600592.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -46,6 +47,7 @@ import java.util.Arrays;
 // [Non-joined] A single-tenant app makes a silent request with common authority. It should fail.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/1600592
 @RetryOnFailure(retryCount = 2)
+@RunOnAPI29Minus("Consent Page")
 public class TestCase1600592 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase497069.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase497069.java
@@ -35,8 +35,8 @@ import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerPara
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
-import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Test;
 
@@ -114,7 +114,7 @@ public class TestCase497069 extends AbstractMsalBrokerTest {
     @Override
     public LabQuery getLabQuery() {
         return LabQuery.builder()
-                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .userType(UserType.CLOUD)
                 .build();
     }
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase850455.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase850455.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -41,6 +42,7 @@ import org.junit.Test;
 
 // [Non-joined][MSAL] Acquire Token + Acquire Token Silent (Prompt.SELECT_ACCOUNT)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850455
+@RetryOnFailure(retryCount = 2)
 public class TestCase850455 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561079.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561079.java
@@ -51,7 +51,7 @@ import java.util.Arrays;
 // [WPJ] - Get Device ID
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561079
 // TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore
+@Ignore("PROD/Rc BrokerHosts not available at the moment")
 @RetryOnFailure(retryCount = 2)
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561079 extends AbstractMsalBrokerTest {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561079.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561079.java
@@ -50,8 +50,7 @@ import java.util.Arrays;
 
 // [WPJ] - Get Device ID
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561079
-// TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore("PROD/Rc BrokerHosts not available at the moment")
+@Ignore("This is failing. This test will be turned into Component Test")
 @RetryOnFailure(retryCount = 2)
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561079 extends AbstractMsalBrokerTest {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561080.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561080.java
@@ -54,7 +54,7 @@ import java.util.Arrays;
 // [WPJ] Get device state
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561080
 // TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore("Chrome Automation is inconsistent")
+@Ignore("PROD/Rc BrokerHosts not available at the moment, Chrome Automation is inconsistent")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561080 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561080.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561080.java
@@ -53,8 +53,7 @@ import java.util.Arrays;
 
 // [WPJ] Get device state
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561080
-// TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore("PROD/Rc BrokerHosts not available at the moment, Chrome Automation is inconsistent")
+@Ignore("This is failing. This test will be turned into Component Test")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561080 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561081.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561081.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 // [WPJ] WPJ Leave
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561081
 // TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore("Chrome Automation is very inconsistent")
+@Ignore("PROD/Rc BrokerHosts not available at the moment, Chrome Automation is very inconsistent")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561081 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561081.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase1561081.java
@@ -56,8 +56,7 @@ import java.util.concurrent.TimeUnit;
 
 // [WPJ] WPJ Leave
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561081
-// TODO: Revisit once we can pull Prod/RC Brokerhost APKs from pipelines
-@Ignore("PROD/Rc BrokerHosts not available at the moment, Chrome Automation is very inconsistent")
+@Ignore("This is failing. This test will be turned into Component Test")
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 public class TestCase1561081 extends AbstractMsalBrokerTest {
 
@@ -108,7 +107,7 @@ public class TestCase1561081 extends AbstractMsalBrokerTest {
         //this gets the deviceId from the Ui and matches it to the deviceID obtained from the AT
         getAndConfirmDeviceIdFromMyAccount(deviceId, username, password, true);
 
-        //init the release candidate BrokerHost in order to run wpj Leave
+        // init the release candidate BrokerHost in order to run wpj Leave
         // Install BrokerHost.apk
         BrokerHost brokerHost = new BrokerHost(BrokerHost.BROKER_HOST_APK_RC);
         if(brokerHost.isInstalled()){

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -44,6 +45,7 @@ import java.util.Arrays;
 
 // [MSAL-Only] A single-tenant app makes a silent request with common authority. It should fail..
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/2016158
+@RunOnAPI29Minus("Consent Page")
 public class TestCase2016158 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497038.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497038.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -45,6 +46,7 @@ import java.util.Arrays;
 
 // Cross Apps SSO with System Browser
 // https://identitydivision.visualstudio.com/DefaultCollection/DevEx/_workitems/edit/497038
+@RunOnAPI29Minus("Consent Page")
 public class TestCase497038 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
@@ -43,6 +44,7 @@ import java.util.Arrays;
 
 // Interactive Auth with select_account (no consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99267
+@RunOnAPI29Minus("Consent Page")
 public class TestCase99267 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99274.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99274.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.UiResponse;
@@ -43,6 +44,7 @@ import java.util.Arrays;
 
 // Interactive Auth with select_account (with consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99274
+@RunOnAPI29Minus("Consent Page")
 public class TestCase99274 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99652.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99652.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -43,6 +44,7 @@ import java.util.Arrays;
 
 // Interactive auth with force_login for managed account (with consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99652
+@RunOnAPI29Minus("Consent Page")
 public class TestCase99652 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1420484.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1420484.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.app.IApp;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
@@ -57,6 +58,7 @@ import java.util.Collection;
 // [CrossCloud] Acquire token (Interactive and silent) for cross cloud guest account (Msal Only)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1420484
 @RunWith(Parameterized.class)
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1420484 extends AbstractGuestAccountMsalUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616315.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616315.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -55,6 +56,7 @@ import java.util.Collection;
 // [CrossCloud] AcquireToken from Cross/foreign Cloud after acquiring token from home cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1616315
 @RunWith(Parameterized.class)
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1616315 extends AbstractGuestAccountMsalUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616316.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616316.java
@@ -33,6 +33,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
+import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -54,6 +56,7 @@ import java.util.Collection;
 // [CrossCloud] AcquireToken from home Cloud after acquiring token from cross/foreign cloud
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/1616315
 @RunWith(Parameterized.class)
+@RunOnAPI29Minus("Keep me signed in")
 public class TestCase1616316 extends AbstractGuestAccountMsalUiTest {
 
     private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
@@ -85,7 +88,7 @@ public class TestCase1616316 extends AbstractGuestAccountMsalUiTest {
                     PromptHandlerParameters.builder()
                             .prompt(PromptParameter.SELECT_ACCOUNT)
                             .loginHint(userName)
-                            .staySignedInPageExpected(true)
+                            .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
                             .speedBumpExpected(true)
                             .build();
             final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);


### PR DESCRIPTION
This PR adds in new annotations from common. This will help seperate tests into an optimal run state on the Broker CI Pipeline. Most changes in this PR are to add one or two lines of code to annotate the tests.

This PR should be reviewed after going through the Common and Android-Complete. Can be reviewed at the same time as the Broker PR.
Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1875
Android-Complete: https://github.com/AzureAD/android-complete/pull/161
Broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2031