### PR TITLE
Fix failing MsalTestApp Dist Builds

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.NEXT
 ----------
+- [MINOR] MsalTestApp uses 1.4.0 for com.microsoft.identity.client:opentelemetry.exporter (#1878)
 - [PATCH] Accommodating broker validator refactoring (#1851)
 - [MINOR] Update YubiKit version to 2.3.0 (#1854)
 

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -122,10 +122,10 @@ dependencies {
     if (findProject(":otelexporter") != null) {
         localImplementation(project(':otelexporter'))
     } else {
-        localImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.2.0"
+        localImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.4.0"
     }
 
-    distImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.2.0"
+    distImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.4.0"
     implementation platform("io.opentelemetry:opentelemetry-bom:1.18.0")
     implementation("io.opentelemetry:opentelemetry-sdk:1.18.0")
 }

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -122,10 +122,10 @@ dependencies {
     if (findProject(":otelexporter") != null) {
         localImplementation(project(':otelexporter'))
     } else {
-        localImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.4.0"
+        localImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.+"
     }
 
-    distImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.4.0"
+    distImplementation "com.microsoft.identity.client:opentelemetry.exporter:1.+"
     implementation platform("io.opentelemetry:opentelemetry-bom:1.18.0")
     implementation("io.opentelemetry:opentelemetry-sdk:1.18.0")
 }


### PR DESCRIPTION
Seems that a new version of opentelemetry.exporter was released that changed a method signature, causing failures in MSAL Test App Assemble. In this PR i bump the version up to 1.4.0. Also update submodule (not needed for this PR, updated it to latest dev)

Failing Run:
https://dev.azure.com/IdentityDivision/Engineering/_build/results?buildId=1148620&view=logs&j=0207f532-dabb-5a77-6e5d-97703bc0a64b&t=cf002438-f9d4-56e7-58f8-7f4343e1eb4c

Passing Run:
https://dev.azure.com/IdentityDivision/Engineering/_build/results?buildId=1148867&view=results