### PR TITLE
Android 11 Compatibility

### DIFF
--- a/package-inspector/src/main/AndroidManifest.xml
+++ b/package-inspector/src/main/AndroidManifest.xml
@@ -2,6 +2,13 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.microsoft.inspector">
 
+    <permission android:name="android.permission.QUERY_ALL_PACKAGES" />
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.MAIN" />
+        </intent>
+    </queries>    
+    
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
Package Inspector does not find all apps starting from Android 11 - as per issue https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/1516