### PR TITLE
Set target sdk and compile sdk to34

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ V.NEXT
 ----------
 - [PATCH] Accommodating broker validator refactoring (#1851)
 - [MINOR] Update YubiKit version to 2.3.0 (#1854)
+- [MINOR] Updated target and compile SDK versions to 34 (#1865)
 
 Version 4.6.2
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,8 +5,8 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 34
+    compileSdkVersion = 34
     buildToolsVersion = "28.0.3"
 
     // Plugins

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -35,7 +35,7 @@ ext {
     junitVersion = "4.12"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"
-    lombokVersion = "1.18.12"
+    lombokVersion = "1.18.22"
     materialVersion = "1.0.0"
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -7,6 +7,7 @@ ext {
     automationAppMinSDKVersion = 21
     targetSdkVersion = 34
     compileSdkVersion = 34
+    automationAndTestAppCompileSDK = 33
     buildToolsVersion = "28.0.3"
 
     // Plugins

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -68,7 +68,7 @@ ext {
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.3.0"
     yubikitPivVersion = "2.3.0"
-    powerliftAndroidVersion="1.0.0"
+    powerliftAndroidVersion="1.0.3"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"

--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -43,7 +43,7 @@ android {
         }
     }
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
 
     defaultConfig {
         multiDexEnabled true

--- a/msalautomationapp/src/main/AndroidManifest.xml
+++ b/msalautomationapp/src/main/AndroidManifest.xml
@@ -16,7 +16,9 @@
         android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
-            android:name=".MainActivity">
+            tools:replace="android:exported"
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -25,7 +27,9 @@
         </activity>
 
         <activity
-            android:name="com.microsoft.identity.client.BrowserTabActivity">
+            tools:replace="android:exported"
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/package-inspector/build.gradle
+++ b/package-inspector/build.gradle
@@ -8,7 +8,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
     buildToolsVersion rootProject.ext.buildToolsVersion
     defaultConfig {
         multiDexEnabled true

--- a/package-inspector/src/main/AndroidManifest.xml
+++ b/package-inspector/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.microsoft.inspector.MainActivity">
+        <activity 
+            android:name="com.microsoft.inspector.MainActivity"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -51,7 +51,7 @@ android {
     }
 
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdkVersion rootProject.ext.automationAndTestAppCompileSDK
     defaultConfig {
         multiDexEnabled true
         applicationId "com.msft.identity.client.sample"

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
             android:name="com.microsoft.identity.client.testapp.StartActivity"
             android:taskAffinity=""
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -63,7 +64,8 @@
             android:theme="@style/AppTheme.NoActionBar"
             android:taskAffinity=""
             android:documentLaunchMode="always"
-            android:configChanges="keyboardHidden|keyboard">
+            android:configChanges="keyboardHidden|keyboard"
+            android:exported="false">
         </activity>
 
         <activity

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -69,8 +69,10 @@
         </activity>
 
         <activity
+            tools:replace="android:exported"
             android:name="com.microsoft.identity.client.BrowserTabActivity"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
- Increasing the targetSDK and compileSDK to 34
- After increasing the targetSDK, it gave some errors like exported attribute must be added when there is an intent filter. So I added that.
- PowerliftSDK version to the latest '1.0.3' as this one has fixes for target and compile sdk to be 34.
- Automation and test apps still have compile sdk as 33