### PR TITLE
Added a new button in MSALTestApp to get the active broker pkg name

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -53,8 +53,10 @@ import com.microsoft.identity.client.IAuthenticationResult;
 import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.Prompt;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.broker.BrokerValidator;
 import com.microsoft.identity.common.java.opentelemetry.OTelUtility;
+import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -86,6 +88,7 @@ public class AcquireTokenFragment extends Fragment {
     private Button mAcquireTokenSilentWithResource;
     private Button mAcquireTokenWithDeviceCodeFlow;
     private Button mBrokerHelper;
+    private Button mGetActiveBrokerPkg;
     private Button mGenerateSHR;
     private Spinner mSelectAccount;
     private Spinner mConfigFileSpinner;
@@ -153,6 +156,7 @@ public class AcquireTokenFragment extends Fragment {
         mAcquireTokenSilentWithResource = view.findViewById(R.id.btn_acquiretokensilentWithResource);
         mAcquireTokenWithDeviceCodeFlow = view.findViewById(R.id.btn_acquiretokenWithDeviceCodeFlow);
         mBrokerHelper = view.findViewById(R.id.btnBrokerHelper);
+        mGetActiveBrokerPkg = view.findViewById(R.id.btnGetActiveBroker);
         mGenerateSHR = view.findViewById(R.id.btn_generate_shr);
         mConfigFileSpinner = view.findViewById(R.id.configFile);
         mAuthScheme = view.findViewById(R.id.authentication_scheme);
@@ -292,6 +296,15 @@ public class AcquireTokenFragment extends Fragment {
             @Override
             public void onClick(View v) {
                 PublicClientApplication.showExpectedMsalRedirectUriInfo(activity);
+            }
+        });
+
+        mGetActiveBrokerPkg.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                final String activeBrokerPkgName = mMsalWrapper.getActiveBrokerPkgName(activity);
+                final String activeBrokerPkgNameMsg = StringUtil.isNullOrEmpty(activeBrokerPkgName) ? "Could not find a valid broker" : "Active broker pkg name : " + activeBrokerPkgName;
+                AcquireTokenFragment.this.showMessage(activeBrokerPkgNameMsg);
             }
         });
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -203,6 +203,8 @@ abstract class MsalWrapper {
 
     abstract void acquireTokenSilentAsyncInternal(@NonNull final AcquireTokenSilentParameters parameters);
 
+    abstract String getActiveBrokerPkgName(@NonNull final Activity activity);
+
     public void acquireTokenWithDeviceCodeFlow(@NonNull RequestOptions requestOptions,
                                                @NonNull final INotifyOperationResultCallback<IAuthenticationResult> callback) {
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
@@ -22,6 +22,8 @@
 //   THE SOFTWARE.
 package com.microsoft.identity.client.testapp;
 
+import android.app.Activity;
+
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.AcquireTokenParameters;
@@ -30,6 +32,8 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.PoPAuthenticationScheme;
+import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.java.exception.ClientException;
@@ -135,5 +139,10 @@ public class MultipleAccountModeWrapper extends MsalWrapper {
                     }
                 }
         );
+    }
+
+    @Override
+    public String getActiveBrokerPkgName(@NonNull final Activity activity) {
+        return ((PublicClientApplication) mApp).getActiveBrokerPackageName(activity.getApplicationContext());
     }
 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
@@ -22,6 +22,8 @@
 //   THE SOFTWARE.
 package com.microsoft.identity.client.testapp;
 
+import android.app.Activity;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -31,6 +33,8 @@ import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.PoPAuthenticationScheme;
+import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
 import com.microsoft.identity.common.java.exception.ClientException;
@@ -125,6 +129,11 @@ public class SingleAccountModeWrapper extends MsalWrapper {
     @Override
     void acquireTokenSilentAsyncInternal(@NonNull AcquireTokenSilentParameters parameters) {
         mApp.acquireTokenSilentAsync(parameters);
+    }
+
+    @Override
+    String getActiveBrokerPkgName(@NonNull Activity activity) {
+        return ((PublicClientApplication) mApp).getActiveBrokerPackageName(activity.getApplicationContext());
     }
 
     @Override

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -613,12 +613,21 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="horizontal">
-
+            <Button
+                android:id="@+id/btnGetActiveBroker"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="5"
+                android:gravity="center"
+                android:text="@string/get_active_broker" />
             <ToggleButton
                 android:id="@+id/btn_trust_debug_brkr"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_weight="1"
+                android:layout_weight="5"
+                android:gravity="center"
+                android:layout_gravity="center_vertical"
                 android:text="@string/trust_debug_broker" />
         </LinearLayout>
 

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -54,6 +54,7 @@
     <string name="config_file_text">Config File</string>
     <string name="auth_scheme_text">Auth Scheme</string>
     <string name="launch_main_activity_button">Start Task</string>
+    <string name="get_active_broker">Get active broker package</string>
 
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>


### PR DESCRIPTION
Added a new button in MSALTestApp to get the active broker pkg name. This is using the new API added for CP to fetch the active broker pkg name directly instead of using BrokerValidator.getCurrentActiveBrokerPackageName.

This will be useful for writing UI automation tests 