### PR TITLE
Add preferred browser support

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
+- [MINOR] Add preferred browser support (#1761)
 - [MINOR] Adding sub error codes to MsalUiRequiredException (#1758)
 
 Version 4.2.0

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -77,6 +77,7 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.LOGGING;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.MULTIPLE_CLOUDS_SUPPORTED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.POWER_OPT_CHECK_FOR_NETWORK_REQUEST_ENABLED;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.PREFERRED_BROWSER;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REDIRECT_URI;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REQUIRED_BROKER_PROTOCOL_VERSION;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.TELEMETRY;
@@ -103,6 +104,7 @@ public class PublicClientApplicationConfiguration {
         static final String ENVIRONMENT = "environment";
         static final String REQUIRED_BROKER_PROTOCOL_VERSION = "minimum_required_broker_protocol_version";
         static final String TELEMETRY = "telemetry";
+        static final String PREFERRED_BROWSER = "preferred_browser";
         static final String BROWSER_SAFE_LIST = "browser_safelist";
         static final String ACCOUNT_MODE = "account_mode";
         static final String CLIENT_CAPABILITIES = "client_capabilities";
@@ -142,6 +144,9 @@ public class PublicClientApplicationConfiguration {
 
     @SerializedName(REQUIRED_BROKER_PROTOCOL_VERSION)
     private String mRequiredBrokerProtocolVersion;
+
+    @SerializedName(PREFERRED_BROWSER)
+    private BrowserDescriptor mPreferredBrowser;
 
     @SerializedName(BROWSER_SAFE_LIST)
     private List<BrowserDescriptor> mBrowserSafeList;
@@ -189,6 +194,15 @@ public class PublicClientApplicationConfiguration {
      */
     public void setTokenCacheSecretKeys(@NonNull final byte[] rawKey) {
         AuthenticationSettings.INSTANCE.setSecretKey(rawKey);
+    }
+
+    /**
+     * Gets the preferred browser.
+     *
+     * @return The preferred browser to be used for auth flow.
+     */
+    public BrowserDescriptor getPreferredBrowser() {
+        return mPreferredBrowser;
     }
 
     /**
@@ -463,6 +477,7 @@ public class PublicClientApplicationConfiguration {
         this.mUseBroker = config.mUseBroker == null ? this.mUseBroker : config.mUseBroker;
         this.mTelemetryConfiguration = config.mTelemetryConfiguration == null ? this.mTelemetryConfiguration : config.mTelemetryConfiguration;
         this.mRequiredBrokerProtocolVersion = config.mRequiredBrokerProtocolVersion == null ? this.mRequiredBrokerProtocolVersion : config.mRequiredBrokerProtocolVersion;
+        this.mPreferredBrowser = config.mPreferredBrowser == null ? this.mPreferredBrowser : config.mPreferredBrowser;
         if (this.mBrowserSafeList == null) {
             this.mBrowserSafeList = config.mBrowserSafeList;
         } else if (config.mBrowserSafeList != null) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -130,6 +130,7 @@ public class CommandParametersAdapter {
                 .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
                 .sdkType(SdkType.MSAL)
                 .sdkVersion(PublicClientApplication.getSdkVersion())
+                .preferredBrowser(configuration.getPreferredBrowser())
                 .browserSafeList(configuration.getBrowserSafeList())
                 .authority(authority)
                 .claimsRequestJson(claimsRequestJson)

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -28,6 +28,7 @@
     "logcat_enabled": true
   },
   "account_mode": "MULTIPLE",
+  "preferred_browser" : null,
   "browser_safelist": [
     {
       "browser_package_name": "com.android.chrome",

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
@@ -54,7 +54,9 @@ public class MultipleAccountModeWrapper extends MsalWrapper {
     @Override
     public String getDefaultBrowser() {
         try {
-            return BrowserSelector.select(mApp.getConfiguration().getAppContext(), mApp.getConfiguration().getBrowserSafeList()).getPackageName();
+            return BrowserSelector.select(mApp.getConfiguration().getAppContext(),
+                    mApp.getConfiguration().getBrowserSafeList(),
+                    mApp.getConfiguration().getPreferredBrowser()).getPackageName();
         } catch (ClientException e) {
             return "Unknown";
         }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
@@ -58,7 +58,9 @@ public class SingleAccountModeWrapper extends MsalWrapper {
     @Override
     public String getDefaultBrowser() {
         try {
-            return BrowserSelector.select(mApp.getConfiguration().getAppContext(), mApp.getConfiguration().getBrowserSafeList()).getPackageName();
+            return BrowserSelector.select(mApp.getConfiguration().getAppContext(),
+                    mApp.getConfiguration().getBrowserSafeList(),
+                    mApp.getConfiguration().getPreferredBrowser()).getPackageName();
         } catch (ClientException e) {
             return "Unknown";
         }


### PR DESCRIPTION
related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1957

----

Workaround for https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2314902

If "preferred_browser" is set (in MSAL configuration), then MSAL and Broker (for Intune COBO/CloutExt only) will use that browser if it's installed and the package condition matches.

Otherwise, It will fall back to the existing behavior.

Did manual test with MSAL + Broker. Added 2 unit tests.
Will ask for explicit sign off from Intune before merging in.