### PR TITLE
Target, compile SDK, AGP and gradle versions increased

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -7,13 +7,13 @@ name: $(date:yyyyMMdd)$(rev:.r)
 
 variables:
 - name: BuildParameters.jdkVersion
-  value: 1.8
+  value: 1.11
 - name: BuildParameters.jdkArchitecture
   value: x64
 - name: BuildParameters.javaHomeSelection
   value: JDKVersion
 - name: robolectricSdkVersion
-  value: 28
+  value: 33
 
 trigger:
   branches:
@@ -44,8 +44,9 @@ jobs:
     persistCredentials: True
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
-    displayName: Use Java 8
+    displayName: Use Java 11
     inputs:
+      versionSpec: '11'
       jdkArchitectureOption: x64
       jdkSourceOption: PreInstalled
   - task: Gradle@2
@@ -88,11 +89,12 @@ jobs:
     inputs:
       filename: echo
       arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)'
-  - task: Gradle@1
+  - task: Gradle@3
     displayName: Lint Local debug
     inputs:
       tasks: clean msal:lintLocalDebug
       publishJUnitResults: false
+      jdkVersion: 1.11
 - job: codeql
   displayName: CodeQL
   cancelTimeoutInMinutes: 1
@@ -101,6 +103,12 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - task: JavaToolInstaller@0
+    displayName: Use Java 11
+    inputs:
+      versionSpec: '11'
+      jdkArchitectureOption: x64
+      jdkSourceOption: PreInstalled
   - task: CmdLine@1
     displayName: Set Office MVN Access Token in Environment
     inputs:

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 V.NEXT
 ----------
 - [MINOR] MSA UI tests for Brokered Auth (#1856)
+- [MINOR] Updated target, compile SDK, AGP and gradle versions(#1882)
 
 Version 4.7.0
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -5,18 +5,18 @@ ext {
     minSdkVersion = 16
     brokerProjectMinSdkVersion = 24
     automationAppMinSDKVersion = 21
-    targetSdkVersion = 30
-    compileSdkVersion = 30
+    targetSdkVersion = 33
+    compileSdkVersion = 34
     buildToolsVersion = "28.0.3"
 
     // Plugins
-    gradleVersion = '4.2.2'
+    gradleVersion = '7.4.2'
     kotlinVersion = '1.7.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
 
     //Java Language Support
-    coreLibraryDesugaringVersion = "1.0.9"
+    coreLibraryDesugaringVersion = "1.1.5"
 
     // Libraries
     androidxTestRunnerVersion = "1.4.0"
@@ -34,7 +34,7 @@ ext {
     junitVersion = "4.12"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"
-    lombokVersion = "1.18.12"
+    lombokVersion = "1.18.22"
     materialVersion = "1.0.0"
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
@@ -43,7 +43,7 @@ ext {
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"
-    robolectricVersion = "4.5.1"
+    robolectricVersion = "4.9.2"
     uiAutomatorVersion = "2.2.0"
     flatBuffersJavaVersion = "1.12.0"
     daggerVersion = "2.31.2"
@@ -61,14 +61,14 @@ ext {
     junitVintageEngineVersion = "5.7.2"
     dbusJavaVersion = "3.3.0"
     dbusJavaUtilsVersion = "3.3.0"
-    bouncyCastleVersion = "1.67"
+    bouncyCastleVersion = "1.69"
     oshiCoreVersion = "5.7.5"
     tokenShare = "1.6.5"
     intuneAppSdkVersion = "8.6.3"
     javaAssistVersion = "3.27.0-GA"
     yubikitAndroidVersion = "2.3.0"
     yubikitPivVersion = "2.3.0"
-    powerliftAndroidVersion="1.0.0"
+    powerliftAndroidVersion="1.0.3"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -54,7 +54,7 @@ android {
     }
 
 
-    compileSdkVersion rootProject.ext.compileSdkVersion
+    compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
         multiDexEnabled true
@@ -62,7 +62,7 @@ android {
         if(project.getProperties().get("robolectricSdkVersion")){
             println "Using command line parameter robolectricSdkVersion for target sdk version " + project.getProperties().get("robolectricSdkVersion")
             targetSdkVersion project.getProperties().get("robolectricSdkVersion")
-        }else{
+        } else{
             targetSdkVersion rootProject.ext.targetSdkVersion
         }
         versionCode getAppVersionCode()
@@ -161,7 +161,8 @@ android {
 task javadoc(type: Javadoc) {
     failOnError false
     source = android.sourceSets.main.java.srcDirs
-    classpath += configurations.compile
+    configurations.api.setCanBeResolved(true)
+    classpath += configurations.api
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
 
     options.memberLevel = JavadocMemberLevel.PUBLIC
@@ -218,7 +219,7 @@ dependencies {
     //mockito-inline was introduced in mockito 2.7.6
     //see: https://javadoc.io/static/org.mockito/mockito-core/3.6.28/org/mockito/Mockito.html#0.1
     testImplementation "org.mockito:mockito-inline:$rootProject.ext.mockitoCoreVersion"
-    testImplementation ("org.robolectric:robolectric:4.5.1")
+    testImplementation ("org.robolectric:robolectric:$rootProject.ext.robolectricVersion")
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
     testLocalImplementation project(':testutils')
     testDistImplementation("com.microsoft.identity:testutils:0.0+") {

--- a/msal/src/androidTest/AndroidManifest.xml
+++ b/msal/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.microsoft.identity.msal"
+    xmlns:tools="http://schemas.android.com/tools"
     android:versionCode="1"
     android:versionName="1.0">
 
@@ -18,7 +18,10 @@
 
         <activity android:name="com.microsoft.identity.client.TestActivity" />
 
-        <activity android:name="com.microsoft.identity.client.BrowserTabActivity">
+        <activity
+            tools:replace="android:exported"
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -47,6 +47,7 @@ android {
 
     defaultConfig {
         multiDexEnabled true
+        namespace = "com.microsoft.identity.client.msal.automationapp"
         applicationId "com.msft.identity.client.sample"
         minSdkVersion rootProject.ext.automationAppMinSDKVersion
         targetSdkVersion rootProject.ext.targetSdkVersion

--- a/msalautomationapp/src/androidTest/AndroidManifest.xml
+++ b/msalautomationapp/src/androidTest/AndroidManifest.xml
@@ -13,7 +13,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
 
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerUpdateTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/AbstractMsalBrokerUpdateTest.java
@@ -26,7 +26,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest;
-import com.microsoft.identity.client.msal.automationapp.BrokerTestHelper;
 import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.ui.automation.IBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;

--- a/msalautomationapp/src/main/AndroidManifest.xml
+++ b/msalautomationapp/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:networkSecurityConfig="@xml/network_security_config">
 
         <activity
-            android:name=".MainActivity">
+            android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
@@ -25,7 +26,9 @@
         </activity>
 
         <activity
-            android:name="com.microsoft.identity.client.BrowserTabActivity">
+            tools:replace="android:exported"
+            android:name="com.microsoft.identity.client.BrowserTabActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/package-inspector/build.gradle
+++ b/package-inspector/build.gradle
@@ -8,8 +8,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdk rootProject.ext.compileSdkVersion
     defaultConfig {
         multiDexEnabled true
         applicationId "com.microsoft.shatestapp"

--- a/package-inspector/src/main/AndroidManifest.xml
+++ b/package-inspector/src/main/AndroidManifest.xml
@@ -9,7 +9,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.microsoft.inspector.MainActivity">
+        <activity 
+            android:name="com.microsoft.inspector.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
             android:name="com.microsoft.identity.client.testapp.StartActivity"
             android:taskAffinity=""
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
@@ -67,8 +68,10 @@
         </activity>
 
         <activity
+            tools:replace="android:exported"
             android:name="com.microsoft.identity.client.BrowserTabActivity"
-            android:launchMode="singleTask">
+            android:launchMode="singleTask"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
- Target sdk version changed to 33
- Compile sdk version changed to 34
- AGP version changed to 7.4.2
- Gradle distribution url changed to 7.5

After changing above versions, I had to update other dependencies for compatibility

- Powerlift version changed to 1.0.3
- Bouncy castle version changed to 1.69
- robolectric version to 4.9
- Also, with new gradle versions, some of the properties used in gradle were deprecated (naming conventions changed). So, made those changes
- With gradle version changes, we should not be having a package name in AndroidManifest.xml.. instead, should add a namespace property in build.gradle. https://developer.android.com/build/publish-library/prep-lib-release#choose-namespace
- For apps targeting Android 14, Android restricts apps from sending implicit intents to internal app components. So , added exported attribute. https://developer.android.com/about/versions/14/behavior-changes-14#safer-intents
