### PR TITLE
UI Maintenance: Include Common Fixes, Fix flighting UI Test Case, Move Some Cases to the Right Package

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922530.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922530.java
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerUpdateTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -44,6 +45,7 @@ import java.util.Arrays;
 
 // [Joined] [Update-old-to-V5] Acquire PoP token Silent
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1922530
+@RetryOnFailure
 public class TestCase1922530  extends AbstractMsalBrokerUpdateTest {
     @Test
     public void test_1922530() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
@@ -22,6 +22,8 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.brokerapi;
 
+import androidx.annotation.NonNull;
+
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
@@ -107,7 +109,7 @@ public class TestCase1561087 extends AbstractMsalBrokerTest {
      *
      * @param flightToCheck flight to be checked against flight set from BrokerHost
      */
-    private void checkIfBrokerContainsFlight(final String flightToCheck) {
+    private void checkIfBrokerContainsFlight(@NonNull final String flightToCheck) {
         final String withoutBrackets = flightToCheck.replace("{", "").replace("}", "");
         Assert.assertTrue(mBroker.getFlights().contains(withoutBrackets));
     }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
@@ -42,32 +42,37 @@ public class TestCase1561087 extends AbstractMsalBrokerTest {
         // Set flights and get to check if the flight information is returned
         final String flightsJson =  "{\"SetFlightsTest\":\"true\"}";
         mBroker.overwriteFlights(flightsJson);
-        Assert.assertEquals(flightsJson, mBroker.getFlights());
+        containsWithoutBrackets(flightsJson);
 
         // Add flights and get to check if the flight information is returned
         final String anotherFlightJson = "{\"AnotherFlight\":\"hello\"}";
         mBroker.setFlights(anotherFlightJson);
-        Assert.assertEquals( "{\"AnotherFlight\":\"hello\",\"SetFlightsTest\":\"true\"}", mBroker.getFlights());
+        containsWithoutBrackets(anotherFlightJson);
+        containsWithoutBrackets(flightsJson);
 
         // Override flights and get to check if the flight information is returned
         final String flightToOverwrite = "{\"SetFlightsTest\":\"false\"}";
         mBroker.setFlights(flightToOverwrite);
-        Assert.assertEquals("{\"AnotherFlight\":\"hello\",\"SetFlightsTest\":\"false\"}", mBroker.getFlights());
+        containsWithoutBrackets(anotherFlightJson);
+        containsWithoutBrackets(flightToOverwrite);
 
         // Add flight with null value. SetFlightsTest should be removed.
         final String flightMapWithNullValue = "{\"SetFlightsTest\": null}";
         mBroker.setFlights(flightMapWithNullValue);
-        Assert.assertEquals("{\"AnotherFlight\":\"hello\"}", mBroker.getFlights());
+        containsWithoutBrackets(anotherFlightJson);
+        Assert.assertFalse(mBroker.getFlights().contains("SetFlightsTest"));
 
         // Add an empty flight map. the flight map should not change.
         final String emptyFlightMap = "{}";
+        final String oldFlights = mBroker.getFlights();
         mBroker.setFlights(emptyFlightMap);
-        Assert.assertEquals("{\"AnotherFlight\":\"hello\"}", mBroker.getFlights());
+        Assert.assertEquals(oldFlights, mBroker.getFlights());
 
-        // clear flights and get to check if the flights are cleared
+        // clear flights and get to check if the flights are cleared.
+        // Looks like some defaults flights are added even after flights are cleared, so we can check that the flights we added have been deleted.
         final String clearFlightsJson = "{}";
         mBroker.overwriteFlights(clearFlightsJson);
-        Assert.assertEquals(clearFlightsJson, mBroker.getFlights());
+        Assert.assertFalse(mBroker.getFlights().contains("AnotherFlight"));
     }
 
     @Override
@@ -95,5 +100,10 @@ public class TestCase1561087 extends AbstractMsalBrokerTest {
     @Override
     public int getConfigFileResourceId() {
         return R.raw.msal_config_default;
+    }
+
+    private void containsWithoutBrackets(final String flightToCheck) {
+        final String withoutBrackets = flightToCheck.replace("{", "").replace("}", "");
+        Assert.assertTrue(mBroker.getFlights().contains(withoutBrackets));
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1561087.java
@@ -42,24 +42,24 @@ public class TestCase1561087 extends AbstractMsalBrokerTest {
         // Set flights and get to check if the flight information is returned
         final String flightsJson =  "{\"SetFlightsTest\":\"true\"}";
         mBroker.overwriteFlights(flightsJson);
-        containsWithoutBrackets(flightsJson);
+        checkIfBrokerContainsFlight(flightsJson);
 
         // Add flights and get to check if the flight information is returned
         final String anotherFlightJson = "{\"AnotherFlight\":\"hello\"}";
         mBroker.setFlights(anotherFlightJson);
-        containsWithoutBrackets(anotherFlightJson);
-        containsWithoutBrackets(flightsJson);
+        checkIfBrokerContainsFlight(anotherFlightJson);
+        checkIfBrokerContainsFlight(flightsJson);
 
         // Override flights and get to check if the flight information is returned
         final String flightToOverwrite = "{\"SetFlightsTest\":\"false\"}";
         mBroker.setFlights(flightToOverwrite);
-        containsWithoutBrackets(anotherFlightJson);
-        containsWithoutBrackets(flightToOverwrite);
+        checkIfBrokerContainsFlight(anotherFlightJson);
+        checkIfBrokerContainsFlight(flightToOverwrite);
 
         // Add flight with null value. SetFlightsTest should be removed.
         final String flightMapWithNullValue = "{\"SetFlightsTest\": null}";
         mBroker.setFlights(flightMapWithNullValue);
-        containsWithoutBrackets(anotherFlightJson);
+        checkIfBrokerContainsFlight(anotherFlightJson);
         Assert.assertFalse(mBroker.getFlights().contains("SetFlightsTest"));
 
         // Add an empty flight map. the flight map should not change.
@@ -102,7 +102,12 @@ public class TestCase1561087 extends AbstractMsalBrokerTest {
         return R.raw.msal_config_default;
     }
 
-    private void containsWithoutBrackets(final String flightToCheck) {
+    /**
+     * Check if the Broker contain the parameter flight by removing brackets from the parameter and using String.contains()
+     *
+     * @param flightToCheck flight to be checked against flight set from BrokerHost
+     */
+    private void checkIfBrokerContainsFlight(final String flightToCheck) {
         final String withoutBrackets = flightToCheck.replace("{", "").replace("}", "");
         Assert.assertTrue(mBroker.getFlights().contains(withoutBrackets));
     }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833511.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833511.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.testpass.broker;
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.flw;
 
 import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
 
@@ -30,6 +30,7 @@ import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiSelector;
 
 import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
@@ -42,7 +43,7 @@ import org.junit.Test;
 // End My Shift - Perform shared device registration with non-admin account.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833511
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
-public class TestCase833511 extends AbstractMsalBrokerTest{
+public class TestCase833511 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833511() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -57,7 +57,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, only account from the same tenant should be able to acquire token.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833513
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure
+@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Checking for text error in WebView")
 public class TestCase833513 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, an account signed in through App A can be used by App B.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833514
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure
+@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Azure Sample App")
 public class TestCase833514 extends AbstractMsalBrokerTest {
 
@@ -167,7 +167,7 @@ public class TestCase833514 extends AbstractMsalBrokerTest {
 
         getAccountLatch.await(TokenRequestTimeout.SILENT);
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(3));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(8));
 
         final TokenRequestLatch silentLatch = new TokenRequestLatch(1);
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
@@ -20,7 +20,7 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.testpass.broker;
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.flw;
 
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.Prompt;
@@ -28,6 +28,7 @@ import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
@@ -36,6 +37,7 @@ import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequ
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.common.java.util.ThreadUtils;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
@@ -49,7 +51,7 @@ import java.util.Arrays;
 // End My Shift - In Shared device mode, MSAL should notify the app if the sign-out account is changed.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833517
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
-public class TestCase833517 extends AbstractMsalBrokerTest{
+public class TestCase833517 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833517() throws Throwable{
@@ -57,6 +59,7 @@ public class TestCase833517 extends AbstractMsalBrokerTest{
         final String password = mLabAccount.getPassword();
 
         mBroker.performSharedDeviceRegistration(username, password);
+
         final MsalSdk msalSdk = new MsalSdk();
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
@@ -89,12 +92,12 @@ public class TestCase833517 extends AbstractMsalBrokerTest{
 
         getSettingsScreen().removeAccount(username);
 
+        ThreadUtils.sleepSafely(10000, "Sleep", "Interrupted");
+
         //final IPublicClientApplication pca = PublicClientApplication.create(mActivity,getConfigFileResourceId());
         final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
         Assert.assertNull(account);
     }
-
-
 
     @Override
     public LabQuery getLabQuery() {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -110,7 +110,6 @@ public class TestCase1561151 extends AbstractMsalBrokerTest {
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
-
         // get a token silently
         final MsalAuthResult silentAuthResult = msalSdk.acquireTokenSilent(silentParams, TokenRequestTimeout.SILENT);
         silentAuthResult.assertFailure();


### PR DESCRIPTION
This PR includes the UI Automation fixes from common, which mainly deal with playstore automation and timeout changes. Also fixed the flighting test case (https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561087) along with more retries/fixes for the other cases. Some test cases were in the wrong package and have been moved.


Pre-req: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1901