### PR TITLE
Removing a flag entry in the cache for one cross cloud unit test

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
@@ -297,22 +297,17 @@ public class CrossCloudGuestAccountTest extends AcquireTokenAbstractTest {
         final IMultiTypeNameValueStorage sharedPreferences = mComponents.getStorageSupplier()
                 .getEncryptedFileStore(SHARED_PREFERENCES_NAME);
         final Map<String, ?> cacheValues = sharedPreferences.getAll();
+        //Getting rid of the SHA-1 cleared flag so it doesn't mess with the assertions below.
+        cacheValues.remove(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED);
 
-        if (cacheValues.size() == 5) {
-            assertNotNull("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account; check that one of them is the sha1-cleared flag",
-                    cacheValues.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED));
-        } else {
-            assertEquals("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account",
-                    4, cacheValues.size());
-        }
+        assertEquals("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account",
+                4, cacheValues.size());
 
         for (String key : cacheValues.keySet()) {
-            if (!key.equals(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED)) {
-                assertFalse("Verify cache record not found for homeAccountId of removed account",
-                        key.contains(mTestCaseData.homeAccountId));
-                assertTrue("Verify cache record found for account that was not removed",
-                        key.contains(accountNotToRemove.getId()));
-            }
+            assertFalse("Verify cache record not found for homeAccountId of removed account",
+                    key.contains(mTestCaseData.homeAccountId));
+            assertTrue("Verify cache record found for account that was not removed",
+                    key.contains(accountNotToRemove.getId()));
         }
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
@@ -65,6 +65,7 @@ import java.util.UUID;
 import java.util.regex.Pattern;
 
 import static com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper.getAccount;
+import static com.microsoft.identity.common.java.cache.AbstractAccountCredentialCache.SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED;
 import static com.microsoft.identity.internal.testutils.TestConstants.Scopes.USER_READ_SCOPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -297,8 +298,13 @@ public class CrossCloudGuestAccountTest extends AcquireTokenAbstractTest {
                 .getEncryptedFileStore(SHARED_PREFERENCES_NAME);
         final Map<String, ?> cacheValues = sharedPreferences.getAll();
 
-        assertEquals("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account",
-                4, cacheValues.size());
+        if (cacheValues.size() == 5) {
+            assertNotNull("If number of cache records = 5, check that one of them is sha1-cleared",
+                    cacheValues.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED));
+        } else {
+            assertEquals("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account",
+                    4, cacheValues.size());
+        }
 
         for (String key : cacheValues.keySet()) {
             assertFalse("Verify cache record not found for homeAccountId of removed account",

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
@@ -299,7 +299,7 @@ public class CrossCloudGuestAccountTest extends AcquireTokenAbstractTest {
         final Map<String, ?> cacheValues = sharedPreferences.getAll();
 
         if (cacheValues.size() == 5) {
-            assertNotNull("If number of cache records = 5, check that one of them is sha1-cleared",
+            assertNotNull("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account; check that one of them is the sha1-cleared flag",
                     cacheValues.get(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED));
         } else {
             assertEquals("Verify number of Cache records (AT, RT, IdToken, AccountRecord) for non removed account",

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CrossCloudGuestAccountTest.java
@@ -307,10 +307,12 @@ public class CrossCloudGuestAccountTest extends AcquireTokenAbstractTest {
         }
 
         for (String key : cacheValues.keySet()) {
-            assertFalse("Verify cache record not found for homeAccountId of removed account",
-                    key.contains(mTestCaseData.homeAccountId));
-            assertTrue("Verify cache record found for account that was not removed",
-                    key.contains(accountNotToRemove.getId()));
+            if (!key.equals(SHA1_APPLICATION_IDENTIFIER_ACCESS_TOKEN_CLEARED)) {
+                assertFalse("Verify cache record not found for homeAccountId of removed account",
+                        key.contains(mTestCaseData.homeAccountId));
+                assertTrue("Verify cache record found for account that was not removed",
+                        key.contains(accountNotToRemove.getId()));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
After [my PR was merged into common](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2058), one particular unit test in CrossCloudGuestAccountTest was failing. 
An assertion checks the size of the cache at one point, and the size expected is 4, while the actual value is 5. 5 is actually expected, because my PR added in another entry for a sha1-cleared flag. 
The next assertion also fails because the key for the flag doesn't follow the credential id convention. But since the flag isn't associated with a particular account, it shouldn't have an account id attached to it. 
This PR just removes the flag entry from the map before the assertions are run. As far as I know, there shouldn't be cases in prod where assumptions are made based just off of the size of the entire cache (the methods in SharedPreferencesAccountCredentialCache and SPACCWMC should only return parts of the cache that are specifically filtered to accounts, etc.). (but lmk if I've missed something)