### PR TITLE
Add UI (in testapp) for setting active broker in cache

### DIFF
--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -448,6 +448,33 @@
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:weightSum="15">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="5"
+                android:text="Force Set Cache Active Broker" />
+
+            <Spinner
+                android:id="@+id/spinner_knownBrokerApps"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="8" />
+
+            <Button
+                android:id="@+id/btn_setCachedActiveBroker"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="top"
+                android:layout_weight="2"
+                android:text="Set"
+                android:textSize="10dp" />
+        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/testapps/testapp/src/main/res/values/strings.xml
+++ b/testapps/testapp/src/main/res/values/strings.xml
@@ -67,6 +67,6 @@
     <string name="trust_debug_broker">DebugBroker?</string>
     <string name="enable_new_broker_discovery">Enable New Broker Discovery</string>
     <string name="clear_active_broker_cache">Clear Active Broker Cache</string>
-    <string name="current_cached_active_broker">Current Cached Active Broker</string>
+    <string name="current_cached_active_broker">Cached Active Broker</string>
     <string name="none">None</string>
 </resources>


### PR DESCRIPTION
This will allow us to force set the active broker cache.

With this option, this will make us much easier to test the passthrough mode. 
(e.g. if Active broker is LTW, I can now force MSAL to make a request to AuthApp. AuthApp will trigger passthrough and forward the request to LTW to process).


![Screenshot 2023-08-17 at 6 12 36 PM](https://github.com/AzureAD/microsoft-authentication-library-for-android/assets/19558668/3e07b453-a317-45a5-b365-cae8b2c95a0c)
![Screenshot 2023-08-17 at 6 12 41 PM](https://github.com/AzureAD/microsoft-authentication-library-for-android/assets/19558668/b3ed596f-6c24-4e31-8676-622ed3516a6e)
