### PR TITLE
Add WebView UI Test Case, Re-activate AutoMFA cases, AzureSample now runnable on API 30+

### DIFF
--- a/msalautomationapp/src/androidTest/AndroidManifest.xml
+++ b/msalautomationapp/src/androidTest/AndroidManifest.xml
@@ -23,12 +23,4 @@
 
     </application>
 
-    <!-- Required for API Level 30 to make sure we can detect First Party Apps.-->
-    <queries>
-        <package android:name="com.microsoft.office.outlook" />
-        <package android:name="com.microsoft.office.word" />
-        <package android:name="com.microsoft.teams" />
-        <package android:name="com.azuresamples.msalandroidapp" />
-    </queries>
-
 </manifest>

--- a/msalautomationapp/src/androidTest/AndroidManifest.xml
+++ b/msalautomationapp/src/androidTest/AndroidManifest.xml
@@ -23,4 +23,12 @@
 
     </application>
 
+    <!-- Required for API Level 30 to make sure we can detect First Party Apps.-->
+    <queries>
+        <package android:name="com.microsoft.office.outlook" />
+        <package android:name="com.microsoft.office.word" />
+        <package android:name="com.microsoft.teams" />
+        <package android:name="com.azuresamples.msalandroidapp" />
+    </queries>
+
 </manifest>

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/AbstractMsalUiTest.java
@@ -43,8 +43,10 @@ import com.microsoft.identity.client.SilentAuthenticationCallback;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.client.ui.automation.ILabTest;
 import com.microsoft.identity.client.ui.automation.IRuleBasedTest;
+import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
 import com.microsoft.identity.client.ui.automation.browser.IBrowser;
+import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
 import com.microsoft.identity.client.ui.automation.rules.RulesHelper;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.labapi.utilities.BuildConfig;
@@ -335,5 +337,9 @@ public abstract class AbstractMsalUiTest implements IMsalTest, ILabTest, IRuleBa
     @Override
     public RuleChain getPrimaryRules() {
         return RulesHelper.getPrimaryRules(null);
+    }
+
+    protected ISettings getSettingsScreen() {
+        return TestContext.getTestContext().getTestDevice().getSettings();
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerTest.java
@@ -27,10 +27,8 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
 import com.microsoft.identity.client.msal.automationapp.BrokerTestHelper;
 import com.microsoft.identity.client.ui.automation.IBrokerTest;
-import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.ITestBroker;
-import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
 import com.microsoft.identity.client.ui.automation.rules.RulesHelper;
 
 import org.junit.rules.RuleChain;
@@ -56,9 +54,5 @@ public abstract class AbstractMsalBrokerTest extends AbstractMsalUiTest implemen
     @Override
     public RuleChain getPrimaryRules() {
         return RulesHelper.getPrimaryRules(getBroker());
-    }
-
-    protected ISettings getSettingsScreen() {
-        return TestContext.getTestContext().getTestDevice().getSettings();
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -61,7 +61,6 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833514
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
 @RetryOnFailure(retryCount = 2)
-@RunOnAPI29Minus("Azure Sample App")
 public class TestCase833514 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -60,7 +60,7 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, an account signed in through App A can be used by App B.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833514
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 public class TestCase833514 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -22,6 +22,9 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.flw;
 
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.MultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.SignInParameters;
@@ -31,19 +34,17 @@ import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
-import com.microsoft.identity.client.ui.automation.annotations.DoNotRunOnPipeline;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
-import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
-import com.microsoft.identity.client.ui.automation.browser.IBrowser;
+import com.microsoft.identity.client.ui.automation.browser.BrowserEdge;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.common.java.util.ThreadUtils;
 import com.microsoft.identity.labapi.utilities.client.ILabAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
@@ -55,17 +56,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.concurrent.TimeUnit;
 
 // End My Shift - In Shared device mode, global sign out should work.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure
-@RunOnAPI29Minus("Azure Sample App")
-@DoNotRunOnPipeline("This test is failing on pipeline at various points. Most commonly, getting 'an account is already signed in' when calling SAPCA.signIn()")
+@RetryOnFailure(retryCount = 2)
 public class TestCase833515 extends AbstractMsalBrokerTest {
-
-    final static String MY_APPS_URL = "myapps.microsoft.com";
 
     @Test
     public void test_833515() throws MsalException, InterruptedException, LabApiException {
@@ -92,7 +88,7 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         // we should be in shared device mode
         Assert.assertTrue(mApplication.isSharedDevice());
 
-        // fetching a new temp user from lab account
+        // fetching another user from lab account
         final LabQuery labQuery = LabQuery.builder()
                 .userType(UserType.CLOUD)
                 .build();
@@ -100,7 +96,6 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         final ILabAccount labAccount = mLabClient.getLabAccount(labQuery);
         final String username2 = labAccount.getUsername();
         final String password2 = labAccount.getPassword();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(30));
 
         Assert.assertNotEquals(username1, username2);
 
@@ -137,29 +132,41 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         azureSampleApp.uninstall();
         azureSampleApp.install();
         azureSampleApp.launch();
-        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
         azureSampleApp.confirmSignedIn(username2);
 
-        // clearing history of chrome.
-        final IBrowser chrome = new BrowserChrome();
-        chrome.clear();
+        // clearing history of edge
+        final BrowserEdge edge = new BrowserEdge();
+        edge.install();
+        edge.clear();
 
-        // relaunching chrome after clearing history of chrome.
-        chrome.launch();
-        chrome.handleFirstRun();
-        chrome.navigateTo(MY_APPS_URL);
+        // relaunching edge after clearing history
+        Assert.assertTrue(edge.confirmSignedIn(username2));
 
-        // login into myapps from chrome
-        final AadLoginComponentHandler aadLoginComponentHandler = new AadLoginComponentHandler();
-        aadLoginComponentHandler.handleEmailField(username2);
-        aadLoginComponentHandler.handlePasswordField(password2);
+        final TokenRequestLatch signOutLatch = new TokenRequestLatch(1);
 
-        //signing out from the application.
-        ((SingleAccountPublicClientApplication) mApplication).signOut();
+        // signing out from the application
+        ((SingleAccountPublicClientApplication) mApplication).signOut(new ISingleAccountPublicClientApplication.SignOutCallback() {
+            @Override
+            public void onSignOut() {
+                signOutLatch.countDown();
+            }
 
-        // TODO: Looks like the account picker is no longer showing up during sign out, is this expected?
-        // selecting which account should be logged out.
-        // aadLoginComponentHandler.handleAccountPicker(username2);
+            @Override
+            public void onError(@NonNull MsalException exception) {
+                Assert.fail("Sign out failed: " + exception.getMessage());
+            }
+        });
+
+        signOutLatch.await(TokenRequestTimeout.LONG);
+
+        ThreadUtils.sleepSafely(5000, "Interrupted", "Sleep failed");
+
+        edge.forceStop();
+        edge.launch();
+
+        // Sometime edge forces a restart when account is signed out, can continue by pressing "OK"
+        UiAutomatorUtils.handleButtonClickForObjectWithText("OK");
+        Assert.assertTrue(edge.confirmSignedIn(null));
 
         // Confirming account is signed out in Azure.
         azureSampleApp.launch();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833515.java
@@ -56,11 +56,12 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
 // End My Shift - In Shared device mode, global sign out should work.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833515
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 public class TestCase833515 extends AbstractMsalBrokerTest {
 
     @Test
@@ -96,6 +97,7 @@ public class TestCase833515 extends AbstractMsalBrokerTest {
         final ILabAccount labAccount = mLabClient.getLabAccount(labQuery);
         final String username2 = labAccount.getUsername();
         final String password2 = labAccount.getPassword();
+        Thread.sleep(TimeUnit.SECONDS.toMillis(30));
 
         Assert.assertNotEquals(username1, username2);
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833516.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833516.java
@@ -55,7 +55,7 @@ import java.util.Arrays;
 // End My Shift - In Shared device mode, there can be only one sign-in account.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833516
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 public class TestCase833516 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
@@ -51,6 +52,7 @@ import java.util.Arrays;
 // End My Shift - In Shared device mode, MSAL should notify the app if the sign-out account is changed.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833517
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
+@RetryOnFailure
 public class TestCase833517 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497044.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497044.java
@@ -29,6 +29,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -37,14 +39,14 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.Mfa;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
 
 // Interactive auth w/ force_login w/ MFA
 // https://identitydivision.visualstudio.com/DefaultCollection/DevEx/_workitems/edit/497044
-@Ignore("https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1886086")
+@RetryOnFailure(retryCount = 3) // Seems like AutoMFA does not work sometimes, seems rare but adding extra retries
+@RunOnAPI29Minus("Verify Your Identity (MFA)")
 public class TestCase497044 extends AbstractMsalUiTest {
 
     @Test
@@ -71,6 +73,7 @@ public class TestCase497044 extends AbstractMsalUiTest {
                         .sessionExpected(false)
                         .consentPageExpected(false)
                         .speedBumpExpected(false)
+                        .verifyYourIdentityPageExpected(true)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.basic
 
 import android.webkit.WebView;
 
+import androidx.annotation.NonNull;
 import androidx.test.uiautomator.UiObject;
 import androidx.test.uiautomator.UiSelector;
 
@@ -33,6 +34,7 @@ import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
 import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
@@ -45,12 +47,31 @@ import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
+import java.util.Collection;
 
 // MSAL Falls Back on WebView When All Browsers are Disabled
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/532736
+@RunWith(Parameterized.class)
+@RetryOnFailure
 public class TestCase532736 extends AbstractMsalUiTest {
+
+    private final int mConfigFileResourceId;
+
+    public TestCase532736(final String name, final @NonNull int configFileResourceId) {
+        mConfigFileResourceId = configFileResourceId;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection guestHomeAzureEnvironment() {
+        return Arrays.asList(new Object[][]{
+                {"DEFAULT_CONFIG", R.raw.msal_config_default},
+                {"BROWSER_CONFIG", R.raw.msal_config_browser},
+        });
+    }
 
     @After
     public void enableChrome() {
@@ -118,6 +139,6 @@ public class TestCase532736 extends AbstractMsalUiTest {
     }
     @Override
     public int getConfigFileResourceId() {
-        return R.raw.msal_config_browser;
+        return mConfigFileResourceId;
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
@@ -1,0 +1,116 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.basic;
+
+import android.webkit.WebView;
+
+import androidx.test.uiautomator.UiObject;
+import androidx.test.uiautomator.UiSelector;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
+import com.microsoft.identity.client.ui.automation.device.settings.ISettings;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// MSAL Falls Back on WebView When All Browsers are Disabled
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/532736
+public class TestCase532736 extends AbstractMsalUiTest {
+
+    @Test
+    public void test_532736() throws Throwable {
+        final String username = mLabAccount.getUsername();
+
+        // Disable Chrome
+        ISettings settings = getSettingsScreen();
+        BrowserChrome chrome = ((BrowserChrome) mBrowser);
+
+        settings.disableAppThroughSettings(chrome.getPackageName());
+
+        final MsalSdk msalSdk = new MsalSdk();
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.SELECT_ACCOUNT)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        msalSdk.acquireTokenInteractive(authTestParams, new OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                // Assert that webview UI object exists
+                final UiObject webView = UiAutomatorUtils.obtainUiObjectWithUiSelector(new UiSelector().className(WebView.class), CommonUtils.FIND_UI_ELEMENT_TIMEOUT);
+                Assert.assertTrue(webView.exists());
+
+                // Assert that no objects from Chrome package are present
+                final UiObject chromeObject = UiAutomatorUtils.obtainUiObjectWithUiSelector(new UiSelector().packageName("com.android.chrome"), CommonUtils.FIND_UI_ELEMENT_TIMEOUT);
+                Assert.assertFalse(chromeObject.exists());
+
+                // Some cleanup after the test passes
+                settings.enableAppThroughSettings(chrome.getPackageName());
+            }
+        }, TokenRequestTimeout.SILENT);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_browser;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase532736.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -51,13 +52,22 @@ import java.util.Arrays;
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/532736
 public class TestCase532736 extends AbstractMsalUiTest {
 
+    @After
+    public void enableChrome() {
+        final ISettings settings = getSettingsScreen();
+        final BrowserChrome chrome = ((BrowserChrome) mBrowser);
+
+        // Some cleanup after the test concludes
+        settings.enableAppThroughSettings(chrome.getPackageName());
+    }
+
     @Test
     public void test_532736() throws Throwable {
         final String username = mLabAccount.getUsername();
 
         // Disable Chrome
-        ISettings settings = getSettingsScreen();
-        BrowserChrome chrome = ((BrowserChrome) mBrowser);
+        final ISettings settings = getSettingsScreen();
+        final BrowserChrome chrome = ((BrowserChrome) mBrowser);
 
         settings.disableAppThroughSettings(chrome.getPackageName());
 
@@ -81,11 +91,8 @@ public class TestCase532736 extends AbstractMsalUiTest {
                 // Assert that no objects from Chrome package are present
                 final UiObject chromeObject = UiAutomatorUtils.obtainUiObjectWithUiSelector(new UiSelector().packageName("com.android.chrome"), CommonUtils.FIND_UI_ELEMENT_TIMEOUT);
                 Assert.assertFalse(chromeObject.exists());
-
-                // Some cleanup after the test passes
-                settings.enableAppThroughSettings(chrome.getPackageName());
             }
-        }, TokenRequestTimeout.SILENT);
+        }, TokenRequestTimeout.SILENT); // This isn't a silent request, but we want to complete it quickly since we're just checking for WebView
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99656.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99656.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -39,7 +41,6 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.Mfa;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -47,7 +48,8 @@ import java.util.concurrent.TimeUnit;
 
 // Interactive auth with force_login and step-up MFA
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99656
-@Ignore("https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1886086")
+@RetryOnFailure(retryCount = 3) // Seems like AutoMFA does not work sometimes, seems rare but adding extra retries
+@RunOnAPI29Minus("Verify Your Identity (MFA)")
 public class TestCase99656 extends AbstractMsalUiTest {
 
     private final String TAG = TestCase99656.class.getSimpleName();
@@ -76,6 +78,7 @@ public class TestCase99656 extends AbstractMsalUiTest {
                         .sessionExpected(false)
                         .consentPageExpected(false)
                         .speedBumpExpected(false)
+                        .verifyYourIdentityPageExpected(true)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938368.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938368.java
@@ -32,6 +32,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.app.IApp;
 import com.microsoft.identity.client.ui.automation.browser.BrowserChrome;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
@@ -55,6 +56,7 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/938368
 // Adding a retry on failure, sometimes arlington login page fails to load
 @RetryOnFailure(retryCount = 2)
+@RunOnAPI29Minus("Speed Bump Page")
 public class TestCase938368 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/main/AndroidManifest.xml
+++ b/msalautomationapp/src/main/AndroidManifest.xml
@@ -39,4 +39,12 @@
 
     </application>
 
+    <!-- Required for API Level 30 to make sure we can detect First Party Apps.-->
+    <queries>
+        <package android:name="com.microsoft.office.outlook" />
+        <package android:name="com.microsoft.office.word" />
+        <package android:name="com.microsoft.teams" />
+        <package android:name="com.azuresamples.msalandroidapp" />
+    </queries>
+
 </manifest>


### PR DESCRIPTION
Add automation for WebView test case: https://identitydivision.visualstudio.com/DevEx/_workitems/edit/532736

Also in this PR, tested Auto MFA account and found it is now working, added prompt handler support for pressing through Verify Your Identity page. Also added AzureSampleApp to AndroidManifest query so that it can be opened in API 30+. Some other tweaks to improve test stability.

Pre-req: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1906