### PR TITLE
Use Active Broker cache specifically for Client SDK

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 V.NEXT
 ----------
+- [MINOR] Use Active Broker cache specifically for Client SDK (#1892)
 - [MINOR] MSA UI tests for Brokered Auth (#1856)
 - [MINOR] Updated target, compile SDK, AGP and gradle versions(#1882)
 

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -2301,7 +2301,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
      **/
     @Nullable
     public String getActiveBrokerPackageName(@NonNull final Context context) {
-        final BrokerData activeBroker = BrokerDiscoveryClientFactory.getInstance(context,
+        final BrokerData activeBroker = BrokerDiscoveryClientFactory.getInstanceForClientSdk(context,
                         AndroidPlatformComponentsFactory.createFromContext(context))
                 .getActiveBroker(false);
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
@@ -43,7 +43,7 @@ class MSALControllerFactory(
     private val platformComponents: IPlatformComponents,
     private val applicationConfiguration: PublicClientApplicationConfiguration) {
 
-    private val discoveryClient = BrokerDiscoveryClientFactory.getInstance(
+    private val discoveryClient = BrokerDiscoveryClientFactory.getInstanceForClientSdk(
         context = applicationContext,
         platformComponents = platformComponents
     )

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -180,7 +180,7 @@ public class AcquireTokenFragment extends Fragment {
         mDebugBrokers.setTextOn("Debug Brokers");
         mDebugBrokers.setChecked(BrokerData.getShouldTrustDebugBrokers());
 
-        mCache = ClientActiveBrokerCache.Companion.getCache(
+        mCache = ClientActiveBrokerCache.getClientSdkCache(
                 AndroidPlatformComponentsFactory.createFromContext(getContext()).getStorageSupplier()
         );
 


### PR DESCRIPTION
Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2164