### PR TITLE
Changes to support MSA accounts in Broker

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,7 +3,7 @@ V.Next
 ----------
 - [MINOR] Support CIAM Authority Type (#1783)
 - [MINOR] Bumping YubiKit Versions to 2.2.0 (#1784)
-- [MINOR] Changes to support MSA accounts in Broker #2003 (#1793)
+- [MINOR] Changes to support MSA accounts in Broker (#1793)
 
 Version 4.3.1
 ----------

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ V.Next
 ----------
 - [MINOR] Support CIAM Authority Type (#1783)
 - [MINOR] Bumping YubiKit Versions to 2.2.0 (#1784)
+- [MINOR] Changes to support MSA accounts in Broker #2003 (#1793)
 
 Version 4.3.1
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -22,34 +22,29 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.internal.controllers;
 
+import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
+
 import android.accounts.AccountManager;
 import android.accounts.AuthenticatorDescription;
 import android.annotation.TargetApi;
-import android.app.Activity;
 import android.content.Context;
 import android.os.Build;
 import android.os.PowerManager;
 
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.PublicClientApplicationConfiguration;
 import com.microsoft.identity.client.exception.MsalClientException;
-import com.microsoft.identity.common.java.authorities.AnyPersonalAccount;
-import com.microsoft.identity.common.java.authorities.Authority;
-import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
-import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.BrokerMsalController;
 import com.microsoft.identity.common.internal.controllers.LocalMSALController;
-import com.microsoft.identity.common.java.flighting.CommonFlight;
-import com.microsoft.identity.common.java.flighting.CommonFlightManager;
+import com.microsoft.identity.common.java.authorities.Authority;
+import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority;
+import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.microsoft.identity.common.java.AuthenticationConstants.Broker.BROKER_ACCOUNT_TYPE;
 
 /**
  * Responsible for returning the correct controller depending on the type of request (Silent, Interactive), authority
@@ -131,7 +126,7 @@ public class MSALControllerFactory {
 
         //If app has not asked for Broker or if the authority is not AAD return false
         if (!applicationConfiguration.getUseBroker() || !(authority instanceof AzureActiveDirectoryAuthority)) {
-            Logger.verbose( methodTag, logBrokerEligibleFalse +
+            Logger.verbose(methodTag, logBrokerEligibleFalse +
                     "App does not ask for Broker or the authority is not AAD authority.");
             return false;
         }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -134,15 +134,6 @@ public class MSALControllerFactory {
             return false;
         }
 
-        //Do not use broker when the audience is MSA only (personal accounts / consumers tenant alias)
-        AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
-
-        if (azureActiveDirectoryAuthority.getAudience() instanceof AnyPersonalAccount) {
-            Logger.verbose(methodTag, logBrokerEligibleFalse +
-                    "The audience is MSA only.");
-            return false;
-        }
-
         // Check if broker installed
         if (!brokerInstalled(applicationContext)) {
             Logger.verbose(methodTag, logBrokerEligibleFalse +

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -136,17 +136,6 @@ public class MSALControllerFactory {
             return false;
         }
 
-        if (!CommonFlightManager.isFlightEnabled(CommonFlight.SUPPORT_MSA_ACCOUNTS_IN_BROKER)) {
-            //Do not use broker when the audience is MSA only (personal accounts / consumers tenant alias)
-            AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
-
-            if (azureActiveDirectoryAuthority.getAudience() instanceof AnyPersonalAccount) {
-                Logger.verbose(methodTag, logBrokerEligibleFalse +
-                        "The audience is MSA only.");
-                return false;
-            }
-        }
-
         // Check if broker installed
         if (!brokerInstalled(applicationContext)) {
             Logger.verbose(methodTag, logBrokerEligibleFalse +

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.java
@@ -42,6 +42,8 @@ import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.java.controllers.BaseController;
 import com.microsoft.identity.common.internal.controllers.BrokerMsalController;
 import com.microsoft.identity.common.internal.controllers.LocalMSALController;
+import com.microsoft.identity.common.java.flighting.CommonFlight;
+import com.microsoft.identity.common.java.flighting.CommonFlightManager;
 import com.microsoft.identity.common.logging.Logger;
 
 import java.util.ArrayList;
@@ -132,6 +134,17 @@ public class MSALControllerFactory {
             Logger.verbose( methodTag, logBrokerEligibleFalse +
                     "App does not ask for Broker or the authority is not AAD authority.");
             return false;
+        }
+
+        if (!CommonFlightManager.isFlightEnabled(CommonFlight.SUPPORT_MSA_ACCOUNTS_IN_BROKER)) {
+            //Do not use broker when the audience is MSA only (personal accounts / consumers tenant alias)
+            AzureActiveDirectoryAuthority azureActiveDirectoryAuthority = (AzureActiveDirectoryAuthority) authority;
+
+            if (azureActiveDirectoryAuthority.getAudience() instanceof AnyPersonalAccount) {
+                Logger.verbose(methodTag, logBrokerEligibleFalse +
+                        "The audience is MSA only.");
+                return false;
+            }
         }
 
         // Check if broker installed

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -43,6 +43,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ToggleButton;
 
+import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.microsoft.identity.client.HttpMethod;
@@ -298,7 +299,9 @@ public class AcquireTokenFragment extends Fragment {
         mGetUsers.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                mOnFragmentInteractionListener.onGetUsers();
+                mOnFragmentInteractionListener.onGetUsers(
+                        Constants.getResourceIdFromConfigFile(getCurrentRequestOptions().getConfigFile())
+                );
             }
         });
 
@@ -349,7 +352,6 @@ public class AcquireTokenFragment extends Fragment {
             }
         });
 
-        loadMsalApplicationFromRequestParameters(getCurrentRequestOptions());
         return view;
     }
 
@@ -397,7 +399,7 @@ public class AcquireTokenFragment extends Fragment {
     @Override
     public void onResume() {
         super.onResume();
-        loadAccounts();
+        loadMsalApplicationFromRequestParameters(getCurrentRequestOptions());
     }
 
     private void loadAccounts() {
@@ -564,6 +566,6 @@ public class AcquireTokenFragment extends Fragment {
 
         void onGetStringResult(String valueToDisplay);
 
-        void onGetUsers();
+        void onGetUsers(int configFileResourceId);
     }
 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -22,6 +22,8 @@
 //   THE SOFTWARE.
 package com.microsoft.identity.client.testapp;
 
+import static com.microsoft.identity.client.testapp.R.id.enablePII;
+
 import android.app.Activity;
 import android.content.ClipData;
 import android.content.ClipboardManager;
@@ -43,7 +45,6 @@ import android.widget.TextView;
 import android.widget.Toast;
 import android.widget.ToggleButton;
 
-import androidx.annotation.NonNull;
 import androidx.fragment.app.Fragment;
 
 import com.microsoft.identity.client.HttpMethod;
@@ -57,8 +58,6 @@ import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static com.microsoft.identity.client.testapp.R.id.enablePII;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -257,8 +257,8 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
-    public void onGetUsers() {
-        final Fragment fragment = new UsersFragment();
+    public void onGetUsers(final int configResourceId) {
+        final Fragment fragment = new UsersFragment(configResourceId);
         attachFragment(fragment);
     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/UsersFragment.java
@@ -55,6 +55,11 @@ public class UsersFragment extends Fragment {
 
     private ListView mUserList;
     private Gson mGson;
+    private final int mIntConfigResourceId;
+
+    public UsersFragment(final int configResourceId) {
+        mIntConfigResourceId = configResourceId;
+    }
 
     @Override
     public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
@@ -63,7 +68,7 @@ public class UsersFragment extends Fragment {
         mUserList = view.findViewById(R.id.user_list);
 
         MsalWrapper.create(getContext(),
-                R.raw.msal_config_default,
+                mIntConfigResourceId,
                 new INotifyOperationResultCallback<MsalWrapper>() {
                     @Override
                     public void onSuccess(MsalWrapper msalWrapper) {


### PR DESCRIPTION
Two things done here:

- Let MSAL go to the Broker for MSA accounts (Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2003)
- Some improvements in MSAL Test App. I noticed that GetUsers fragment was always using default msal config resource id for loading accounts. So updated that to honor current request options. Also the correct place to load PCA is inside `onResume` so updated that too.