### PR TITLE
Adding webauthn_capable property option for MSAL config files

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ V.NEXT
 ----------
 - [MINOR] MSA UI tests for Brokered Auth (#1856)
 - [MINOR] Updated target, compile SDK, AGP and gradle versions(#1882)
+- [MINOR] Adding webauthn_capable property option for MSAL config files (#1895)
 
 Version 4.7.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -418,7 +418,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     public Boolean isWebauthnCapable() {
-        return webauthnCapable != null ? webauthnCapable : false;
+        return webauthnCapable != null && webauthnCapable;
     }
 
     public Authority getDefaultAuthority() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -418,7 +418,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     public Boolean isWebauthnCapable() {
-        return webauthnCapable != null && webauthnCapable;
+        return webauthnCapable == Boolean.TRUE;
     }
 
     public Authority getDefaultAuthority() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -42,7 +42,6 @@ import com.microsoft.identity.client.configuration.AccountMode;
 import com.microsoft.identity.client.configuration.HttpConfiguration;
 import com.microsoft.identity.client.configuration.LoggerConfiguration;
 import com.microsoft.identity.client.exception.MsalClientException;
-import com.microsoft.identity.client.internal.MsalUtils;
 import com.microsoft.identity.common.adal.internal.AuthenticationConstants;
 import com.microsoft.identity.common.adal.internal.AuthenticationSettings;
 import com.microsoft.identity.common.java.authorities.Authority;
@@ -82,6 +81,7 @@ import static com.microsoft.identity.client.PublicClientApplicationConfiguration
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.REQUIRED_BROKER_PROTOCOL_VERSION;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.TELEMETRY;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.USE_BROKER;
+import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEBAUTHN_CAPABLE;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_CONTROLS_ENABLED;
 import static com.microsoft.identity.client.PublicClientApplicationConfiguration.SerializedNames.WEB_VIEW_ZOOM_ENABLED;
 import static com.microsoft.identity.client.exception.MsalClientException.APP_MANIFEST_VALIDATION_ERROR;
@@ -113,6 +113,7 @@ public class PublicClientApplicationConfiguration {
         static final String POWER_OPT_CHECK_FOR_NETWORK_REQUEST_ENABLED = "power_opt_check_for_network_req_enabled";
         static final String HANDLE_TASKS_WITH_NULL_TASKAFFINITY = "handle_null_taskaffinity";
         static final String AUTHORIZATION_IN_CURRENT_TASK = "authorization_in_current_task";
+        static final String WEBAUTHN_CAPABLE = "webauthn_capable";
     }
 
     @SerializedName(CLIENT_ID)
@@ -178,6 +179,13 @@ public class PublicClientApplicationConfiguration {
      */
     @SerializedName(AUTHORIZATION_IN_CURRENT_TASK)
     private Boolean isAuthorizationInCurrentTask;
+
+    /**
+     * When set to true, a passkey option will be visible in WebView.
+     * Host apps should set flag as true after ensuring they have provided the correct info for passkey support.
+     */
+    @SerializedName(WEBAUTHN_CAPABLE)
+    private Boolean webauthnCapable;
 
     transient private OAuth2TokenCache mOAuth2TokenCache;
 
@@ -409,6 +417,10 @@ public class PublicClientApplicationConfiguration {
         return isAuthorizationInCurrentTask;
     }
 
+    public Boolean isWebauthnCapable() {
+        return webauthnCapable != null ? webauthnCapable : false;
+    }
+
     public Authority getDefaultAuthority() {
         if (mAuthorities != null) {
             if (mAuthorities.size() > 1) {
@@ -493,6 +505,7 @@ public class PublicClientApplicationConfiguration {
         this.powerOptCheckEnabled = config.powerOptCheckEnabled == null ? this.powerOptCheckEnabled : config.powerOptCheckEnabled;
         this.handleNullTaskAffinity = config.handleNullTaskAffinity == null ? this.handleNullTaskAffinity : config.handleNullTaskAffinity;
         this.isAuthorizationInCurrentTask = config.isAuthorizationInCurrentTask == null ? this.isAuthorizationInCurrentTask : config.isAuthorizationInCurrentTask;
+        this.webauthnCapable = config.webauthnCapable == null ? this.webauthnCapable : config.webauthnCapable;
     }
 
     void validateConfiguration() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -418,7 +418,7 @@ public class PublicClientApplicationConfiguration {
     }
 
     public Boolean isWebauthnCapable() {
-        return webauthnCapable == Boolean.TRUE;
+        return Boolean.TRUE.equals(webauthnCapable);
     }
 
     public Authority getDefaultAuthority() {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -5,6 +5,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.microsoft.identity.client.AcquireTokenParameters;
 import com.microsoft.identity.client.AcquireTokenSilentParameters;
@@ -19,6 +20,7 @@ import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.client.claims.RequestedClaimAdditionalInformation;
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
 import com.microsoft.identity.common.internal.commands.parameters.AndroidActivityInteractiveTokenCommandParameters;
+import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.authorities.Authority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority;
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryB2CAuthority;
@@ -41,8 +43,10 @@ import com.microsoft.identity.common.java.ui.AuthorizationAgent;
 import com.microsoft.identity.common.internal.util.StringUtil;
 import com.microsoft.identity.common.logging.Logger;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +142,9 @@ public class CommandParametersAdapter {
                 .forceRefresh(parameters.getClaimsRequest() != null)
                 .scopes(new HashSet<>(parameters.getScopes()))
                 .extraScopesToConsent(parameters.getExtraScopesToConsent())
-                .extraQueryStringParameters(parameters.getExtraQueryStringParameters())
+                .extraQueryStringParameters(getExtraQueryStringParameters(
+                        parameters.getExtraQueryStringParameters(),
+                        configuration))
                 .loginHint(getLoginHint(parameters))
                 .account(parameters.getAccountRecord())
                 .authenticationScheme(authenticationScheme)
@@ -485,5 +491,29 @@ public class CommandParametersAdapter {
                 .homeAccountId(homeAccountId)
                 .popParameters(popParameters)
                 .build();
+    }
+
+    /**
+     * Adds additional query string parameters to original list.
+     * @param queryStringParameters extra query string parameters inputted.
+     * @param configuration configuration created from MSAL config file.
+     * @return combined list of query string parameters.
+     */
+    @Nullable
+    public static List<Map.Entry<String, String>> getExtraQueryStringParameters(
+            @Nullable final List<Map.Entry<String, String>> queryStringParameters,
+            @NonNull final PublicClientApplicationConfiguration configuration) {
+        if (configuration.isWebauthnCapable()) {
+            final Map.Entry<String, String> webauthnExtraParameter = new AbstractMap.SimpleEntry<>(
+                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD,
+                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE);
+            if (queryStringParameters == null) {
+                return Collections.singletonList(webauthnExtraParameter);
+            }
+            if (!queryStringParameters.contains(webauthnExtraParameter)) {
+                queryStringParameters.add(webauthnExtraParameter);
+            }
+        }
+        return queryStringParameters;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -500,7 +500,7 @@ public class CommandParametersAdapter {
      * @return combined list of query string parameters.
      */
     @Nullable
-    public static List<Map.Entry<String, String>> getExtraQueryStringParameters(
+    private static List<Map.Entry<String, String>> getExtraQueryStringParameters(
             @Nullable final List<Map.Entry<String, String>> queryStringParameters,
             @NonNull final PublicClientApplicationConfiguration configuration) {
         if (configuration.isWebauthnCapable()) {

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -18,6 +18,7 @@
   "power_opt_check_for_network_req_enabled": true,
   "handle_null_taskaffinity": false,
   "authorization_in_current_task": false,
+  "webauthn_capable": false,
   "http": {
     "connect_timeout": 10000,
     "read_timeout": 30000

--- a/msal/src/test/res/raw/webauthn_capable.json
+++ b/msal/src/test/res/raw/webauthn_capable.json
@@ -5,7 +5,7 @@
   "multiple_clouds_supported":true,
   "broker_redirect_uri_registered": true,
   "account_mode": "MULTIPLE",
-  "webauthn_capable": "true",
+  "webauthn_capable": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/msal/src/test/res/raw/webauthn_capable.json
+++ b/msal/src/test/res/raw/webauthn_capable.json
@@ -1,0 +1,17 @@
+{
+  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.microsoft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "multiple_clouds_supported":true,
+  "broker_redirect_uri_registered": true,
+  "account_mode": "MULTIPLE",
+  "webauthn_capable": "true",
+  "authorities" : [
+    {
+      "type": "AAD",
+      "audience": {
+        "type": "AzureADandPersonalMicrosoftAccount"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
This PR adds logic to handle an MSAL config file property `webauthn_capable` with a boolean value.
When the property is set to true, MSAL adds the `webauthn=1` parameter to the extra query string parameter list for interactive token calls. Once the server side implementation handling the parameter is in prod, adding this extra query parameter will make a passkey option appear on the sign in page in browser and WebView. 
The property is set to false by default, as host apps (only 1P apps) should set this to true once they can confirm the future passkey feature works with their app. 

### Testing
I used msalTestApp and tested with a test flight of ESTS and some injected JavaScript code (which mimics the work that still needs to be done on the ESTS UX side). I set the config property to "true" in the WEBVIEW test config file, and when using this config file, the passkey option correctly appeared. The option does not appear when this config property isn't set. 
Note that this PR does not include the logic for the test flight nor the JavaScript code, so this property will add the query string parameter, but the server side does nothing about it at the moment. 

### Related PRs
- https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2171
- https://github.com/AzureAD/ad-accounts-for-android/pull/2527