### PR TITLE
make changes to test app to validate Broker DCF flow

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/IPublicClientApplication.java
@@ -109,7 +109,7 @@ public interface IPublicClientApplication {
 
     /**
      * Perform the Device Code Flow (DCF) protocol to allow a device without input capability to authenticate and get a new access token.
-     * Currently, flow is only supported in local MSAL. No Broker support.
+     * NOTE: This API has no Broker support.
      *
      * @param scopes   the desired access scopes
      * @param callback callback object used to communicate with the API throughout the protocol
@@ -121,7 +121,7 @@ public interface IPublicClientApplication {
      *              Use {@link IPublicClientApplication#acquireTokenWithDeviceCode(List, DeviceCodeFlowCallback)} instead.
      *
      * Perform the Device Code Flow (DCF) protocol to allow a device without input capability to authenticate and get a new access token.
-     * Currently, flow is only supported in local MSAL. No Broker support.
+     * NOTE: This API has no Broker support.
      *
      * @param scopes   the desired access scopes
      * @param callback callback object used to communicate with the API throughout the protocol

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -137,6 +137,7 @@ import com.microsoft.identity.msal.BuildConfig;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -1830,7 +1831,10 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         }
     }
 
-    public void acquireTokenWithDeviceCode(@NonNull List<String> scopes, @NonNull final DeviceCodeFlowCallback callback, @Nullable final ClaimsRequest claimsRequest, @Nullable final UUID correlationId) {
+    public void acquireTokenWithDeviceCode(@NonNull List<String> scopes,
+                                           @NonNull final DeviceCodeFlowCallback callback,
+                                           @Nullable final ClaimsRequest claimsRequest,
+                                           @Nullable final UUID correlationId) {
         final Context context = mPublicClientConfiguration.getAppContext();
         PackageHelper packageHelper = new PackageHelper(context);
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -137,7 +137,6 @@ import com.microsoft.identity.msal.BuildConfig;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MainActivity.java
@@ -172,7 +172,7 @@ public class MainActivity extends AppCompatActivity
         final Resource resource = Resource.getDefault();
 
         final AriaSpanExporter ariaSpanExporter = new AriaSpanExporter(
-                BuildConfig.otelAriaToken, null
+                BuildConfig.otelAriaToken, null, applicationContext
         );
 
         final SdkTracerProvider sdkTracerProvider = SdkTracerProvider.builder()

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MsalWrapper.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
@@ -208,8 +209,14 @@ abstract class MsalWrapper {
     public void acquireTokenWithDeviceCodeFlow(@NonNull RequestOptions requestOptions,
                                                @NonNull final INotifyOperationResultCallback<IAuthenticationResult> callback) {
 
+        ClaimsRequest claimsRequest = null;
+        if (!StringUtil.isNullOrEmpty(requestOptions.getClaims())) {
+            claimsRequest = ClaimsRequest.getClaimsRequestFromJsonString(requestOptions.getClaims());
+        }
+
         acquireTokenWithDeviceCodeFlowInternal(
                 Arrays.asList(requestOptions.getScopes().toLowerCase().split(" ")),
+                claimsRequest,
                 new IPublicClientApplication.DeviceCodeFlowCallback() {
                     @Override
                     public void onUserCodeReceived(@NonNull String vUri,
@@ -235,7 +242,9 @@ abstract class MsalWrapper {
                 });
     }
 
-    abstract void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes, @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback);
+    abstract void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes,
+                                                         @Nullable ClaimsRequest claimsRequest,
+                                                         @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback);
 
     AuthenticationCallback getAuthenticationCallback(@NonNull final INotifyOperationResultCallback<IAuthenticationResult> callback) {
         return new AuthenticationCallback() {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/MultipleAccountModeWrapper.java
@@ -25,6 +25,7 @@ package com.microsoft.identity.client.testapp;
 import android.app.Activity;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
@@ -33,6 +34,7 @@ import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
 import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.PoPAuthenticationScheme;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
@@ -116,8 +118,9 @@ public class MultipleAccountModeWrapper extends MsalWrapper {
 
     @Override
     void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes,
+                                                @Nullable final ClaimsRequest claimsRequest,
                                                 @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback) {
-        mApp.acquireTokenWithDeviceCode(scopes, callback);
+        mApp.acquireTokenWithDeviceCode(scopes, callback, claimsRequest, null);
     }
 
     @Override

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SingleAccountModeWrapper.java
@@ -34,6 +34,7 @@ import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.PoPAuthenticationScheme;
 import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.internal.ui.browser.BrowserSelector;
@@ -138,8 +139,9 @@ public class SingleAccountModeWrapper extends MsalWrapper {
 
     @Override
     void acquireTokenWithDeviceCodeFlowInternal(@NonNull List<String> scopes,
+                                                @Nullable final ClaimsRequest claimsRequest,
                                                 @NonNull final IPublicClientApplication.DeviceCodeFlowCallback callback) {
-        mApp.acquireTokenWithDeviceCode(scopes, callback);
+        mApp.acquireTokenWithDeviceCode(scopes, callback, claimsRequest, null);
     }
 
     @Override


### PR DESCRIPTION
related PR: https://github.com/AzureAD/ad-accounts-for-android/pull/2457

Currently - the logic is wired to the local version of acquireTokenWithDeviceCode(), so i wire it with the new one and pass claimsrequest to it.