### PR TITLE
Remove Schedules from MSAL UI Pipeline YMLs, add Multi-API Testing Support.

### DIFF
--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -23,6 +23,10 @@ parameters:
     displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
+  - name: flankShards
+    displayName: Max Number of Flank Shards
+    type: number
+    default: 2
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
@@ -107,7 +111,7 @@ stages:
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
     jobs:
       - template: ./templates/flank/run-on-firebase-with-flank.yml
         parameters:
@@ -121,14 +125,15 @@ stages:
           resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
           apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+          flankShards: ${{ parameters.flankShards }}
   # MSAL with Broker Test Plan stage (API 29-)
   - stage: 'msal_with_broker_low_api'
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
     jobs:
       - template: ./templates/run-on-firebase.yml
         parameters:
@@ -142,5 +147,5 @@ stages:
           resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
           apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -44,103 +44,103 @@ variables:
   firebaseTimeout: 45m
 
 stages:
-# msalautomationapp
-- stage: 'msalautomationapp'
-  displayName: Build MSAL Automation APKs
-  jobs:
-    - template: ./templates/build-msal-automation-app.yml
-      parameters:
-        brokerFlavor: BrokerHost
-        msalFlavor: Local
-        brokerSource: LocalApk
-# Brokers
-- stage: 'brokers'
-  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  displayName: Brokers and Azure Sample APKs
-  jobs:
-    - job: 'download_brokers'
-      displayName: Download Brokers
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - checkout: none
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download latest Azure Sample'
-          inputs:
-            buildType: 'specific'
-            project: '$(engineeringProjectId)'
-            definition: '$(azureSamplePipelineId)'
-            artifactName: AzureSample
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-            buildVersionToDownload: 'latest'
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download Broker Host'
-          inputs:
-            buildType: specific
-            project: '$(engineeringProjectId)'
-            definition: '$(brokerHostPipelineId)'
-            artifactName: BrokerHost
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-        - task: UniversalPackages@0
-          displayName: 'Download old brokerHost version from feed'
-          inputs:
-            command: 'download'
-            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
-            feedsToUse: 'external'
-            externalFeedCredentials: '$(msazureServiceConnection)'
-            feedDownloadExternal: '$(msazureFeedName)'
-            packageDownloadExternal: 'broker-host'
-            versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
-        - publish: $(Build.ArtifactStagingDirectory)/azureSample
-          displayName: 'Publish Azure Sample apk for later use'
-          artifact: azureSample
-        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-          displayName: 'Publish Broker Host apk for later use'
-          artifact: brokerHost
-        - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
-          displayName: 'Publish Broker Host old apk for later use'
-          artifact: oldBrokerHost
-# MSAL with Broker Test Plan stage (API 30+)
-- stage: 'msal_with_broker_high_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
-  jobs:
-    - template: ./templates/flank/run-on-firebase-with-flank.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Dev BrokerHost"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-# MSAL with Broker Test Plan stage (API 29-)
-- stage: 'msal_with_broker_low_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Dev BrokerHost"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # msalautomationapp
+  - stage: 'msalautomationapp'
+    displayName: Build MSAL Automation APKs
+    jobs:
+      - template: ./templates/build-msal-automation-app.yml
+        parameters:
+          brokerFlavor: BrokerHost
+          msalFlavor: Local
+          brokerSource: LocalApk
+  # Brokers
+  - stage: 'brokers'
+    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+    displayName: Brokers and Azure Sample APKs
+    jobs:
+      - job: 'download_brokers'
+        displayName: Download Brokers
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download latest Azure Sample'
+            inputs:
+              buildType: 'specific'
+              project: '$(engineeringProjectId)'
+              definition: '$(azureSamplePipelineId)'
+              artifactName: AzureSample
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+              buildVersionToDownload: 'latest'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Broker Host'
+            inputs:
+              buildType: specific
+              project: '$(engineeringProjectId)'
+              definition: '$(brokerHostPipelineId)'
+              artifactName: BrokerHost
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+          - task: UniversalPackages@0
+            displayName: 'Download old brokerHost version from feed'
+            inputs:
+              command: 'download'
+              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
+              feedsToUse: 'external'
+              externalFeedCredentials: '$(msazureServiceConnection)'
+              feedDownloadExternal: '$(msazureFeedName)'
+              packageDownloadExternal: 'broker-host'
+              versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
+          - publish: $(Build.ArtifactStagingDirectory)/azureSample
+            displayName: 'Publish Azure Sample apk for later use'
+            artifact: azureSample
+          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+            displayName: 'Publish Broker Host apk for later use'
+            artifact: brokerHost
+          - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
+            displayName: 'Publish Broker Host old apk for later use'
+            artifact: oldBrokerHost
+  # MSAL with Broker Test Plan stage (API 30+)
+  - stage: 'msal_with_broker_high_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    jobs:
+      - template: ./templates/flank/run-on-firebase-with-flank.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Dev BrokerHost"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+          resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # MSAL with Broker Test Plan stage (API 29-)
+  - stage: 'msal_with_broker_low_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    jobs:
+      - template: ./templates/run-on-firebase.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Dev BrokerHost"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+          resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -1,51 +1,32 @@
 # run MSAL with Broker UI automation testcases
-# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://dev.azure.com/IdentityDivision/Engineering/_build/index?definitionId=1742&_a=completed
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
 pr: none
 
-schedules:
-  - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Daily Local MSAL UI Automation with Broker Run
-    branches:
-      include:
-        - dev
-    always: true
-
 parameters:
-  - name: firebaseDeviceId
+  - name: firebaseDeviceIdHigh
+    displayName: Firebase Device Id (Api 30+)
     type: string
-    displayName: Firebase Device Id
+    default: oriole
+  - name: firebaseDeviceAndroidVersionHigh
+    displayName: Firebase Device Android Version (Api 30+)
+    type: number
+    default: 32
+  - name: firebaseDeviceIdLow
+    displayName: Firebase Device Id (Api 29-)
+    type: string
     default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
-  - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
+  - name: firebaseDeviceAndroidVersionLow
+    displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
-    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore
+    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
   - name: oldBrokerHostVersion
     displayName: Old Broker host Version
     type: string
@@ -63,81 +44,103 @@ variables:
   firebaseTimeout: 45m
 
 stages:
-  # msalautomationapp
-  - stage: 'msalautomationapp'
-    displayName: Build MSAL Automation APKs
-    jobs:
-      - template: ./templates/build-msal-automation-app.yml
-        parameters:
-          brokerFlavor: BrokerHost
-          msalFlavor: Local
-          brokerSource: LocalApk
-  # Brokers
-  - stage: 'brokers'
-    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Brokers and Azure Sample APKs
-    jobs:
-      - job: 'download_brokers'
-        displayName: Download Brokers
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: none
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download latest Azure Sample'
-            inputs:
-              buildType: 'specific'
-              project: '$(engineeringProjectId)'
-              definition: '$(azureSamplePipelineId)'
-              artifactName: AzureSample
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-              buildVersionToDownload: 'latest'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Broker Host'
-            inputs:
-              buildType: specific
-              project: '$(engineeringProjectId)'
-              definition: '$(brokerHostPipelineId)'
-              artifactName: BrokerHost
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-          - task: UniversalPackages@0
-            displayName: 'Download old brokerHost version from feed'
-            inputs:
-              command: 'download'
-              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
-              feedsToUse: 'external'
-              externalFeedCredentials: '$(msazureServiceConnection)'
-              feedDownloadExternal: '$(msazureFeedName)'
-              packageDownloadExternal: 'broker-host'
-              versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
-
-          - publish: $(Build.ArtifactStagingDirectory)/azureSample
-            displayName: 'Publish Azure Sample apk for later use'
-            artifact: azureSample
-          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-            displayName: 'Publish Broker Host apk for later use'
-            artifact: brokerHost
-          - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
-            displayName: 'Publish Broker Host old apk for later use'
-            artifact: oldBrokerHost
-  # MSAL with Broker Test Plan stage
-  - stage: 'msal_with_broker'
-    dependsOn:
-      - msalautomationapp
-      - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite
-    jobs:
-      - template: ./templates/flank/run-on-firebase-with-flank.yml
-        parameters:
-          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-          testTargetPackages: ${{ parameters.testTargetPackages }}
-          resultsHistoryName: "Dev MSAL with Dev BrokerHost"
-          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                  /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
-                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-          resultsDir: "msal-BrokerHost-$(Build.BuildId)-$(Build.BuildNumber)"
-          firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
-          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+# msalautomationapp
+- stage: 'msalautomationapp'
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerFlavor: BrokerHost
+        msalFlavor: Local
+        brokerSource: LocalApk
+# Brokers
+- stage: 'brokers'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Brokers and Azure Sample APKs
+  jobs:
+    - job: 'download_brokers'
+      displayName: Download Brokers
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - checkout: none
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download latest Azure Sample'
+          inputs:
+            buildType: 'specific'
+            project: '$(engineeringProjectId)'
+            definition: '$(azureSamplePipelineId)'
+            artifactName: AzureSample
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+            buildVersionToDownload: 'latest'
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Broker Host'
+          inputs:
+            buildType: specific
+            project: '$(engineeringProjectId)'
+            definition: '$(brokerHostPipelineId)'
+            artifactName: BrokerHost
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+        - task: UniversalPackages@0
+          displayName: 'Download old brokerHost version from feed'
+          inputs:
+            command: 'download'
+            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
+            feedsToUse: 'external'
+            externalFeedCredentials: '$(msazureServiceConnection)'
+            feedDownloadExternal: '$(msazureFeedName)'
+            packageDownloadExternal: 'broker-host'
+            versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
+        - publish: $(Build.ArtifactStagingDirectory)/azureSample
+          displayName: 'Publish Azure Sample apk for later use'
+          artifact: azureSample
+        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+          displayName: 'Publish Broker Host apk for later use'
+          artifact: brokerHost
+        - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
+          displayName: 'Publish Broker Host old apk for later use'
+          artifact: oldBrokerHost
+# MSAL with Broker Test Plan stage (API 30+)
+- stage: 'msal_with_broker_high_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+  jobs:
+    - template: ./templates/flank/run-on-firebase-with-flank.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Dev BrokerHost"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+# MSAL with Broker Test Plan stage (API 29-)
+- stage: 'msal_with_broker_low_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+  jobs:
+    - template: ./templates/flank/run-on-firebase.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Dev BrokerHost"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-BrokerHost-nightly.yml
@@ -130,7 +130,7 @@ stages:
     - brokers
   displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -23,6 +23,10 @@ parameters:
     displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
+  - name: flankShards
+    displayName: Max Number of Flank Shards
+    type: number
+    default: 2
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
@@ -107,7 +111,7 @@ stages:
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
     jobs:
       - template: ./templates/flank/run-on-firebase-with-flank.yml
         parameters:
@@ -121,14 +125,15 @@ stages:
           resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
           apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+          flankShards: ${{ parameters.flankShards }}
   # MSAL with Broker Test Plan stage (API 29-)
   - stage: 'msal_with_broker_low_api'
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
     jobs:
       - template: ./templates/run-on-firebase.yml
         parameters:
@@ -142,5 +147,5 @@ stages:
           resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
           apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -90,7 +90,7 @@ stages:
             command: 'download'
             downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
             feedsToUse: 'internal'
-            vstsFeed: '${internalFeedName}'
+            vstsFeed: '$(internalFeedName)'
             vstsFeedPackage: 'com.azure.authenticator'
             vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
         - publish: $(Build.ArtifactStagingDirectory)/azureSample

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -1,55 +1,36 @@
 # run MSAL with Broker UI automation testcases
-# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://dev.azure.com/IdentityDivision/Engineering/_build/index?definitionId=1761&_a=completed
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
 pr: none
 
-schedules:
-  - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Daily Local MSAL UI Automation with Prod Broker Run
-    branches:
-      include:
-        - dev
-    always: true
-
 parameters:
-  - name: firebaseDeviceId
+  - name: firebaseDeviceIdHigh
+    displayName: Firebase Device Id (Api 30+)
     type: string
-    displayName: Firebase Device Id
+    default: oriole
+  - name: firebaseDeviceAndroidVersionHigh
+    displayName: Firebase Device Android Version (Api 30+)
+    type: number
+    default: 32
+  - name: firebaseDeviceIdLow
+    displayName: Firebase Device Id (Api 29-)
+    type: string
     default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
-  - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
+  - name: firebaseDeviceAndroidVersionLow
+    displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
-    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore
-  - name: oldBrokerHostVersion
-    displayName: Old Broker host Version
+    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
+  - name: oldAuthenticatorVersion
+    displayName: Old Authenticator Version
     type: string
-    default: '0.0.1'
+    default: '6.2204.2470'
 
 variables:
   engineeringProjectId: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'
@@ -59,85 +40,106 @@ variables:
   msazureFeedName: Android-Broker
   azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
-  oldBrokerHostApk: brokerHost-local-debug.apk
+  oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   firebaseTimeout: 45m
 
 stages:
-  # msalautomationapp
-  - stage: 'msalautomationapp'
-    displayName: Build MSAL Automation APKs
-    jobs:
-      - template: ./templates/build-msal-automation-app.yml
-        parameters:
-          brokerFlavor: AutoBroker
-          msalFlavor: Local
-          brokerSource: PlayStore
-  # Brokers
-  - stage: 'brokers'
-    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Brokers and Azure Sample APKs
-    jobs:
-      - job: 'download_brokers'
-        displayName: Download Brokers
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: none
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download latest Azure Sample'
-            inputs:
-              buildType: 'specific'
-              project: '$(engineeringProjectId)'
-              definition: '$(azureSamplePipelineId)'
-              artifactName: AzureSample
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-              buildVersionToDownload: 'latest'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Broker Host'
-            inputs:
-              buildType: specific
-              project: '$(engineeringProjectId)'
-              definition: '$(brokerHostPipelineId)'
-              artifactName: BrokerHost
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-          - task: UniversalPackages@0
-            displayName: 'Download old brokerHost version from feed'
-            inputs:
-              command: 'download'
-              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
-              feedsToUse: 'external'
-              externalFeedCredentials: '$(msazureServiceConnection)'
-              feedDownloadExternal: '$(msazureFeedName)'
-              packageDownloadExternal: 'broker-host'
-              versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
-
-          - publish: $(Build.ArtifactStagingDirectory)/azureSample
-            displayName: 'Publish Azure Sample apk for later use'
-            artifact: azureSample
-          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-            displayName: 'Publish Broker Host apk for later use'
-            artifact: brokerHost
-          - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
-            displayName: 'Publish Broker Host old apk for later use'
-            artifact: oldBrokerHost
-  # MSAL with Broker Test Plan stage
-  - stage: 'msal_with_broker'
-    dependsOn:
-      - msalautomationapp
-      - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite
-    jobs:
-      - template: ./templates/flank/run-on-firebase-with-flank.yml
-        parameters:
-          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
-          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
-          testTargetPackages: ${{ parameters.testTargetPackages }}
-          resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
-          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                  /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
-                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-          resultsDir: "msal-BrokerHost-$(Build.BuildId)-$(Build.BuildNumber)"
-          firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
-          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+# msalautomationapp
+- stage: 'msalautomationapp'
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerFlavor: AutoBroker
+        msalFlavor: Local
+        brokerSource: PlayStore
+# Brokers
+- stage: 'brokers'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Brokers and Azure Sample APKs
+  jobs:
+    - job: 'download_brokers'
+      displayName: Download Brokers
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - checkout: none
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download latest Azure Sample'
+          inputs:
+            buildType: 'specific'
+            project: '$(engineeringProjectId)'
+            definition: '$(azureSamplePipelineId)'
+            artifactName: AzureSample
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+            buildVersionToDownload: 'latest'
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Broker Host'
+          inputs:
+            buildType: specific
+            project: '$(engineeringProjectId)'
+            definition: '$(brokerHostPipelineId)'
+            artifactName: BrokerHost
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+        - task: UniversalPackages@0
+          displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
+          inputs:
+            command: 'download'
+            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
+            feedsToUse: 'internal'
+            vstsFeed: '${{ parameters.internalFeedName }}'
+            vstsFeedPackage: 'com.azure.authenticator'
+            vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
+        - publish: $(Build.ArtifactStagingDirectory)/azureSample
+          displayName: 'Publish Azure Sample apk for later use'
+          artifact: azureSample
+        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+          displayName: 'Publish Broker Host apk for later use'
+          artifact: brokerHost
+        - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
+          displayName: 'Publish Broker Host old apk for later use'
+          artifact: oldAuthenticator
+# MSAL with Broker Test Plan stage (API 30+)
+- stage: 'msal_with_broker_high_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+  jobs:
+    - template: ./templates/flank/run-on-firebase-with-flank.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+# MSAL with Broker Test Plan stage (API 29-)
+- stage: 'msal_with_broker_low_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+  jobs:
+    - template: ./templates/flank/run-on-firebase.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -130,7 +130,7 @@ stages:
     - brokers
   displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -45,102 +45,102 @@ variables:
   internalFeedName: AndroidAdal
 
 stages:
-# msalautomationapp
-- stage: 'msalautomationapp'
-  displayName: Build MSAL Automation APKs
-  jobs:
-    - template: ./templates/build-msal-automation-app.yml
-      parameters:
-        brokerFlavor: AutoBroker
-        msalFlavor: Local
-        brokerSource: PlayStore
-# Brokers
-- stage: 'brokers'
-  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  displayName: Brokers and Azure Sample APKs
-  jobs:
-    - job: 'download_brokers'
-      displayName: Download Brokers
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - checkout: none
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download latest Azure Sample'
-          inputs:
-            buildType: 'specific'
-            project: '$(engineeringProjectId)'
-            definition: '$(azureSamplePipelineId)'
-            artifactName: AzureSample
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-            buildVersionToDownload: 'latest'
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download Broker Host'
-          inputs:
-            buildType: specific
-            project: '$(engineeringProjectId)'
-            definition: '$(brokerHostPipelineId)'
-            artifactName: BrokerHost
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-        - task: UniversalPackages@0
-          displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
-          inputs:
-            command: 'download'
-            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
-            feedsToUse: 'internal'
-            vstsFeed: '$(internalFeedName)'
-            vstsFeedPackage: 'com.azure.authenticator'
-            vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
-        - publish: $(Build.ArtifactStagingDirectory)/azureSample
-          displayName: 'Publish Azure Sample apk for later use'
-          artifact: azureSample
-        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-          displayName: 'Publish Broker Host apk for later use'
-          artifact: brokerHost
-        - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
-          displayName: 'Publish Broker Host old apk for later use'
-          artifact: oldAuthenticator
-# MSAL with Broker Test Plan stage (API 30+)
-- stage: 'msal_with_broker_high_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
-  jobs:
-    - template: ./templates/flank/run-on-firebase-with-flank.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
-                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
-        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-# MSAL with Broker Test Plan stage (API 29-)
-- stage: 'msal_with_broker_low_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
-                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
-        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # msalautomationapp
+  - stage: 'msalautomationapp'
+    displayName: Build MSAL Automation APKs
+    jobs:
+      - template: ./templates/build-msal-automation-app.yml
+        parameters:
+          brokerFlavor: AutoBroker
+          msalFlavor: Local
+          brokerSource: PlayStore
+  # Brokers
+  - stage: 'brokers'
+    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+    displayName: Brokers and Azure Sample APKs
+    jobs:
+      - job: 'download_brokers'
+        displayName: Download Brokers
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download latest Azure Sample'
+            inputs:
+              buildType: 'specific'
+              project: '$(engineeringProjectId)'
+              definition: '$(azureSamplePipelineId)'
+              artifactName: AzureSample
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+              buildVersionToDownload: 'latest'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Broker Host'
+            inputs:
+              buildType: specific
+              project: '$(engineeringProjectId)'
+              definition: '$(brokerHostPipelineId)'
+              artifactName: BrokerHost
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+          - task: UniversalPackages@0
+            displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
+            inputs:
+              command: 'download'
+              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
+              feedsToUse: 'internal'
+              vstsFeed: '$(internalFeedName)'
+              vstsFeedPackage: 'com.azure.authenticator'
+              vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
+          - publish: $(Build.ArtifactStagingDirectory)/azureSample
+            displayName: 'Publish Azure Sample apk for later use'
+            artifact: azureSample
+          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+            displayName: 'Publish Broker Host apk for later use'
+            artifact: brokerHost
+          - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
+            displayName: 'Publish Broker Host old apk for later use'
+            artifact: oldAuthenticator
+  # MSAL with Broker Test Plan stage (API 30+)
+  - stage: 'msal_with_broker_high_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    jobs:
+      - template: ./templates/flank/run-on-firebase-with-flank.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                  /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+          resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # MSAL with Broker Test Plan stage (API 29-)
+  - stage: 'msal_with_broker_low_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    jobs:
+      - template: ./templates/run-on-firebase.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                  /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+          resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-broker-ProdBroker-nightly.yml
@@ -42,6 +42,7 @@ variables:
   brokerHostApk: brokerHost-local-debug.apk
   oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   firebaseTimeout: 45m
+  internalFeedName: AndroidAdal
 
 stages:
 # msalautomationapp
@@ -89,7 +90,7 @@ stages:
             command: 'download'
             downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
             feedsToUse: 'internal'
-            vstsFeed: '${{ parameters.internalFeedName }}'
+            vstsFeed: '${internalFeedName}'
             vstsFeedPackage: 'com.azure.authenticator'
             vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
         - publish: $(Build.ArtifactStagingDirectory)/azureSample

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -1,58 +1,42 @@
 # run MSAL with Broker UI automation testcases
+# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN' was defined in the Variables tab
 # Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://dev.azure.com/IdentityDivision/Engineering/_build/index?definitionId=1763&_a=completed
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
 pr: none
 
-schedules:
-  - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Daily Local MSAL UI Automation with Prod Broker Run
-    branches:
-      include:
-        - dev
-    always: true
-
 parameters:
-  - name: firebaseDeviceId
+  - name: firebaseDeviceIdHigh
+    displayName: Firebase Device Id (Api 30+)
     type: string
-    displayName: Firebase Device Id
+    default: oriole
+  - name: firebaseDeviceAndroidVersionHigh
+    displayName: Firebase Device Android Version (Api 30+)
+    type: number
+    default: 32
+  - name: firebaseDeviceIdLow
+    displayName: Firebase Device Id (Api 29-)
+    type: string
     default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
-  - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
+  - name: firebaseDeviceAndroidVersionLow
+    displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
-    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore
-  - name: oldBrokerHostVersion
-    displayName: Old Broker host Version
+    default: package com.microsoft.identity.client.msal.automationapp.testpass.broker, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
+  - name: oldAuthenticatorVersion
+    displayName: Old Authenticator Version
     type: string
-    default: '0.0.1'
+    default: '6.2204.2470'
   - name: msalVersion
     displayName: MSAL Version
     type: string
+    default: "0.0.+"
 
 variables:
   engineeringProjectId: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'
@@ -62,86 +46,107 @@ variables:
   msazureFeedName: Android-Broker
   azureSampleApk: AzureSample-local-debug.apk
   brokerHostApk: brokerHost-local-debug.apk
-  oldBrokerHostApk: brokerHost-local-debug.apk
+  oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   firebaseTimeout: 45m
 
 stages:
-  # msalautomationapp
-  - stage: 'msalautomationapp'
-    displayName: Build MSAL Automation APKs
-    jobs:
-      - template: ./templates/build-msal-automation-app.yml
-        parameters:
-          brokerFlavor: AutoBroker
-          msalFlavor: Dist
-          brokerSource: PlayStore
-          msalVersion: ${{ parameters.msalVersion }}
-  # Brokers
-  - stage: 'brokers'
-    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Brokers and Azure Sample APKs
-    jobs:
-      - job: 'download_brokers'
-        displayName: Download Brokers
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: none
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download latest Azure Sample'
-            inputs:
-              buildType: 'specific'
-              project: '$(engineeringProjectId)'
-              definition: '$(azureSamplePipelineId)'
-              artifactName: AzureSample
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-              buildVersionToDownload: 'latest'
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download Broker Host'
-            inputs:
-              buildType: specific
-              project: '$(engineeringProjectId)'
-              definition: '$(brokerHostPipelineId)'
-              artifactName: BrokerHost
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-          - task: UniversalPackages@0
-            displayName: 'Download old brokerHost version from feed'
-            inputs:
-              command: 'download'
-              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldBrokerHost'
-              feedsToUse: 'external'
-              externalFeedCredentials: '$(msazureServiceConnection)'
-              feedDownloadExternal: '$(msazureFeedName)'
-              packageDownloadExternal: 'broker-host'
-              versionDownloadExternal: '${{ parameters.oldBrokerHostVersion }}'
-
-          - publish: $(Build.ArtifactStagingDirectory)/azureSample
-            displayName: 'Publish Azure Sample apk for later use'
-            artifact: azureSample
-          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-            displayName: 'Publish Broker Host apk for later use'
-            artifact: brokerHost
-          - publish: $(Build.ArtifactStagingDirectory)/oldBrokerHost
-            displayName: 'Publish Broker Host old apk for later use'
-            artifact: oldBrokerHost
-  # MSAL with Broker Test Plan stage
-  - stage: 'msal_with_broker'
-    dependsOn:
-      - msalautomationapp
-      - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite
-    jobs:
-      - template: ./templates/flank/run-on-firebase-with-flank.yml
-        parameters:
-          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-dist-AutoBroker-debug.apk"
-          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-dist-AutoBroker-debug-androidTest.apk"
-          testTargetPackages: ${{ parameters.testTargetPackages }}
-          resultsHistoryName: "Release Test MSAL with Prod Broker (AuthApp, CP)"
-          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                  /data/local/tmp/OldBrokerHost.apk=$(Pipeline.Workspace)/oldBrokerHost/$(oldBrokerHostApk),\
-                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-          resultsDir: "msal-AutoBroker-release-$(Build.BuildId)-$(Build.BuildNumber)"
-          firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
-          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+# msalautomationapp
+- stage: 'msalautomationapp'
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerFlavor: AutoBroker
+        msalFlavor: Dist
+        brokerSource: PlayStore
+        msalVersion: ${{ parameters.msalVersion }}
+# Brokers
+- stage: 'brokers'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Brokers and Azure Sample APKs
+  jobs:
+    - job: 'download_brokers'
+      displayName: Download Brokers
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - checkout: none
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download latest Azure Sample'
+          inputs:
+            buildType: 'specific'
+            project: '$(engineeringProjectId)'
+            definition: '$(azureSamplePipelineId)'
+            artifactName: AzureSample
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+            buildVersionToDownload: 'latest'
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download Broker Host'
+          inputs:
+            buildType: specific
+            project: '$(engineeringProjectId)'
+            definition: '$(brokerHostPipelineId)'
+            artifactName: BrokerHost
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+        - task: UniversalPackages@0
+          displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
+          inputs:
+            command: 'download'
+            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
+            feedsToUse: 'internal'
+            vstsFeed: '${{ parameters.internalFeedName }}'
+            vstsFeedPackage: 'com.azure.authenticator'
+            vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
+        - publish: $(Build.ArtifactStagingDirectory)/azureSample
+          displayName: 'Publish Azure Sample apk for later use'
+          artifact: azureSample
+        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+          displayName: 'Publish Broker Host apk for later use'
+          artifact: brokerHost
+        - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
+          displayName: 'Publish Broker Host old apk for later use'
+          artifact: oldAuthenticator
+# MSAL with Broker Test Plan stage (API 30+)
+- stage: 'msal_with_broker_high_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+  jobs:
+    - template: ./templates/flank/run-on-firebase-with-flank.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+# MSAL with Broker Test Plan stage (API 29-)
+- stage: 'msal_with_broker_low_api'
+  dependsOn:
+    - msalautomationapp
+    - brokers
+  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+  jobs:
+    - template: ./templates/flank/run-on-firebase.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -51,103 +51,103 @@ variables:
   internalFeedName: AndroidAdal
 
 stages:
-# msalautomationapp
-- stage: 'msalautomationapp'
-  displayName: Build MSAL Automation APKs
-  jobs:
-    - template: ./templates/build-msal-automation-app.yml
-      parameters:
-        brokerFlavor: AutoBroker
-        msalFlavor: Dist
-        brokerSource: PlayStore
-#        msalVersion: ${{ parameters.msalVersion }}
-# Brokers
-- stage: 'brokers'
-  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  displayName: Brokers and Azure Sample APKs
-  jobs:
-    - job: 'download_brokers'
-      displayName: Download Brokers
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - checkout: none
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download latest Azure Sample'
-          inputs:
-            buildType: 'specific'
-            project: '$(engineeringProjectId)'
-            definition: '$(azureSamplePipelineId)'
-            artifactName: AzureSample
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-            buildVersionToDownload: 'latest'
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download Broker Host'
-          inputs:
-            buildType: specific
-            project: '$(engineeringProjectId)'
-            definition: '$(brokerHostPipelineId)'
-            artifactName: BrokerHost
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
-        - task: UniversalPackages@0
-          displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
-          inputs:
-            command: 'download'
-            downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
-            feedsToUse: 'internal'
-            vstsFeed: '$(internalFeedName)'
-            vstsFeedPackage: 'com.azure.authenticator'
-            vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
-        - publish: $(Build.ArtifactStagingDirectory)/azureSample
-          displayName: 'Publish Azure Sample apk for later use'
-          artifact: azureSample
-        - publish: $(Build.ArtifactStagingDirectory)/brokerHost
-          displayName: 'Publish Broker Host apk for later use'
-          artifact: brokerHost
-        - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
-          displayName: 'Publish Broker Host old apk for later use'
-          artifact: oldAuthenticator
-# MSAL with Broker Test Plan stage (API 30+)
-- stage: 'msal_with_broker_high_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
-  jobs:
-    - template: ./templates/flank/run-on-firebase-with-flank.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
-                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
-        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-# MSAL with Broker Test Plan stage (API 29-)
-- stage: 'msal_with_broker_low_api'
-  dependsOn:
-    - msalautomationapp
-    - brokers
-  displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
-        otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
-                /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
-                /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
-        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # msalautomationapp
+  - stage: 'msalautomationapp'
+    displayName: Build MSAL Automation APKs
+    jobs:
+      - template: ./templates/build-msal-automation-app.yml
+        parameters:
+          brokerFlavor: AutoBroker
+          msalFlavor: Dist
+          brokerSource: PlayStore
+  #        msalVersion: ${{ parameters.msalVersion }}
+  # Brokers
+  - stage: 'brokers'
+    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+    displayName: Brokers and Azure Sample APKs
+    jobs:
+      - job: 'download_brokers'
+        displayName: Download Brokers
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download latest Azure Sample'
+            inputs:
+              buildType: 'specific'
+              project: '$(engineeringProjectId)'
+              definition: '$(azureSamplePipelineId)'
+              artifactName: AzureSample
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+              buildVersionToDownload: 'latest'
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download Broker Host'
+            inputs:
+              buildType: specific
+              project: '$(engineeringProjectId)'
+              definition: '$(brokerHostPipelineId)'
+              artifactName: BrokerHost
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/brokerHost'
+          - task: UniversalPackages@0
+            displayName: 'Download old authenticator (Pre v5 Broker) version from feed'
+            inputs:
+              command: 'download'
+              downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
+              feedsToUse: 'internal'
+              vstsFeed: '$(internalFeedName)'
+              vstsFeedPackage: 'com.azure.authenticator'
+              vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
+          - publish: $(Build.ArtifactStagingDirectory)/azureSample
+            displayName: 'Publish Azure Sample apk for later use'
+            artifact: azureSample
+          - publish: $(Build.ArtifactStagingDirectory)/brokerHost
+            displayName: 'Publish Broker Host apk for later use'
+            artifact: brokerHost
+          - publish: $(Build.ArtifactStagingDirectory)/oldAuthenticator
+            displayName: 'Publish Broker Host old apk for later use'
+            artifact: oldAuthenticator
+  # MSAL with Broker Test Plan stage (API 30+)
+  - stage: 'msal_with_broker_high_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    jobs:
+      - template: ./templates/flank/run-on-firebase-with-flank.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                  /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+          resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # MSAL with Broker Test Plan stage (API 29-)
+  - stage: 'msal_with_broker_low_api'
+    dependsOn:
+      - msalautomationapp
+      - brokers
+    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    jobs:
+      - template: ./templates/run-on-firebase.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsHistoryName: "Dev MSAL with Prod Broker (AuthApp, CP)"
+          otherFiles: "/data/local/tmp/BrokerHost.apk=$(Pipeline.Workspace)/brokerHost/$(brokerHostApk),\
+                  /data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk),\
+                  /data/local/tmp/OldAuthenticator.apk=$(Pipeline.Workspace)/oldAuthenticator/$(oldAuthenticatorApk)"
+          resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -97,7 +97,7 @@ stages:
             command: 'download'
             downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
             feedsToUse: 'internal'
-            vstsFeed: '${internalFeedName}'
+            vstsFeed: '$(internalFeedName)'
             vstsFeedPackage: 'com.azure.authenticator'
             vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
         - publish: $(Build.ArtifactStagingDirectory)/azureSample

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -137,7 +137,7 @@ stages:
     - brokers
   displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug.apk"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-AutoBroker-debug-androidTest.apk"

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -25,6 +25,10 @@ parameters:
     displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
+  - name: flankShards
+    displayName: Max Number of Flank Shards
+    type: number
+    default: 2
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
@@ -114,7 +118,7 @@ stages:
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 30+)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
     jobs:
       - template: ./templates/flank/run-on-firebase-with-flank.yml
         parameters:
@@ -128,14 +132,15 @@ stages:
           resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
           apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+          flankShards: ${{ parameters.flankShards }}
   # MSAL with Broker Test Plan stage (API 29-)
   - stage: 'msal_with_broker_low_api'
     dependsOn:
       - msalautomationapp
       - brokers
-    displayName: Running MSAL with Broker Test UI Test Suite (API 29-)
+    displayName: Running MSAL with Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
     jobs:
       - template: ./templates/run-on-firebase.yml
         parameters:
@@ -149,5 +154,5 @@ stages:
           resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-          testRunTitle: "Broker(MSAL) UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          testRunTitle: "Broker(MSAL) UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
           apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -48,6 +48,7 @@ variables:
   brokerHostApk: brokerHost-local-debug.apk
   oldAuthenticatorApk: Authenticator-4.1.0-RC.apk
   firebaseTimeout: 45m
+  internalFeedName: AndroidAdal
 
 stages:
 # msalautomationapp
@@ -96,7 +97,7 @@ stages:
             command: 'download'
             downloadDirectory: '$(Build.ArtifactStagingDirectory)/oldAuthenticator'
             feedsToUse: 'internal'
-            vstsFeed: '${{ parameters.internalFeedName }}'
+            vstsFeed: '${internalFeedName}'
             vstsFeedPackage: 'com.azure.authenticator'
             vstsPackageVersion: '${{ parameters.oldAuthenticatorVersion }}'
         - publish: $(Build.ArtifactStagingDirectory)/azureSample

--- a/azure-pipelines/ui-automation/msal-broker-release.yml
+++ b/azure-pipelines/ui-automation/msal-broker-release.yml
@@ -60,7 +60,7 @@ stages:
         brokerFlavor: AutoBroker
         msalFlavor: Dist
         brokerSource: PlayStore
-        msalVersion: ${{ parameters.msalVersion }}
+#        msalVersion: ${{ parameters.msalVersion }}
 # Brokers
 - stage: 'brokers'
   dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -38,74 +38,74 @@ variables:
   resultsHistoryName: Dev MSAL without Broker
 
 stages:
-# msalautomationapp
-- stage: 'msalautomationapp'
-  displayName: Build MSAL Automation APKs
-  jobs:
-    - template: ./templates/build-msal-automation-app.yml
-      parameters:
-        brokerFlavor: BrokerHost
-        msalFlavor: Local
-        brokerSource: LocalApk
-# Azure Sample
-- stage: 'azuresample'
-  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-  displayName: Dowload Azure Sample APK
-  jobs:
-    - job: 'download_azure_sample'
-      displayName: Download Azure Sample
-      pool:
-        vmImage: ubuntu-latest
-      steps:
-        - checkout: none
-        - task: DownloadPipelineArtifact@2
-          displayName: 'Download latest Azure Sample'
-          inputs:
-            buildType: 'specific'
-            project: '$(engineeringProjectId)'
-            definition: '$(azureSamplePipelineId)'
-            artifactName: AzureSample
-            itemPattern: '**/*.apk'
-            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-            buildVersionToDownload: 'latest'
-        - publish: $(Build.ArtifactStagingDirectory)/azureSample
-          displayName: 'Publish Azure Sample apk for later use'
-          artifact: azureSample
-# MSAL without Broker Test UI stage (API 30+)
-- stage: 'msal_without_broker_high_api'
-  dependsOn:
-    - msalautomationapp
-    - azuresample
-  displayName: Running MSAL without Broker Test UI Test Suite (API 30+)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        resultsHistoryName: "Dev MSAL without Broker"
-        otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-        testRunTitle: "MSAL UI Automation - Build (API 30+) # $(Build.BuildNumber)"
-        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
-# MSAL without Broker Test UI stage (API 29-)
-- stage: 'msal_without_broker_low_api'
-  dependsOn:
-    - msalautomationapp
-    - azuresample
-  displayName: Running MSAL without Broker Test UI Test Suite (API 29-)
-  jobs:
-    - template: ./templates/run-on-firebase.yml
-      parameters:
-        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-        testTargetPackages: ${{ parameters.testTargetPackages }}
-        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
-        resultsHistoryName: "Dev MSAL without Broker"
-        otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-        testRunTitle: "MSAL UI Automation - Build (API 29-) # $(Build.BuildNumber)"
-        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # msalautomationapp
+  - stage: 'msalautomationapp'
+    displayName: Build MSAL Automation APKs
+    jobs:
+      - template: ./templates/build-msal-automation-app.yml
+        parameters:
+          brokerFlavor: BrokerHost
+          msalFlavor: Local
+          brokerSource: LocalApk
+  # Azure Sample
+  - stage: 'azuresample'
+    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+    displayName: Dowload Azure Sample APK
+    jobs:
+      - job: 'download_azure_sample'
+        displayName: Download Azure Sample
+        pool:
+          vmImage: ubuntu-latest
+        steps:
+          - checkout: none
+          - task: DownloadPipelineArtifact@2
+            displayName: 'Download latest Azure Sample'
+            inputs:
+              buildType: 'specific'
+              project: '$(engineeringProjectId)'
+              definition: '$(azureSamplePipelineId)'
+              artifactName: AzureSample
+              itemPattern: '**/*.apk'
+              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+              buildVersionToDownload: 'latest'
+          - publish: $(Build.ArtifactStagingDirectory)/azureSample
+            displayName: 'Publish Azure Sample apk for later use'
+            artifact: azureSample
+  # MSAL without Broker Test UI stage (API 30+)
+  - stage: 'msal_without_broker_high_api'
+    dependsOn:
+      - msalautomationapp
+      - azuresample
+    displayName: Running MSAL without Broker Test UI Test Suite (API 30+)
+    jobs:
+      - template: ./templates/run-on-firebase.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          resultsHistoryName: "Dev MSAL without Broker"
+          otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+          testRunTitle: "MSAL UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+  # MSAL without Broker Test UI stage (API 29-)
+  - stage: 'msal_without_broker_low_api'
+    dependsOn:
+      - msalautomationapp
+      - azuresample
+    displayName: Running MSAL without Broker Test UI Test Suite (API 29-)
+    jobs:
+      - template: ./templates/run-on-firebase.yml
+        parameters:
+          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+          testTargetPackages: ${{ parameters.testTargetPackages }}
+          resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+          resultsHistoryName: "Dev MSAL without Broker"
+          otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+          firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
+          testRunTitle: "MSAL UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -78,7 +78,7 @@ stages:
     - azuresample
   displayName: Running MSAL without Broker Test UI Test Suite (API 30+)
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
@@ -97,7 +97,7 @@ stages:
     - azuresample
   displayName: Running MSAL without Broker Test UI Test Suite (API 29-)
   jobs:
-    - template: ./templates/flank/run-on-firebase.yml
+    - template: ./templates/run-on-firebase.yml
       parameters:
         automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
         automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -105,7 +105,7 @@ stages:
         resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
         resultsHistoryName: "Dev MSAL without Broker"
         otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-        firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
-        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
         testRunTitle: "MSAL UI Automation - Build (API 29-) # $(Build.BuildNumber)"
         apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -76,7 +76,7 @@ stages:
     dependsOn:
       - msalautomationapp
       - azuresample
-    displayName: Running MSAL without Broker Test UI Test Suite (API 30+)
+    displayName: Running MSAL without Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionHigh }})
     jobs:
       - template: ./templates/run-on-firebase.yml
         parameters:
@@ -88,14 +88,14 @@ stages:
           otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
-          testRunTitle: "MSAL UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+          testRunTitle: "MSAL UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionHigh }}) # $(Build.BuildNumber)"
           apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
   # MSAL without Broker Test UI stage (API 29-)
   - stage: 'msal_without_broker_low_api'
     dependsOn:
       - msalautomationapp
       - azuresample
-    displayName: Running MSAL without Broker Test UI Test Suite (API 29-)
+    displayName: Running MSAL without Broker Test UI Test Suite (API ${{ parameters.firebaseDeviceAndroidVersionLow }})
     jobs:
       - template: ./templates/run-on-firebase.yml
         parameters:
@@ -107,5 +107,5 @@ stages:
           otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
           firebaseDeviceId: ${{ parameters.firebaseDeviceIdLow }}
           firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionLow }}
-          testRunTitle: "MSAL UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+          testRunTitle: "MSAL UI Automation - Build (API ${{ parameters.firebaseDeviceAndroidVersionLow }}) # $(Build.BuildNumber)"
           apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/msal-local-nightly.yml
+++ b/azure-pipelines/ui-automation/msal-local-nightly.yml
@@ -1,51 +1,32 @@
 # run MSAL without Broker UI automation testcases
-# Variable: 'ENV_VSTS_MVN_ANDROIDADACCOUNTS_USERNAME' was defined in the Variables tab
 # Variable: 'gCloudProjectId' was defined in the Variables tab
-# Variable: 'mvnAccessToken' was defined in the Variables tab
+# https://dev.azure.com/IdentityDivision/Engineering/_build/index?definitionId=1743&_a=completed
 name: $(Build.BuildId)_$(Build.DefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 
 trigger: none
 pr: none
 
-schedules:
-  - cron: "0 5 * * 1-6" # 5:00 AM UTC everyday Mon-Sat
-    displayName: Daily Local MSAL UI Automation without Broker Run
-    branches:
-      include:
-        - dev
-    always: true
-
 parameters:
-  - name: firebaseDeviceId
+  - name: firebaseDeviceIdHigh
+    displayName: Firebase Device Id (Api 30+)
     type: string
-    displayName: Firebase Device Id
+    default: oriole
+  - name: firebaseDeviceAndroidVersionHigh
+    displayName: Firebase Device Android Version (Api 30+)
+    type: number
+    default: 32
+  - name: firebaseDeviceIdLow
+    displayName: Firebase Device Id (Api 29-)
+    type: string
     default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
-  - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
+  - name: firebaseDeviceAndroidVersionLow
+    displayName: Firebase Device Android Version (Api 29-)
     type: number
     default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
   - name: testTargetPackages
     displayName: Packages as Test Targets
     type: string
-    default: package com.microsoft.identity.client.msal.automationapp.testpass.msalonly, package com.microsoft.identity.client.msal.automationapp.testpass.b2c, notAnnotation org.junit.Ignore
+    default: package com.microsoft.identity.client.msal.automationapp.testpass.msalonly, package com.microsoft.identity.client.msal.automationapp.testpass.b2c, notAnnotation org.junit.Ignore, notAnnotation com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline
 
 variables:
   engineeringProjectId: 'fac9d424-53d2-45c0-91b5-ef6ba7a6bf26'
@@ -57,53 +38,74 @@ variables:
   resultsHistoryName: Dev MSAL without Broker
 
 stages:
-  # msalautomationapp
-  - stage: 'msalautomationapp'
-    displayName: Build MSAL Automation APKs
-    jobs:
-      - template: ./templates/build-msal-automation-app.yml
-        parameters:
-          brokerFlavor: BrokerHost
-          msalFlavor: Local
-          brokerSource: LocalApk
-  # Azure Sample
-  - stage: 'azuresample'
-    dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
-    displayName: Dowload Azure Sample APK
-    jobs:
-      - job: 'download_azure_sample'
-        displayName: Download Azure Sample
-        pool:
-          vmImage: ubuntu-latest
-        steps:
-          - checkout: none
-          - task: DownloadPipelineArtifact@2
-            displayName: 'Download latest Azure Sample'
-            inputs:
-              buildType: 'specific'
-              project: '$(engineeringProjectId)'
-              definition: '$(azureSamplePipelineId)'
-              artifactName: AzureSample
-              itemPattern: '**/*.apk'
-              targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
-              buildVersionToDownload: 'latest'
-          - publish: $(Build.ArtifactStagingDirectory)/azureSample
-            displayName: 'Publish Azure Sample apk for later use'
-            artifact: azureSample
-  # MSAL without Broker Test UI stage
-  - stage: 'msal_without_broker'
-    dependsOn:
-      - msalautomationapp
-      - azuresample
-    displayName: Running MSAL without Broker Test UI Test Suite
-    jobs:
-      - template: ./templates/flank/run-on-firebase-with-flank.yml
-        parameters:
-          automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
-          automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
-          testTargetPackages: ${{ parameters.testTargetPackages }}
-          resultsDir: "msal-BrokerHost-$(Build.BuildId)-$(Build.BuildNumber)"
-          resultsHistoryName: "Dev MSAL with Dev BrokerHost"
-          otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
-          firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
-          firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+# msalautomationapp
+- stage: 'msalautomationapp'
+  displayName: Build MSAL Automation APKs
+  jobs:
+    - template: ./templates/build-msal-automation-app.yml
+      parameters:
+        brokerFlavor: BrokerHost
+        msalFlavor: Local
+        brokerSource: LocalApk
+# Azure Sample
+- stage: 'azuresample'
+  dependsOn: []    # this removes the implicit dependency on previous stage and causes this to run in parallel
+  displayName: Dowload Azure Sample APK
+  jobs:
+    - job: 'download_azure_sample'
+      displayName: Download Azure Sample
+      pool:
+        vmImage: ubuntu-latest
+      steps:
+        - checkout: none
+        - task: DownloadPipelineArtifact@2
+          displayName: 'Download latest Azure Sample'
+          inputs:
+            buildType: 'specific'
+            project: '$(engineeringProjectId)'
+            definition: '$(azureSamplePipelineId)'
+            artifactName: AzureSample
+            itemPattern: '**/*.apk'
+            targetPath: '$(Build.ArtifactStagingDirectory)/azureSample'
+            buildVersionToDownload: 'latest'
+        - publish: $(Build.ArtifactStagingDirectory)/azureSample
+          displayName: 'Publish Azure Sample apk for later use'
+          artifact: azureSample
+# MSAL without Broker Test UI stage (API 30+)
+- stage: 'msal_without_broker_high_api'
+  dependsOn:
+    - msalautomationapp
+    - azuresample
+  displayName: Running MSAL without Broker Test UI Test Suite (API 30+)
+  jobs:
+    - template: ./templates/flank/run-on-firebase.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsDir: "msal-BrokerHost-highapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        resultsHistoryName: "Dev MSAL without Broker"
+        otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceIdHigh }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersionHigh }}
+        testRunTitle: "MSAL UI Automation - Build (API 30+) # $(Build.BuildNumber)"
+        apiLevelTarget: "notAnnotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"
+# MSAL without Broker Test UI stage (API 29-)
+- stage: 'msal_without_broker_low_api'
+  dependsOn:
+    - msalautomationapp
+    - azuresample
+  displayName: Running MSAL without Broker Test UI Test Suite (API 29-)
+  jobs:
+    - template: ./templates/flank/run-on-firebase.yml
+      parameters:
+        automationAppApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug.apk"
+        automationAppTestApkPath: "$(Pipeline.Workspace)/msalautomationapks/msalautomationapp-local-BrokerHost-debug-androidTest.apk"
+        testTargetPackages: ${{ parameters.testTargetPackages }}
+        resultsDir: "msal-BrokerHost-lowapi-$(Build.BuildId)-$(Build.BuildNumber)"
+        resultsHistoryName: "Dev MSAL without Broker"
+        otherFiles: "/data/local/tmp/AzureSample.apk=$(Pipeline.Workspace)/azureSample/$(azureSampleApk)"
+        firebaseDeviceId: ${{ parameters.firebaseDeviceId }}
+        firebaseDeviceAndroidVersion: ${{ parameters.firebaseDeviceAndroidVersion }}
+        testRunTitle: "MSAL UI Automation - Build (API 29-) # $(Build.BuildNumber)"
+        apiLevelTarget: "annotation com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus"

--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -2,7 +2,7 @@ flank:
    ## Max Test Shards
    # test shards - the amount of groups to split the test suite into
    # set to -1 to use one shard per test. default: 1
-   max-test-shards: 3
+   max-test-shards: 2
 
    ## Number of Test Runs
    # test runs - the amount of times to run the tests.

--- a/azure-pipelines/ui-automation/templates/flank/flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/flank.yml
@@ -1,9 +1,4 @@
 flank:
-   ## Max Test Shards
-   # test shards - the amount of groups to split the test suite into
-   # set to -1 to use one shard per test. default: 1
-   max-test-shards: 2
-
    ## Number of Test Runs
    # test runs - the amount of times to run the tests.
    # 1 runs the tests once. 10 runs all the tests 10x

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -4,10 +4,10 @@ parameters:
   - name: automationAppTestApkPath
     type: string
   - name: testTargetPackages
-    displayName: Packages as Test Targets
+    type: string
+  - name: apiLevelTarget
     type: string
   - name: resultsHistoryName
-    displayName: Results History Name
     type: string
   - name: otherFiles
     type: string
@@ -18,34 +18,14 @@ parameters:
     default: 45m
   - name: firebaseDeviceId
     type: string
-    displayName: Firebase Device Id
-    default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
   - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
     type: number
-    default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
+  - name: testRunTitle
+    type: string
 
 jobs:
   - job: 'run_on_firebase'
-    displayName: Running Test Suite on Firebease
+    displayName: Running Test Suite on Firebase
     timeoutInMinutes: 90
     pool:
       vmImage: ubuntu-latest
@@ -79,15 +59,15 @@ jobs:
               --test "${{ parameters.automationAppTestApkPath }}" \
               --auto-google-login \
               --record-video \
-              --other-files ${{ parameters.otherFiles }} \
               --device model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }},locale=en,orientation=portrait \
-              --timeout "$(firebaseTimeout)" \
+              --timeout "${{ parameters.firebaseTimeout }}" \
+              --other-files ${{ parameters.otherFiles }} \
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull "/sdcard" \
               --use-orchestrator \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
-              --test-targets "${{ parameters.testTargetPackages }}" \
+              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}" \
               --smart-flank-gcs-path "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/smart-flank-xml/msal-only/JUnitReport.xml"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/JUnitReport.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File
@@ -98,4 +78,4 @@ jobs:
         inputs:
           testResultsFiles: 'JUnitReport.xml'
           searchFolder: $(Build.SourcesDirectory)
-          testRunTitle: 'MSAL UI Automation - Build # $(Build.BuildNumber)'
+          testRunTitle: '${{ parameters.testRunTitle }}'

--- a/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
+++ b/azure-pipelines/ui-automation/templates/flank/run-on-firebase-with-flank.yml
@@ -22,6 +22,8 @@ parameters:
     type: number
   - name: testRunTitle
     type: string
+  - name: flankShards
+    type: number
 
 jobs:
   - job: 'run_on_firebase'
@@ -44,7 +46,7 @@ jobs:
         env:
           GOOGLE_APPLICATION_CREDENTIALS: $(gcServiceAccountKey.secureFilePath)
         name: runUiAutomation
-        displayName: Run UI Automation on Firebase
+        displayName: Run UI Automation on Firebase (with Flank)
         inputs:
           targetType: inline
           script: |
@@ -68,6 +70,7 @@ jobs:
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
               --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}" \
+              --max-test-shards ${{ parameters.flankShards }} \
               --smart-flank-gcs-path "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/smart-flank-xml/msal-only/JUnitReport.xml"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/JUnitReport.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File

--- a/azure-pipelines/ui-automation/templates/run-on-firebase.yml
+++ b/azure-pipelines/ui-automation/templates/run-on-firebase.yml
@@ -4,10 +4,10 @@ parameters:
   - name: automationAppTestApkPath
     type: string
   - name: testTargetPackages
-    displayName: Packages as Test Targets
+    type: string
+  - name: apiLevelTarget
     type: string
   - name: resultsHistoryName
-    displayName: Results History Name
     type: string
   - name: otherFiles
     type: string
@@ -18,34 +18,14 @@ parameters:
     default: 45m
   - name: firebaseDeviceId
     type: string
-    displayName: Firebase Device Id
-    default: blueline
-    values:
-      - blueline
-      - flame
-      - redfin
-      - sailfish
-      - walleye
-      - bluejay
-      - oriole
   - name: firebaseDeviceAndroidVersion
-    displayName: Firebase Device Android Version
     type: number
-    default: 28
-    values:
-      - 25
-      - 26
-      - 27
-      - 28
-      - 29
-      - 30
-      - 31
-      - 32
-      - 33
+  - name: testRunTitle
+    type: string
 
 jobs:
   - job: 'run_on_firebase'
-    displayName: Running Test Suite on Firebease
+    displayName: Running Test Suite on Firebase
     timeoutInMinutes: 90
     pool:
       vmImage: ubuntu-latest
@@ -73,14 +53,14 @@ jobs:
               --app "${{ parameters.automationAppApkPath }}" \
               --test "${{ parameters.automationAppTestApkPath }}" \
               --device "model=${{ parameters.firebaseDeviceId }},version=${{ parameters.firebaseDeviceAndroidVersion }}" \
-              --timeout "$(firebaseTimeout)" \
+              --timeout "${{ parameters.firebaseTimeout }}" \
               --other-files ${{ parameters.otherFiles }} \
               --results-dir "${{ parameters.resultsDir }}" \
               --directories-to-pull "/sdcard" \
               --use-orchestrator \
               --environment-variables "clearPackageData=true" \
               --results-history-name "${{ parameters.resultsHistoryName }}" \
-              --test-targets "${{ parameters.testTargetPackages }}"
+              --test-targets "${{ parameters.testTargetPackages }}, ${{ parameters.apiLevelTarget }}"
       - script: gsutil cp "gs://test-lab-ffz6x9pu2y62a-is0rq7a7rwdhi/${{ parameters.resultsDir }}/${{ parameters.firebaseDeviceId }}-${{ parameters.firebaseDeviceAndroidVersion }}-en-portrait/test_result_1.xml" "$(Build.SourcesDirectory)"
         displayName: Download Test Result File
         condition: succeededOrFailed()
@@ -90,4 +70,4 @@ jobs:
         inputs:
           testResultsFiles: '*test_result*.xml'
           searchFolder: $(Build.SourcesDirectory)
-          testRunTitle: 'MSAL UI Automation - Build # $(Build.BuildNumber)'
+          testRunTitle: '${{ parameters.testRunTitle }}'

--- a/msalautomationapp/src/main/res/raw/msal_config_b2c_siso.json
+++ b/msalautomationapp/src/main/res/raw/msal_config_b2c_siso.json
@@ -4,7 +4,7 @@
   "authorities" : [
     {
       "type": "B2C",
-      "authority_url": "https://login.microsoftonline.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SISOPolicy/"
+      "authority_url": "https://msidlabb2c.b2clogin.com/tfp/msidlabb2c.onmicrosoft.com/B2C_1_SISOPolicy/"
     }
   ],
   "logging": {


### PR DESCRIPTION
Creating this PR to remove the hardcoded schedules from the MSAL pipelines YML files, which are being replaced by the usage of the scheduled triggers feature in ADO. ADO Schedule feature does already override whatever schedule is set in the yml file, but removing this schedule will allow us to turn off scheduled runs for a pipeline by disabling the schedule trigger in ADO (Since the schedule in the yml is removed here, this will not leave any scheduled runs and we can avoid the cost of running broken pipelines).

Doing this for the following scheduled Pipelines:
Dev MSAL With Dev BrokerHost: [Pipelines - Runs for Dev MSAL with Dev BrokerHost (azure.com)](https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1742)
Dev MSAL With Prod Broker: [Pipelines - Runs for Dev MSAL with Prod Broker (AuthApp, CP) (azure.com)](https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1761)
Dev MSAL Without Broker: [Pipelines - Runs for Dev MSAL without Broker (azure.com)](https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1743)
MSAL Release with Prod Broker: [Pipelines - Runs for MSAL Release Test with Prod Broker (azure.com)](https://dev.azure.com/IdentityDivision/Engineering/_build?definitionId=1763)

Also included a fix to B2C url, now using custom branded domain since global domain is broken at the moment.