### PR TITLE
July Ui maintenance

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -57,7 +57,6 @@ import java.util.concurrent.TimeUnit;
 // End My Shift - In Shared device mode, only account from the same tenant should be able to acquire token.
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833513
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Checking for text error in WebView")
 public class TestCase833513 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -117,7 +117,7 @@ public class TestCase833513 extends AbstractMsalBrokerTest {
                 .broker(mBroker)
                 .prompt(PromptParameter.SELECT_ACCOUNT)
                 .expectingBrokerAccountChooserActivity(false)
-                .howWouldYouLikeToSignInExpected(false)
+                .howWouldYouLikeToSignInExpected(true)
                 .build();
 
         AdfsPromptHandler adfsPromptHandler = new AdfsPromptHandler(promptHandlerParameters);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833513.java
@@ -118,6 +118,7 @@ public class TestCase833513 extends AbstractMsalBrokerTest {
                 .prompt(PromptParameter.SELECT_ACCOUNT)
                 .expectingBrokerAccountChooserActivity(false)
                 .howWouldYouLikeToSignInExpected(true)
+                .chooseCertificateExpected(true)
                 .build();
 
         AdfsPromptHandler adfsPromptHandler = new AdfsPromptHandler(promptHandlerParameters);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase796050.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase796050.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
+import com.microsoft.identity.client.ui.automation.annotations.FailsWithDailyVersions;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
@@ -55,6 +56,7 @@ import java.util.Arrays;
 // "Add another account" option in Account Chooser Activity
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/796050
 @RetryOnFailure(retryCount = 2)
+@FailsWithDailyVersions("ESTS Seems to have a check against 0.0.X versions for MAM CA")
 public class TestCase796050 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase832430.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.FailsWithDailyVersions;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
@@ -46,6 +47,7 @@ import org.junit.Test;
 // [Joined][MSAL] Acquire Token + Acquire Token Silent with resource (Prompt.SELECT_ACCOUNT)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/832430
 @RetryOnFailure(retryCount = 2)
+@FailsWithDailyVersions("ESTS Seems to have a check against 0.0.X versions for MAM CA")
 public class TestCase832430 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase833526.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase833526.java
@@ -43,7 +43,6 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2579654.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2579654.kt
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout
 import com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers
 import com.microsoft.identity.client.ui.automation.broker.BrokerHost
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter
@@ -53,6 +54,7 @@ import org.junit.rules.TestRule
 // [MWPJ] After entry migration PRT is still usable without extra prompts.
 @LocalBrokerHostDebugUiTest
 @SupportedBrokers(brokers = [BrokerHost::class])
+@RetryOnFailure
 class TestCase2579654 : AbstractMsalBrokerTest() {
 
     private lateinit var mUsGovAccount: ILabAccount

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 // [MSAL-Only] A single-tenant app makes a silent request with common authority. It should fail..
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/2016158
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure
+@RetryOnFailure(retryCount = 2)
 public class TestCase2016158 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 // [MSAL-Only] A single-tenant app makes a silent request with common authority. It should fail..
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/2016158
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 public class TestCase2016158 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497038.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase497038.java
@@ -112,7 +112,6 @@ public class TestCase497038 extends AbstractMsalUiTest {
                         .sessionExpected(true)
                         .consentPageExpected(false)
                         .speedBumpExpected(true)
-                        .speedBumpResponse(UiResponse.ACCEPT)
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 // Interactive Auth with select_account (no consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99267
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure(retryCount = 2)
+@RetryOnFailure
 public class TestCase99267 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99274.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99274.java
@@ -46,7 +46,7 @@ import java.util.Arrays;
 // Interactive Auth with select_account (with consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99274
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure
+@RetryOnFailure(retryCount = 2)
 public class TestCase99274 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1420484.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1420484.java
@@ -97,6 +97,7 @@ public class TestCase1420484 extends AbstractGuestAccountMsalUiTest {
                     .loginHint(userName)
                     .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
                     .speedBumpExpected(true)
+                    .secondSpeedBumpExpected(GlobalConstants.IS_EXPECTING_SECOND_SPEED_BUMP)
                     .build();
             final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
             promptHandler.handlePrompt(userName, password);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616315.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616315.java
@@ -100,6 +100,7 @@ public class TestCase1616315 extends AbstractGuestAccountMsalUiTest {
                             .loginHint(userName)
                             .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
                             .speedBumpExpected(true)
+                            .secondSpeedBumpExpected(GlobalConstants.IS_EXPECTING_SECOND_SPEED_BUMP)
                             .build();
             final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
             promptHandler.handlePrompt(userName, password);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616316.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/crosscloud/TestCase1616316.java
@@ -90,6 +90,7 @@ public class TestCase1616316 extends AbstractGuestAccountMsalUiTest {
                             .loginHint(userName)
                             .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
                             .speedBumpExpected(true)
+                            .secondSpeedBumpExpected(GlobalConstants.IS_EXPECTING_SECOND_SPEED_BUMP)
                             .build();
             final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
             promptHandler.handlePrompt(userName, password);


### PR DESCRIPTION
July UI Maintenance, some cross cloud tests have a second speed bump, 2 MAM_CA tests fail on daily build due to version check (our daily versions start with 0.0, seems ESTS has some check to block sign ins on these versions for MAM_CA, to fix, we'd have to bump our daily versions past 0.0)

Pre-requisite: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/compare/fadi/july-ui?expand=1