### PR TITLE
Fix crash in account adapter

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -60,7 +60,7 @@ class AccountAdapter {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
 
-                if (!acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (acctHomeAccountId != null && acctLocalAccountId != null && !acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }


### PR DESCRIPTION
We have occasionally seen crash reports in New Relic logs for our application that show a nulll pointer exception in line 63 of AccountAdapter.java.

This change should fix these by checking for null pointers.

I see that a simliar issue has already been fixed in https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1847