### PR TITLE
User/mohit/add ltw as build variant for automation

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'kotlin-android'
 
 def msalVersion = "4.+"
 
@@ -164,6 +165,7 @@ android {
 }
 
 dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"
 
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:$rootProject.ext.coreLibraryDesugaringVersion"
 

--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -23,6 +23,7 @@ android {
     final String BROKER_HOST = "BrokerHost"
     final String BROKER_MICROSOFT_AUTHENTICATOR = "BrokerMicrosoftAuthenticator"
     final String BROKER_COMPANY_PORTAL = "BrokerCompanyPortal"
+    final String BROKER_LTW = "BrokerLTW"
     final String AUTO_BROKER = "AutoBroker"
     final String SELECTED_BROKER = "SELECTED_BROKER"
 
@@ -61,6 +62,7 @@ android {
         // constants
         buildConfigField("String", BROKER_MICROSOFT_AUTHENTICATOR, "\"$BROKER_MICROSOFT_AUTHENTICATOR\"")
         buildConfigField("String", BROKER_COMPANY_PORTAL, "\"$BROKER_COMPANY_PORTAL\"")
+        buildConfigField("String", BROKER_LTW, "\"$BROKER_LTW\"")
         buildConfigField("String", BROKER_HOST, "\"$BROKER_HOST\"")
         buildConfigField("String", AUTO_BROKER, "\"$AUTO_BROKER\"")
     }
@@ -115,6 +117,11 @@ android {
         BrokerCompanyPortal {
             dimension "broker"
             buildConfigField("String", SELECTED_BROKER, "\"$BROKER_COMPANY_PORTAL\"")
+        }
+
+        BrokerLTW {
+            dimension "broker"
+            buildConfigField("String", SELECTED_BROKER, "\"$BROKER_LTW\"")
         }
 
         BrokerHost {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateAuthenticator.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateAuthenticator.kt
@@ -1,0 +1,106 @@
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.update
+
+import com.microsoft.identity.client.Prompt
+import com.microsoft.identity.client.msal.automationapp.R
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalCustomBrokerInstallationTest
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler
+import com.microsoft.identity.labapi.utilities.client.LabQuery
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment
+import com.microsoft.identity.labapi.utilities.constants.TempUserType
+import org.junit.Test
+import java.util.*
+
+//@SupportedBrokers(brokers = [BrokerMicrosoftAuthenticator::class])
+@RetryOnFailure
+class TestCaseUpdateAuthenticator : AbstractMsalCustomBrokerInstallationTest() {
+
+    @Test
+    @Throws(Throwable::class)
+    fun test_UpdateAuthenticator() {
+        val username = mLabAccount.username
+        val password = mLabAccount.password
+
+        val brokerAuthenticator = BrokerMicrosoftAuthenticator()
+        brokerAuthenticator.install()
+
+        val msalSdk = MsalSdk()
+        val authTestParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .promptParameter(Prompt.LOGIN)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResult = msalSdk.acquireTokenInteractive(authTestParams, {
+            val promptHandlerParameters = PromptHandlerParameters.builder()
+                .prompt(PromptParameter.LOGIN)
+                .loginHint(username)
+                .sessionExpected(false)
+                .consentPageExpected(false)
+                .speedBumpExpected(false)
+                .broker(null)
+                .expectingBrokerAccountChooserActivity(false)
+                .build()
+            AadPromptHandler(promptHandlerParameters)
+                .handlePrompt(username, password)
+        }, TokenRequestTimeout.MEDIUM)
+
+        // Check if auth result is success
+        authResult.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+
+        // Update the authenticator app
+        brokerAuthenticator.update()
+        // start silent token request in MSAL
+
+        // start silent token request in MSAL
+        val authTestSilentParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .authority(authority)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResultPostUpdate : MsalAuthResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT)
+        authResultPostUpdate.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+    }
+
+
+
+    override fun getLabQuery(): LabQuery {
+        return LabQuery.builder()
+            .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+            .build()
+    }
+
+    override fun getTempUserType(): TempUserType? {
+        return null
+    }
+
+    override fun getScopes(): Array<String>? {
+        return arrayOf("User.read")
+    }
+
+    override fun getAuthority(): String? {
+        return mApplication.configuration.defaultAuthority.authorityURL.toString()
+    }
+
+    override fun getConfigFileResourceId(): Int {
+        return R.raw.msal_config_default
+    }
+
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateCompanyPortal.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateCompanyPortal.kt
@@ -1,0 +1,108 @@
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.update
+
+import com.microsoft.identity.client.Prompt
+import com.microsoft.identity.client.msal.automationapp.R
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerUpdateTest
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalCustomBrokerInstallationTest
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers
+import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler
+import com.microsoft.identity.labapi.utilities.client.LabQuery
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment
+import com.microsoft.identity.labapi.utilities.constants.TempUserType
+import org.junit.Test
+import java.util.*
+
+//@SupportedBrokers(brokers = [BrokerCompanyPortal::class])
+@RetryOnFailure
+class TestCaseUpdateCompanyPortal : AbstractMsalCustomBrokerInstallationTest() {
+
+    @Test
+    @Throws(Throwable::class)
+    fun test_UpdateAuthenticator() {
+        val username = mLabAccount.username
+        val password = mLabAccount.password
+
+        val brokerCompanyPortal = BrokerCompanyPortal()
+        brokerCompanyPortal.install()
+
+        val msalSdk = MsalSdk()
+        val authTestParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .promptParameter(Prompt.LOGIN)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResult = msalSdk.acquireTokenInteractive(authTestParams, {
+            val promptHandlerParameters = PromptHandlerParameters.builder()
+                .prompt(PromptParameter.LOGIN)
+                .loginHint(username)
+                .sessionExpected(false)
+                .consentPageExpected(false)
+                .speedBumpExpected(false)
+                .broker(null)
+                .expectingBrokerAccountChooserActivity(false)
+                .build()
+            AadPromptHandler(promptHandlerParameters)
+                .handlePrompt(username, password)
+        }, TokenRequestTimeout.MEDIUM)
+
+        // Check if auth result is success
+        authResult.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+
+        // Update the authenticator app
+        brokerCompanyPortal.update()
+        // start silent token request in MSAL
+
+        // start silent token request in MSAL
+        val authTestSilentParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .authority(authority)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResultPostUpdate : MsalAuthResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT)
+        authResultPostUpdate.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+    }
+
+
+
+    override fun getLabQuery(): LabQuery {
+        return LabQuery.builder()
+            .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+            .build()
+    }
+
+    override fun getTempUserType(): TempUserType? {
+        return null
+    }
+
+    override fun getScopes(): Array<String>? {
+        return arrayOf("User.read")
+    }
+
+    override fun getAuthority(): String? {
+        return mApplication.configuration.defaultAuthority.authorityURL.toString()
+    }
+
+    override fun getConfigFileResourceId(): Int {
+        return R.raw.msal_config_default
+    }
+
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateLTW.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateLTW.kt
@@ -1,0 +1,108 @@
+package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.update
+
+import com.microsoft.identity.client.Prompt
+import com.microsoft.identity.client.msal.automationapp.R
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerUpdateTest
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalCustomBrokerInstallationTest
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers
+import com.microsoft.identity.client.ui.automation.broker.BrokerLTW
+import com.microsoft.identity.client.ui.automation.constants.AuthScheme
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler
+import com.microsoft.identity.labapi.utilities.client.LabQuery
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment
+import com.microsoft.identity.labapi.utilities.constants.TempUserType
+import org.junit.Test
+import java.util.*
+
+//@SupportedBrokers(brokers = [BrokerLTW::class])
+@RetryOnFailure
+class TestCaseUpdateLTW : AbstractMsalCustomBrokerInstallationTest() {
+
+    @Test
+    @Throws(Throwable::class)
+    fun test_UpdateAuthenticator() {
+        val username = mLabAccount.username
+        val password = mLabAccount.password
+
+        val brokerLTW = BrokerLTW()
+        brokerLTW.install()
+
+        val msalSdk = MsalSdk()
+        val authTestParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .promptParameter(Prompt.LOGIN)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResult = msalSdk.acquireTokenInteractive(authTestParams, {
+            val promptHandlerParameters = PromptHandlerParameters.builder()
+                .prompt(PromptParameter.LOGIN)
+                .loginHint(username)
+                .sessionExpected(false)
+                .consentPageExpected(false)
+                .speedBumpExpected(false)
+                .broker(null)
+                .expectingBrokerAccountChooserActivity(false)
+                .build()
+            AadPromptHandler(promptHandlerParameters)
+                .handlePrompt(username, password)
+        }, TokenRequestTimeout.MEDIUM)
+
+        // Check if auth result is success
+        authResult.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+
+        // Update the authenticator app
+        brokerLTW.update()
+        // start silent token request in MSAL
+
+        // start silent token request in MSAL
+        val authTestSilentParams = MsalAuthTestParams.builder()
+            .activity(mActivity)
+            .loginHint(username)
+            .scopes(Arrays.asList(*mScopes))
+            .authority(authority)
+            .authScheme(AuthScheme.POP)
+            .msalConfigResourceId(configFileResourceId)
+            .build()
+
+        val authResultPostUpdate : MsalAuthResult = msalSdk.acquireTokenSilent(authTestSilentParams, TokenRequestTimeout.SILENT)
+        authResultPostUpdate.assertSuccess()
+        MsalAuthResult.verifyATForPop(authResult.accessToken)
+    }
+
+
+
+    override fun getLabQuery(): LabQuery {
+        return LabQuery.builder()
+            .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+            .build()
+    }
+
+    override fun getTempUserType(): TempUserType? {
+        return null
+    }
+
+    override fun getScopes(): Array<String>? {
+        return arrayOf("User.read")
+    }
+
+    override fun getAuthority(): String? {
+        return mApplication.configuration.defaultAuthority.authorityURL.toString()
+    }
+
+    override fun getConfigFileResourceId(): Int {
+        return R.raw.msal_config_default
+    }
+
+}


### PR DESCRIPTION
This PR adds LTW as local build variant into the msal automation app.
Adds Kotlin support for the module.

Adds test cases for update scenario of broker apps.
Test case defined as below:
Our goal with this task is to add a testcase that should do the following thigs 
Install old Authenticator using new infrastructure added 
Acquire token using MSAL SDK and check if the response is successful 
Install new authenticator app. 
Acquire token using MSAL SDK and check if the response is successful 
Repeat the above steps with company portal and LTW 