### PR TITLE
Adding sub error codes to MsalUiRequiredException

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,7 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
-
+- [MINOR] Adding sub error codes to MsalUiRequiredException (#1758)
 
 Version 4.1.3
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
@@ -26,8 +26,10 @@ package com.microsoft.identity.client.exception;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
-import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
+
+import lombok.Getter;
+import lombok.experimental.Accessors;
 
 /**
  * This exception indicates that UI is required for authentication to succeed.
@@ -56,27 +58,47 @@ public final class MsalUiRequiredException extends MsalException {
      */
     public static final String NO_ACCOUNT_FOUND = ErrorStrings.NO_ACCOUNT_FOUND;
 
+    @Getter
+    @Accessors(prefix = "m")
     @Nullable
     private String mOauthSubErrorCode;
 
+    /**
+     * Constructor of MsalUiRequiredException.
+     *
+     * @param errorCode String
+     */
     public MsalUiRequiredException(final String errorCode) {
         super(errorCode);
     }
 
+    /**
+     * Constructor of MsalUiRequiredException.
+     * @param errorCode    String
+     * @param errorMessage String
+     */
     public MsalUiRequiredException(final String errorCode, final String errorMessage) {
         super(errorCode, errorMessage);
     }
 
+    /**
+     * Constructor of MsalUiRequiredException.
+     * @param errorCode    String
+     * @param errorMessage String
+     * @param throwable    Throwable
+     */
     public MsalUiRequiredException(final String errorCode, final String errorMessage, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
     }
 
-    @Nullable
-    public String getOAuthSubErrorCode() {
-        return mOauthSubErrorCode;
-    }
-
-    public void setOauthSubErrorCode(@Nullable final String subErrorCode) {
-        mOauthSubErrorCode = subErrorCode;
+    /**
+     * Constructor of MsalUiRequiredException.
+     * @param errorCode         String
+     * @param oauthSubErrorCode String
+     * @param errorMessage      String
+     */
+    public MsalUiRequiredException(final String errorCode, @Nullable final String oauthSubErrorCode, final String errorMessage) {
+        super(errorCode, errorMessage);
+        mOauthSubErrorCode = oauthSubErrorCode;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
@@ -23,6 +23,8 @@
 
 package com.microsoft.identity.client.exception;
 
+import androidx.annotation.Nullable;
+
 import com.microsoft.identity.common.java.constants.OAuth2ErrorCode;
 import com.microsoft.identity.common.java.AuthenticationConstants;
 import com.microsoft.identity.common.java.exception.ErrorStrings;
@@ -54,6 +56,9 @@ public final class MsalUiRequiredException extends MsalException {
      */
     public static final String NO_ACCOUNT_FOUND = ErrorStrings.NO_ACCOUNT_FOUND;
 
+    @Nullable
+    private String mOauthSubErrorCode;
+
     public MsalUiRequiredException(final String errorCode) {
         super(errorCode);
     }
@@ -64,5 +69,14 @@ public final class MsalUiRequiredException extends MsalException {
 
     public MsalUiRequiredException(final String errorCode, final String errorMessage, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
+    }
+
+    @Nullable
+    public String getOAuthSubErrorCode() {
+        return mOauthSubErrorCode;
+    }
+
+    public void setOauthSubErrorCode(@Nullable final String subErrorCode) {
+        mOauthSubErrorCode = subErrorCode;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
@@ -22,8 +22,6 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.internal.controllers;
 
-import static com.microsoft.identity.common.java.exception.ErrorStrings.UNSUPPORTED_BROKER_VERSION_ERROR_CODE;
-
 import com.microsoft.identity.client.exception.MsalArgumentException;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
@@ -69,9 +67,11 @@ public class MsalExceptionAdapter {
 
         if (e instanceof UiRequiredException) {
             final UiRequiredException uiRequiredException = ((UiRequiredException) e);
-            final MsalUiRequiredException msalUiRequiredException = new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
-            msalUiRequiredException.setOauthSubErrorCode(uiRequiredException.getOAuthSubErrorCode());
-            return msalUiRequiredException;
+            return new MsalUiRequiredException(
+                    uiRequiredException.getErrorCode(),
+                    uiRequiredException.getOAuthSubErrorCode(),
+                    uiRequiredException.getMessage()
+            );
         }
 
         if (e instanceof IntuneAppProtectionPolicyRequiredException) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
@@ -69,7 +69,9 @@ public class MsalExceptionAdapter {
 
         if (e instanceof UiRequiredException) {
             final UiRequiredException uiRequiredException = ((UiRequiredException) e);
-            return new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
+            final MsalUiRequiredException msalUiRequiredException = new MsalUiRequiredException(uiRequiredException.getErrorCode(), uiRequiredException.getMessage());
+            msalUiRequiredException.setOauthSubErrorCode(uiRequiredException.getOAuthSubErrorCode());
+            return msalUiRequiredException;
         }
 
         if (e instanceof IntuneAppProtectionPolicyRequiredException) {


### PR DESCRIPTION
## Summary
This PR addresses a request from Teams to expose the server sub error code when we return a `MsalUiRequiredException`. This sub error code can help Teams provide the user with a more meaningful message when prompting for reauthentication. 

When generated due to an eSTS response, the only time `MsalUiRequiredException` is created is within `MsalExceptionAdapter`, where the `BaseException` transform into `MsalUiRequiredException` only if the `BaseException` is an instance of `UiRequiredException`. 
Fortunately, `UiRequiredException` already has a field for an OAuth sub error code via `ServiceException`, so the only work that needed to be done was:
- Make sure the OAuth sub error field is set properly within `UiRequiredException` when it is created due to an error received from the server (interaction_Required and invalid_grant error cases). 
- Add a corresponding OAuth sub error field to `MsalUiRequiredException` and set it based on `UiRequiredException` in the one place it is created. 

This PR addresses the latter point, while [this PR](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1944) addresses the former. 

Let me know if I seem to be missing anything.

I tested by attempting to silently auth with an account with a changed password (got invalid_grant error code with bad_token subcode).

## Related PR to review
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1944