### PR TITLE
Revive most of the AcquireTokenNetworkTests

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -113,4 +113,13 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
             return query;
         }
     }
+
+    public static class MsaUser extends AcquireTokenAADTest {
+        @Override
+        public LabUserQuery getLabUserQuery() {
+            final LabUserQuery query = new LabUserQuery();
+            query.userType = LabConstants.UserType.MSA;
+            return query;
+        }
+    }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -26,8 +26,6 @@ import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabConstants;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
-import org.junit.Ignore;
-
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_AAD_MOONCAKE_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.AD_GRAPH_USER_READ_SCOPE;
@@ -110,20 +108,6 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         public LabUserQuery getLabUserQuery() {
             final LabUserQuery query = new LabUserQuery();
             query.protectionPolicy = LabConstants.ProtectionPolicy.MAM_SPO;
-            return query;
-        }
-    }
-
-    public static class MsaTypeUser extends AcquireTokenAADTest {
-        @Override
-        public String[] getScopes() {
-            return AD_GRAPH_USER_READ_SCOPE;
-        }
-        
-        @Override
-        public LabUserQuery getLabUserQuery() {
-            final LabUserQuery query = new LabUserQuery();
-            query.userType = LabConstants.UserType.MSA;
             return query;
         }
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -114,12 +114,17 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         }
     }
 
-//    public static class MsaUser extends AcquireTokenAADTest {
-//        @Override
-//        public LabUserQuery getLabUserQuery() {
-//            final LabUserQuery query = new LabUserQuery();
-//            query.userType = LabConstants.UserType.MSA;
-//            return query;
-//        }
-//    }
+    public static class MsaTypeUser extends AcquireTokenAADTest {
+        @Override
+        public String[] getScopes() {
+            return AD_GRAPH_USER_READ_SCOPE;
+        }
+        
+        @Override
+        public LabUserQuery getLabUserQuery() {
+            final LabUserQuery query = new LabUserQuery();
+            query.userType = LabConstants.UserType.MSA;
+            return query;
+        }
+    }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenAADTest.java
@@ -114,12 +114,12 @@ public abstract class AcquireTokenAADTest extends AcquireTokenNetworkTest {
         }
     }
 
-    public static class MsaUser extends AcquireTokenAADTest {
-        @Override
-        public LabUserQuery getLabUserQuery() {
-            final LabUserQuery query = new LabUserQuery();
-            query.userType = LabConstants.UserType.MSA;
-            return query;
-        }
-    }
+//    public static class MsaUser extends AcquireTokenAADTest {
+//        @Override
+//        public LabUserQuery getLabUserQuery() {
+//            final LabUserQuery query = new LabUserQuery();
+//            query.userType = LabConstants.UserType.MSA;
+//            return query;
+//        }
+//    }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
@@ -29,6 +29,8 @@ import static com.microsoft.identity.internal.testutils.TestConstants.Configurat
 import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.B2C_GLOBAL_DOMAIN_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.B2C_READ_SCOPE;
 
+import org.junit.Ignore;
+
 /**
  * Run all tests in the {@link AcquireTokenNetworkTest} class using B2C
  */
@@ -46,6 +48,7 @@ public abstract class AcquireTokenB2CTest extends AcquireTokenNetworkTest {
         return B2C_READ_SCOPE;
     }
 
+    @Ignore("There is something wrong with the response json being sent for these tests, need to ignore for now")
     public static class B2CLocalUserGlobalMsftDomain extends AcquireTokenB2CTest {
 
         @Override

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenB2CTest.java
@@ -48,7 +48,7 @@ public abstract class AcquireTokenB2CTest extends AcquireTokenNetworkTest {
         return B2C_READ_SCOPE;
     }
 
-    @Ignore("There is something wrong with the response json being sent for these tests, need to ignore for now")
+    @Ignore("We are getting 'You do not have permission to view this directory or page.' as response to token call, need to ignore this class for now")
     public static class B2CLocalUserGlobalMsftDomain extends AcquireTokenB2CTest {
 
         @Override

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenNetworkTest.java
@@ -36,7 +36,6 @@ import com.microsoft.identity.internal.testutils.labutils.LabUserHelper;
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestRule;
@@ -70,7 +69,6 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
-    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSuccess() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -85,7 +83,6 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
-    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSuccessFollowedBySilentSuccess() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -110,7 +107,6 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
-    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentSuccessForceRefresh() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -135,7 +131,6 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
-    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentFailureEmptyCache() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)
@@ -163,7 +158,6 @@ public abstract class AcquireTokenNetworkTest extends AcquireTokenAbstractTest i
     }
 
     @Test
-    @Ignore("Ignoring this for now, unknown external error in B2C")
     public void testAcquireTokenSilentSuccessCacheWithNoAccessToken() {
         final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
                 .startAuthorizationFromActivity(mActivity)


### PR DESCRIPTION
This PR was originally for adding msa tests to AcquireTokenNetworkTests, but after investigating I found out this was not possible, as ROPC is not available for MSA accounts so we cannot do non-ui acquire token calls. Instead this PR is now used to remove some ignore annotations to revive most of the tests in this class, except for `B2CLocalUserGlobalMsftDomain` which seems to still be broken, will need to follow up for that.