### PR TITLE
CIAM Authority and Split Domain

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
+- [MAJOR] Support CIAM Authority Type (#1783)
 - [MINOR] Bumping YubiKit Versions to 2.2.0 (#1784)
 
 Version 4.3.1

--- a/changelog
+++ b/changelog
@@ -1,7 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.Next
 ----------
-- [MAJOR] Support CIAM Authority Type (#1783)
+- [MINOR] Support CIAM Authority Type (#1783)
 - [MINOR] Bumping YubiKit Versions to 2.2.0 (#1784)
 
 Version 4.3.1

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -255,6 +255,25 @@ public final class PublicClientApplicationTest {
                 });
     }
 
+    @Test
+    public void testMultipleAccountCIAMAuthorityAsyncConstructor() {
+        final Context context = new PublicClientApplicationTest.MockContext(mAppContext);
+        mockPackageManagerWithDefaultFlag(context);
+        mockHasCustomTabRedirect(context);
+
+        try {
+            final IMultipleAccountPublicClientApplication app = PublicClientApplication.createMultipleAccountPublicClientApplication(
+                    context,
+                    R.raw.test_msal_config_ciam_multiple_account
+            );
+            Assert.assertTrue(app instanceof IMultipleAccountPublicClientApplication);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (MsalException e) {
+            e.printStackTrace();
+        }
+    }
+
     /**
      * Verify correct exception is thrown if callback is not provided.
      */

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientApplicationTest.java
@@ -268,9 +268,9 @@ public final class PublicClientApplicationTest {
             );
             Assert.assertTrue(app instanceof IMultipleAccountPublicClientApplication);
         } catch (InterruptedException e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         } catch (MsalException e) {
-            e.printStackTrace();
+            Assert.fail(e.getMessage());
         }
     }
 

--- a/msal/src/androidTest/res/raw/test_msal_config_ciam_multiple_account.json
+++ b/msal/src/androidTest/res/raw/test_msal_config_ciam_multiple_account.json
@@ -1,0 +1,14 @@
+{
+  "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "multiple_clouds_supported":true,
+  "broker_redirect_uri_registered": true,
+  "account_mode": "MULTIPLE",
+  "authorities" : [
+    {
+      "type": "CIAM",
+      "authority_url": "https://login.microsoftonline.com/msidlabciam1.onmicrosoft.com/"
+    }
+  ]
+}

--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -174,7 +174,7 @@ public class Account implements IAccount {
     @NonNull
     public String getAuthority() {
         // If the environment shows CIAM, we should return an authority of format https://tenant.ciamlogin.com/tenant.onmicrosoft.com
-        if (getEnvironment().contains("ciamlogin.com")) {
+        if (getEnvironment() != null && getEnvironment().contains("ciamlogin.com")) {
             // Call static method in CIAMAuthority to create the full authority uri
             return CIAMAuthority.getFullAuthorityUrlFromAuthorityWithoutPath(getEnvironment());
         }

--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -174,7 +174,7 @@ public class Account implements IAccount {
     @NonNull
     public String getAuthority() {
         // If the environment shows CIAM, we should return an authority of format https://tenant.ciamlogin.com/tenant.onmicrosoft.com
-        if (getEnvironment() != null && getEnvironment().contains("ciamlogin.com")) {
+        if (getEnvironment() != null && getEnvironment().contains(CIAMAuthority.CIAM_LOGIN_URL_SEGMENT)) {
             // Call static method in CIAMAuthority to create the full authority uri
             return CIAMAuthority.getFullAuthorityUrlFromAuthorityWithoutPath(getEnvironment());
         }

--- a/msal/src/main/java/com/microsoft/identity/client/Account.java
+++ b/msal/src/main/java/com/microsoft/identity/client/Account.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.exception.MsalClientException;
+import com.microsoft.identity.common.java.authorities.CIAMAuthority;
 import com.microsoft.identity.common.java.util.SchemaUtil;
 import com.microsoft.identity.common.java.providers.microsoft.MicrosoftIdToken;
 import com.microsoft.identity.common.java.providers.oauth2.IDToken;
@@ -172,6 +173,11 @@ public class Account implements IAccount {
     @Override
     @NonNull
     public String getAuthority() {
+        // If the environment shows CIAM, we should return an authority of format https://tenant.ciamlogin.com/tenant.onmicrosoft.com
+        if (getEnvironment().contains("ciamlogin.com")) {
+            // Call static method in CIAMAuthority to create the full authority uri
+            return CIAMAuthority.getFullAuthorityUrlFromAuthorityWithoutPath(getEnvironment());
+        }
         // TODO: The below logic only works for the case of AAD. We need to refactor this once we
         //  make a proper fix for B2C
         if (null != getClaims()) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -92,6 +92,7 @@ import com.microsoft.identity.common.internal.net.cache.HttpCache;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryB2CAuthority;
+import com.microsoft.identity.common.java.authorities.CIAMAuthority;
 import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.cache.IMultiTypeNameValueStorage;
 import com.microsoft.identity.common.java.cache.IShareSingleSignOnState;
@@ -1685,8 +1686,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final String requestAuthority = tokenParameters.getAuthority();
         final Authority authority = Authority.getAuthorityFromAuthorityUrl(requestAuthority);
 
-        if (authority instanceof AzureActiveDirectoryB2CAuthority) {
-            // use home account - b2c is not compatible with broker, so no need to construct
+        if (authority instanceof AzureActiveDirectoryB2CAuthority || authority instanceof CIAMAuthority) {
+            // use home account - b2c and CIAM are not compatible with broker, so no need to construct
             // the account used in the request...
             return AccountAdapter.getAccountInternal(
                     mPublicClientConfiguration.getClientId(),

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -127,7 +127,7 @@ public class MSALControllerFactory {
         final String methodTag = TAG + ":brokerEligible";
         final String logBrokerEligibleFalse = "Eligible to call broker? [false]. ";
 
-        //If app has asked for Broker or if the authority is not AAD return false
+        //If app has not asked for Broker or if the authority is not AAD return false
         if (!applicationConfiguration.getUseBroker() || !(authority instanceof AzureActiveDirectoryAuthority)) {
             Logger.verbose( methodTag, logBrokerEligibleFalse +
                     "App does not ask for Broker or the authority is not AAD authority.");

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -29,6 +29,7 @@ import androidx.annotation.NonNull;
 import com.microsoft.identity.common.java.authorities.AccountsInOneOrganization;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience;
+import com.microsoft.identity.common.java.authorities.CIAMAuthority;
 import com.microsoft.identity.common.java.authorities.UnknownAuthority;
 import com.microsoft.identity.internal.testutils.TestConstants;
 import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
@@ -82,6 +83,10 @@ public class ShadowAuthority {
         final List<String> pathSegments = authorityUri.getPathSegments();
 
         if (pathSegments.size() == 0) {
+            if (authorityUrl.contains("ciamlogin.com")){
+                // This is a CIAM authority, return CIAMTestAuthority
+                return new CIAMTestAuthority(CIAMAuthority.getFullAuthorityUrlFromAuthorityWithoutPath(authorityUrl));
+            }
             return new UnknownAuthority();
         }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -33,6 +33,7 @@ import com.microsoft.identity.common.java.authorities.UnknownAuthority;
 import com.microsoft.identity.internal.testutils.TestConstants;
 import com.microsoft.identity.internal.testutils.authorities.AADTestAuthority;
 import com.microsoft.identity.internal.testutils.authorities.B2CTestAuthority;
+import com.microsoft.identity.internal.testutils.authorities.CIAMTestAuthority;
 import com.microsoft.identity.internal.testutils.authorities.MockAuthority;
 import com.microsoft.identity.internal.testutils.authorities.MockDelayedResponseAuthority;
 
@@ -56,6 +57,8 @@ public class ShadowAuthority {
     private static final String B2C_PATH_SEGMENT = "tfp";
     private static final String B2C_PATH_SEGMENT_ALT = "te";
     private static final String AAD_MOCK_DELAYED_PATH_SEGMENT = "mock_with_delays";
+    private static final String CIAM_PATH_SEGMENT = "msidlabciam1.onmicrosoft.com";
+    private static final String CIAM_LAB_TENANT = "d57fb3d4-4b5a-4144-9328-9c1f7d58179d";
 
     /**
      * Returns an Authority based on an authority url.  This method works in similar way to the actual
@@ -104,6 +107,11 @@ public class ShadowAuthority {
             case B2C_PATH_SEGMENT_ALT:
                 //Return new B2C TEST Authority
                 authority = new B2CTestAuthority(authorityUrl);
+                break;
+            case CIAM_PATH_SEGMENT:
+            case CIAM_LAB_TENANT:
+                //Return new CIAM Test Authority
+                authority = new CIAMTestAuthority(authorityUrl);
                 break;
             default:
                 // return new AAD Test Authority

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAuthority.java
@@ -83,7 +83,7 @@ public class ShadowAuthority {
         final List<String> pathSegments = authorityUri.getPathSegments();
 
         if (pathSegments.size() == 0) {
-            if (authorityUrl.contains("ciamlogin.com")){
+            if (authorityUrl.contains(CIAMAuthority.CIAM_LOGIN_URL_SEGMENT)){
                 // This is a CIAM authority, return CIAMTestAuthority
                 return new CIAMTestAuthority(CIAMAuthority.getFullAuthorityUrlFromAuthorityWithoutPath(authorityUrl));
             }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenCIAMTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenCIAMTest.java
@@ -22,7 +22,9 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.e2e.tests.network;
 
-import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.MULTIPLE_ACCOUNT_MODE_CIAM_CONFIG_FILE_PATH;
+import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.CIAM_NO_PATH_CONFIG_FILE_PATH;
+import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.CIAM_TENANT_DOMAIN_CONFIG_FILE_PATH;
+import static com.microsoft.identity.internal.testutils.TestConstants.Configurations.CIAM_TENANT_GUID_CONFIG_FILE_PATH;
 import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.SUBSTRATE_USER_READ_SCOPE;
 
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
@@ -35,26 +37,40 @@ import com.microsoft.identity.internal.testutils.labutils.LabUserQuery;
 public abstract class AcquireTokenCIAMTest extends AcquireTokenNetworkTest {
 
     @Override
-    public String getConfigFilePath() {
-        return MULTIPLE_ACCOUNT_MODE_CIAM_CONFIG_FILE_PATH;
-    }
-
-    @Override
     public String[] getScopes() {
         return SUBSTRATE_USER_READ_SCOPE;
     }
 
     @Override
     public String getAuthority() {
-        return "https://login.microsoftonline.com/d57fb3d4-4b5a-4144-9328-9c1f7d58179d/";
+        return AcquireTokenTestHelper.getAccount().getAuthority();
     }
 
-    public static class CiamFederationProvider extends AcquireTokenCIAMTest {
+    @Override
+    public LabUserQuery getLabUserQuery() {
+        final LabUserQuery query = new LabUserQuery();
+        query.federationProvider = LabConstants.FederationProvider.CIAM;
+        return query;
+    }
+
+    public static class CiamTenantGUID extends AcquireTokenCIAMTest {
         @Override
-        public LabUserQuery getLabUserQuery() {
-            final LabUserQuery query = new LabUserQuery();
-            query.federationProvider = LabConstants.FederationProvider.CIAM;
-            return query;
+        public String getConfigFilePath() {
+            return CIAM_TENANT_GUID_CONFIG_FILE_PATH;
+        }
+    }
+
+    public static class CiamTenantDomain extends AcquireTokenCIAMTest {
+        @Override
+        public String getConfigFilePath() {
+            return CIAM_TENANT_DOMAIN_CONFIG_FILE_PATH;
+        }
+    }
+
+    public static class CiamTenantNoPath extends AcquireTokenCIAMTest {
+        @Override
+        public String getConfigFilePath() {
+            return CIAM_NO_PATH_CONFIG_FILE_PATH;
         }
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenCIAMTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/AcquireTokenCIAMTest.java
@@ -46,7 +46,7 @@ public abstract class AcquireTokenCIAMTest extends AcquireTokenNetworkTest {
 
     @Override
     public String getAuthority() {
-        return AcquireTokenTestHelper.getAccount().getAuthority();
+        return "https://login.microsoftonline.com/d57fb3d4-4b5a-4144-9328-9c1f7d58179d/";
     }
 
     public static class CiamFederationProvider extends AcquireTokenCIAMTest {

--- a/msal/src/test/res/raw/ciam_no_path_test_config.json
+++ b/msal/src/test/res/raw/ciam_no_path_test_config.json
@@ -1,0 +1,11 @@
+{
+  "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "authorities" : [
+    {
+      "type": "CIAM",
+      "authority_url": "https://msidlabciam1.ciamlogin.com"
+    }
+  ]
+}

--- a/msal/src/test/res/raw/ciam_tenant_domain_test_config.json
+++ b/msal/src/test/res/raw/ciam_tenant_domain_test_config.json
@@ -2,12 +2,10 @@
   "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "broker_redirect_uri_registered": true,
-  "account_mode": "MULTIPLE",
   "authorities" : [
     {
       "type": "CIAM",
-      "authority_url": "https://login.ciamlogin.com/msidlabciam1.onmicrosoft.com"
+      "authority_url": "https://msidlabciam1.ciamlogin.com/msidlabciam1.onmicrosoft.com"
     }
   ]
 }

--- a/msal/src/test/res/raw/ciam_tenant_guid_test_config.json
+++ b/msal/src/test/res/raw/ciam_tenant_guid_test_config.json
@@ -1,0 +1,11 @@
+{
+  "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "authorities" : [
+    {
+      "type": "CIAM",
+      "authority_url": "https://msidlabciam1.ciamlogin.com/d57fb3d4-4b5a-4144-9328-9c1f7d58179d"
+    }
+  ]
+}

--- a/msal/src/test/res/raw/multiple_account_ciam_test_config.json
+++ b/msal/src/test/res/raw/multiple_account_ciam_test_config.json
@@ -2,14 +2,12 @@
   "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
   "account_mode": "MULTIPLE",
   "authorities" : [
     {
-      "type": "AAD",
-      "authority_url": "https://login.microsoftonline.com/msidlabciam1.onmicrosoft.com/",
-      "default": true
+      "type": "CIAM",
+      "authority_url": "https://login.ciamlogin.com/msidlabciam1.onmicrosoft.com"
     }
   ]
 }

--- a/testapps/testapp/src/main/res/raw/msal_config_ciam.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_ciam.json
@@ -2,12 +2,10 @@
   "client_id" : "b8e9d222-c4ee-414c-ac29-b0eff1f32400",
   "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "broker_redirect_uri_registered": true,
-  "account_mode": "MULTIPLE",
   "authorities" : [
     {
       "type": "CIAM",
-      "authority_url": "https://login.windows.net/msidlabciam1.onmicrosoft.com",
+      "authority_url": "https://msidlabciam1.ciamlogin.com/msidlabciam1.onmicrosoft.com",
       "default": true
     }
   ]

--- a/testapps/testapp/src/main/res/raw/msal_config_ciam.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_ciam.json
@@ -6,8 +6,8 @@
   "account_mode": "MULTIPLE",
   "authorities" : [
     {
-      "type": "AAD",
-      "authority_url": "https://login.microsoftonline.com/msidlabciam1.onmicrosoft.com/",
+      "type": "CIAM",
+      "authority_url": "https://login.windows.net/msidlabciam1.onmicrosoft.com",
       "default": true
     }
   ]

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="prompt_behavior_text">Prompt</string>
     <string name="data_profile_text">Data Profile</string>
     <string name="scope_text">Scope</string>
-    <string name="scope_default_text">https://substrate.office.com/profile//User.Read</string>
+    <string name="scope_default_text">user.read</string>
     <string name="extra_scope_text">Extra Scopes</string>
     <string name="scope_text_hint">Type in scopes delimited by space</string>
     <string name="enable_pii_text">Enable PII</string>

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="prompt_behavior_text">Prompt</string>
     <string name="data_profile_text">Data Profile</string>
     <string name="scope_text">Scope</string>
-    <string name="scope_default_text">user.read</string>
+    <string name="scope_default_text">https://substrate.office.com/profile//User.Read</string>
     <string name="extra_scope_text">Extra Scopes</string>
     <string name="scope_text_hint">Type in scopes delimited by space</string>
     <string name="enable_pii_text">Enable PII</string>


### PR DESCRIPTION
**What:**
This PR includes MSAL-side changes to support a new CIAM Authority type and Split Domain

Changes:
- Add checks for CIAM authority to block integration with Broker.
- Add check for CIAM Environment in `Account.java` to ensure we are passing the current authority for silent requests.
- Add CIAM test classes to network testing infrastructure
- Pull common-side changes for CIAM authority (Pre-requisite PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/1992)

**Why:**
Simply explained, CIAM is a new offering from Microsoft to provide a combination of B2C and AAD features without sacrificing aspects of or changing the AAD developer experience.

For a much more detailed breakdown, here are some relevant resources:
- [CIAM Introductory Presentation](https://microsoft.sharepoint.com/:p:/t/aad/devex/EWBXiSmdhMNKoFhZ0LiYDpcBySPB7zfl79TI9EkI8a3ZKQ?e=kk6tHW)
- [CIAM Split Domain Doc](https://microsoft-my.sharepoint-df.com/:w:/r/personal/jmprieur_microsoft_com/_layouts/15/Doc.aspx?sourcedoc=%7BF07A764A-DA4A-4CE9-A2F2-D6671C174C47%7D&file=Impact%20of%20CIAM%20split%20domain%20on%20DevEx.docx&_DSL=1&action=default&mobileredirect=true)
- [CIAM Private Preview Repo](https://github.com/microsoft/entra-previews)

**How:**
My implementation focused on building off of existing AAD flow infrastructure to make sure we stay as close as possible to that developer experience.

**Testing:**
This PR includes 3 new classes in our network testing infrastructure to support three format of CIAM authorities passed in the JSON configuration file.
- https://tenantDomain.ciamlogin.com
- https://tenantDomain.ciamlogin.com/GUID
- https://tenantDomain.ciamlogin.com/tenantDomain.onmicrosoft.com

Also did manual testing for these three authority format using MsalTestApp with the following test steps:
- AcquireToken
- AcquireTokenSilent
- AcquireTokenSilent after forwarding device time by 1 day