### PR TITLE
Fix exception in SDM 

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -82,9 +82,7 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                Logger.verbose(
-                        TAG, "acctHomeAccountId " + acctHomeAccountId  + " acctLocalAccountId "+ acctLocalAccountId);
-                if (acctLocalAccountId!=null && acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (acctLocalAccountId != null && acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -82,8 +82,9 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-
-                if (acctHomeAccountId.contains(acctLocalAccountId)) {
+                Logger.verbose(
+                        TAG, "acctHomeAccountId " + acctHomeAccountId  + " acctLocalAccountId "+ acctLocalAccountId);
+                if (acctLocalAccountId!=null && acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -616,8 +616,9 @@ public class SingleAccountPublicClientApplication
                             "Returning the first adapted account.");
         }
 
-        if (!account.isEmpty())
+        if (!account.isEmpty()) {
             return (MultiTenantAccount) account.get(0);
+        }
         return null;
     }
 

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -568,29 +568,11 @@ public class SingleAccountPublicClientApplication
     private MultiTenantAccount getPersistedCurrentAccount() {
         synchronized(SingleAccountPublicClientApplication.class) {
             final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
-            Logger.verbose(
-                    TAG, "currentAccountJsonString "+currentAccountJsonString);
             if (StringExtensions.isNullOrBlank(currentAccountJsonString)) {
                 return null;
             }
 
             final List<ICacheRecord> cacheRecordList = JsonExtensions.getICacheRecordListFromJsonString(currentAccountJsonString);
-            for (ICacheRecord cacheRecord : cacheRecordList) {
-                if (cacheRecord.getAccount()!=null) {
-                    Logger.verbose(TAG, "cache record : " + cacheRecord.getAccount());
-                    if (cacheRecord.getAccount().getUsername() != null ){
-                        Logger.verbose(TAG, "cache record username : " + cacheRecord.getAccount().getUsername());
-                    }
-
-                    if (cacheRecord.getAccount().getLocalAccountId() != null ){
-                        Logger.verbose(TAG, "cache record localAccountId : " + cacheRecord.getAccount().getLocalAccountId());
-                    }
-
-                    if (cacheRecord.getAccount().getHomeAccountId() != null ){
-                        Logger.verbose(TAG, "cache record HomeAccountId : " + cacheRecord.getAccount().getHomeAccountId());
-                    }
-                }
-            }
             return getAccountFromICacheRecordList(cacheRecordList);
         }
     }
@@ -607,16 +589,8 @@ public class SingleAccountPublicClientApplication
                 sharedPreferencesFileManager.clear();
                 return;
             }
-            Logger.verbose(TAG,"persistCurrentAccount method with cacheRecords size " + cacheRecords.size());
+            Logger.info(TAG,"persisting cache records with size " + cacheRecords.size());
             final String currentAccountJsonString = JsonExtensions.getJsonStringFromICacheRecordList(cacheRecords);
-            Logger.verbose(TAG,"persisting following string :  " + currentAccountJsonString);
-            for (ICacheRecord cacheRecord : cacheRecords) {
-                if (cacheRecord.getAccount()!=null && cacheRecord.getAccount().getLocalAccountId()!=null)
-                Logger.verbose(TAG, "persisted the cacheRecord with localAccountId : "+ cacheRecord.getAccount().getLocalAccountId());
-                else if (cacheRecord.getAccount()!=null) {
-                    Logger.verbose(TAG, "localAccountId sent by broker was null!");
-                }
-            }
             sharedPreferencesFileManager.putString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY, currentAccountJsonString);
         }
     }

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -602,7 +602,7 @@ public class SingleAccountPublicClientApplication
     private MultiTenantAccount getAccountFromICacheRecordList(@NonNull final List<ICacheRecord> cacheRecords) {
         final String methodTag = TAG + ":getAccountFromICacheRecords";
 
-        if (cacheRecords == null || cacheRecords.size() == 0) {
+        if (cacheRecords.size() == 0) {
             return null;
         }
 
@@ -616,7 +616,9 @@ public class SingleAccountPublicClientApplication
                             "Returning the first adapted account.");
         }
 
-        return (MultiTenantAccount) account.get(0);
+        if (!account.isEmpty())
+            return (MultiTenantAccount) account.get(0);
+        return null;
     }
 
     @Override

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -62,7 +62,6 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager
 import com.microsoft.identity.common.internal.commands.GetCurrentAccountCommand;
 import com.microsoft.identity.common.internal.commands.RemoveCurrentAccountCommand;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
-import com.microsoft.identity.common.java.cache.CacheRecord;
 import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.DeviceCodeFlowCommandCallback;
@@ -263,13 +262,12 @@ public class SingleAccountPublicClientApplication
 
         if (signInParameters.getPrompt() == null) {
             acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS);
-        }
-        else {
+        } else {
             acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_SIGN_IN_WITH_PARAMETERS_PROMPT);
         }
 
     }
-    
+
     @Deprecated
     @Override
     public void signIn(@NonNull final Activity activity,
@@ -306,9 +304,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     * parameters for the SingleAccountPublicClientApplication API.
+     * Use {@link SingleAccountPublicClientApplication#signIn(SignInParameters)} instead.
      */
     @Deprecated
     @Override
@@ -372,17 +370,16 @@ public class SingleAccountPublicClientApplication
 
         if (signInParameters.getPrompt() == null) {
             acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS);
-        }
-        else {
+        } else {
             acquireTokenInternal(acquireTokenParameters, SINGLE_ACCOUNT_PCA_EXISTING_SIGN_IN_WITH_PARAMETERS_PROMPT);
         }
     }
 
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     * parameters for the SingleAccountPublicClientApplication API.
+     * Use {@link SingleAccountPublicClientApplication#signInAgain(SignInParameters)} instead.
      */
     @Deprecated
     @Override
@@ -454,7 +451,7 @@ public class SingleAccountPublicClientApplication
 
     /**
      * Returns true if the account ID of both account matches (or both accounts are null).
-     * */
+     */
     private boolean isHomeAccountIdMatching(@Nullable final IAccount firstAccount, @Nullable final IAccount secondAccount) {
         final MultiTenantAccount firstMultiTenantAccount = firstAccount instanceof MultiTenantAccount ? (MultiTenantAccount) firstAccount : null;
         final MultiTenantAccount secondMultiTenantAccount = secondAccount instanceof MultiTenantAccount ? (MultiTenantAccount) secondAccount : null;
@@ -566,7 +563,7 @@ public class SingleAccountPublicClientApplication
      * @return a persisted MultiTenantAccount. This could be null.
      */
     private MultiTenantAccount getPersistedCurrentAccount() {
-        synchronized(SingleAccountPublicClientApplication.class) {
+        synchronized (SingleAccountPublicClientApplication.class) {
             final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
             if (StringExtensions.isNullOrBlank(currentAccountJsonString)) {
                 return null;
@@ -584,12 +581,12 @@ public class SingleAccountPublicClientApplication
      *                     Please note that this layer will not verify if the list belongs to a single account or not.
      */
     private void persistCurrentAccount(@Nullable final List<ICacheRecord> cacheRecords) {
-        synchronized(SingleAccountPublicClientApplication.class) {
+        synchronized (SingleAccountPublicClientApplication.class) {
             if (cacheRecords == null || cacheRecords.size() == 0) {
                 sharedPreferencesFileManager.clear();
                 return;
             }
-            Logger.info(TAG,"persisting cache records with size " + cacheRecords.size());
+            Logger.info(TAG, "persisting cache records with size " + cacheRecords.size());
             final String currentAccountJsonString = JsonExtensions.getJsonStringFromICacheRecordList(cacheRecords);
             sharedPreferencesFileManager.putString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY, currentAccountJsonString);
         }
@@ -630,7 +627,7 @@ public class SingleAccountPublicClientApplication
         if (persistedAccount != null) {
             // Nothing is provided.
             if (acquireTokenParameters.getAccount() == null &&
-                    StringExtensions.isNullOrBlank(acquireTokenParameters.getLoginHint())){
+                    StringExtensions.isNullOrBlank(acquireTokenParameters.getLoginHint())) {
                 acquireTokenParameters
                         .getCallback()
                         .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
@@ -650,7 +647,7 @@ public class SingleAccountPublicClientApplication
 
             // If login hint is provided, check if the login hint matches with the persisted account's.
             if (!StringExtensions.isNullOrBlank(acquireTokenParameters.getLoginHint()) &&
-                    !persistedAccount.getUsername().equalsIgnoreCase(acquireTokenParameters.getLoginHint())){
+                    !persistedAccount.getUsername().equalsIgnoreCase(acquireTokenParameters.getLoginHint())) {
                 acquireTokenParameters
                         .getCallback()
                         .onError(new MsalClientException(MsalClientException.CURRENT_ACCOUNT_MISMATCH,
@@ -663,9 +660,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     * parameters for the SingleAccountPublicClientApplication API.
+     * Use {@link SingleAccountPublicClientApplication#acquireToken(AcquireTokenParameters)} instead.
      */
     @Override
     @Deprecated
@@ -700,9 +697,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     * parameters for the SingleAccountPublicClientApplication API.
+     * Use {@link SingleAccountPublicClientApplication#acquireTokenSilentAsync(AcquireTokenSilentParameters)} instead.
      */
     @Deprecated
     @Override
@@ -732,9 +729,9 @@ public class SingleAccountPublicClientApplication
     }
 
     /**
-     * @deprecated  This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
-     *              parameters for the SingleAccountPublicClientApplication API.
-     *              Use {@link SingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
+     * @deprecated This method is now deprecated. The library is moving towards standardizing the use of {@link SignInParameters} as the
+     * parameters for the SingleAccountPublicClientApplication API.
+     * Use {@link SingleAccountPublicClientApplication#acquireTokenSilent(AcquireTokenSilentParameters)} instead.
      */
     @Deprecated
     @WorkerThread

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -62,6 +62,7 @@ import com.microsoft.identity.common.internal.cache.SharedPreferencesFileManager
 import com.microsoft.identity.common.internal.commands.GetCurrentAccountCommand;
 import com.microsoft.identity.common.internal.commands.RemoveCurrentAccountCommand;
 import com.microsoft.identity.common.internal.migration.TokenMigrationCallback;
+import com.microsoft.identity.common.java.cache.CacheRecord;
 import com.microsoft.identity.common.java.cache.ICacheRecord;
 import com.microsoft.identity.common.java.commands.CommandCallback;
 import com.microsoft.identity.common.java.commands.DeviceCodeFlowCommandCallback;
@@ -567,12 +568,29 @@ public class SingleAccountPublicClientApplication
     private MultiTenantAccount getPersistedCurrentAccount() {
         synchronized(SingleAccountPublicClientApplication.class) {
             final String currentAccountJsonString = sharedPreferencesFileManager.getString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY);
-
+            Logger.verbose(
+                    TAG, "currentAccountJsonString "+currentAccountJsonString);
             if (StringExtensions.isNullOrBlank(currentAccountJsonString)) {
                 return null;
             }
 
             final List<ICacheRecord> cacheRecordList = JsonExtensions.getICacheRecordListFromJsonString(currentAccountJsonString);
+            for (ICacheRecord cacheRecord : cacheRecordList) {
+                if (cacheRecord.getAccount()!=null) {
+                    Logger.verbose(TAG, "cache record : " + cacheRecord.getAccount());
+                    if (cacheRecord.getAccount().getUsername() != null ){
+                        Logger.verbose(TAG, "cache record username : " + cacheRecord.getAccount().getUsername());
+                    }
+
+                    if (cacheRecord.getAccount().getLocalAccountId() != null ){
+                        Logger.verbose(TAG, "cache record localAccountId : " + cacheRecord.getAccount().getLocalAccountId());
+                    }
+
+                    if (cacheRecord.getAccount().getHomeAccountId() != null ){
+                        Logger.verbose(TAG, "cache record HomeAccountId : " + cacheRecord.getAccount().getHomeAccountId());
+                    }
+                }
+            }
             return getAccountFromICacheRecordList(cacheRecordList);
         }
     }
@@ -589,8 +607,16 @@ public class SingleAccountPublicClientApplication
                 sharedPreferencesFileManager.clear();
                 return;
             }
-
+            Logger.verbose(TAG,"persistCurrentAccount method with cacheRecords size " + cacheRecords.size());
             final String currentAccountJsonString = JsonExtensions.getJsonStringFromICacheRecordList(cacheRecords);
+            Logger.verbose(TAG,"persisting following string :  " + currentAccountJsonString);
+            for (ICacheRecord cacheRecord : cacheRecords) {
+                if (cacheRecord.getAccount()!=null && cacheRecord.getAccount().getLocalAccountId()!=null)
+                Logger.verbose(TAG, "persisted the cacheRecord with localAccountId : "+ cacheRecord.getAccount().getLocalAccountId());
+                else if (cacheRecord.getAccount()!=null) {
+                    Logger.verbose(TAG, "localAccountId sent by broker was null!");
+                }
+            }
             sharedPreferencesFileManager.putString(CURRENT_ACCOUNT_SHARED_PREFERENCE_KEY, currentAccountJsonString);
         }
     }


### PR DESCRIPTION
Problem : We got an IcM (https://portal.microsofticm.com/imp/v3/incidents/details/390194576/home) in which a single user of yammer app reported that the app was crashing upon launch in SDM. 
Check the IcM sumamry for the stacktrace. The issue is that we are getting a null localAccountId from the cache. We could not figure out why this issue is happening on 1 particular device as we did not get more logs requested.

Fix :  To avoid NPE, we simply added a null check

Note : This does not fix the original problem of localAccountId being NULL but at least can help fix the app from crashing.