### PR TITLE
Change applicationId of msalAutomationApp

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         multiDexEnabled true
-        applicationId "com.msft.identity.client.sample"
+        applicationId "com.microsoft.identity.client.msal.automationapp"
         minSdkVersion rootProject.ext.automationAppMinSDKVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1


### PR DESCRIPTION
Issue : We are unable to install MsalTestApp from UI Automation infrastructure. The msalAutomationApp crashes instantly when install command is executed without any stacktrace. This was the case only with MsalTestApp and not for any other test apps.

Cause : The applicationId of msalAutomationApp mentioned in build.gradle is same as the pkg name of MsalTestApp. So when msal test app install command runs, it crashes the msalAutomationApp as it is trying to install another app with same appId.

Fix : Changed the appId of msalAutomationApp to match the one mentioned in AndroidManifest.xml

Thanks @fadidurah for helping with the root cause.