### PR TITLE
Adding null checks and logging to filter methods in AccountAdapter

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 vNext
 ----------
+- [PATCH] Adding null checks and logging to filter methods in AccountAdapter (#1929)
 
 Version 4.9.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -54,14 +54,24 @@ class AccountAdapter {
 
         @Override
         public List<ICacheRecord> filter(@NonNull List<ICacheRecord> records) {
+            final String methodTag = GuestAccountFilter.class.getSimpleName() + ":filter";
+
             final List<ICacheRecord> result = new ArrayList<>();
 
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-
-                if (!acctHomeAccountId.contains(acctLocalAccountId)) {
-                    result.add(cacheRecord);
+                try {
+                    if (!acctHomeAccountId.contains(acctLocalAccountId)) {
+                        result.add(cacheRecord);
+                    }
+                } catch (final NullPointerException e) {
+                    if (acctHomeAccountId == null) {
+                        Logger.warn(methodTag, "Home account id is null.");
+                    }
+                    if (acctLocalAccountId == null) {
+                        Logger.warn(methodTag, "Local account id is null.");
+                    }
                 }
             }
 
@@ -77,13 +87,23 @@ class AccountAdapter {
 
         @Override
         public List<ICacheRecord> filter(@NonNull final List<ICacheRecord> records) {
+            final String methodTag = HomeAccountFilter.class.getSimpleName() + ":filter";
             final List<ICacheRecord> result = new ArrayList<>();
 
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                if (acctLocalAccountId != null && acctHomeAccountId.contains(acctLocalAccountId)) {
-                    result.add(cacheRecord);
+                try {
+                    if (acctHomeAccountId.contains(acctLocalAccountId)) {
+                        result.add(cacheRecord);
+                    }
+                } catch (final NullPointerException e) {
+                    if (acctHomeAccountId == null) {
+                        Logger.warn(methodTag, "Home account id is null.");
+                    }
+                    if (acctLocalAccountId == null) {
+                        Logger.warn(methodTag, "Local account id is null.");
+                    }
                 }
             }
 
@@ -98,8 +118,13 @@ class AccountAdapter {
 
         private boolean hasNoCorrespondingHomeAccount(@NonNull final ICacheRecord guestRecord,
                                                       @NonNull final List<ICacheRecord> homeRecords) {
+            final String methodTag = CacheRecordFilter.class.getSimpleName() + ":hasNoCorrespondingHomeAccount";
             // Init our sought value
             final String guestAccountHomeAccountId = guestRecord.getAccount().getHomeAccountId();
+            if (guestAccountHomeAccountId == null){
+                Logger.warn(methodTag, "Guest account home account id is null.");
+                return true;
+            }
 
             // Create a List of home_account_ids from the homeRecords...
             final List<String> homeAccountIds = new ArrayList<String>() {{

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -62,16 +62,16 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                boolean notNullorEmpty = true;
+                boolean isNullorEmpty = false;
                 if (StringUtil.isNullOrEmpty(acctHomeAccountId)) {
                     Logger.warn(methodTag, "Home account id is null or empty.");
-                    notNullorEmpty = false;
+                    isNullorEmpty = true;
                 }
                 if (StringUtil.isNullOrEmpty(acctLocalAccountId)) {
                     Logger.warn(methodTag, "Local account id is null or empty.");
-                    notNullorEmpty = false;
+                    isNullorEmpty = true;
                 }
-                if (notNullorEmpty && !acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (!isNullorEmpty && !acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }
@@ -95,16 +95,16 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                boolean notNullorEmpty = true;
+                boolean isNullorEmpty = false;
                 if (StringUtil.isNullOrEmpty(acctHomeAccountId)) {
                     Logger.warn(methodTag, "Home account id is null or empty.");
-                    notNullorEmpty = false;
+                    isNullorEmpty = true;
                 }
                 if (StringUtil.isNullOrEmpty(acctLocalAccountId)) {
                     Logger.warn(methodTag, "Local account id is null or empty.");
-                    notNullorEmpty = false;
+                    isNullorEmpty = true;
                 }
-                if (notNullorEmpty && acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (!isNullorEmpty && acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -51,27 +51,28 @@ class AccountAdapter {
     }
 
     private static class GuestAccountFilter implements CacheRecordFilter {
+        final static String TAG = GuestAccountFilter.class.getSimpleName();
 
         @Override
         public List<ICacheRecord> filter(@NonNull List<ICacheRecord> records) {
-            final String methodTag = GuestAccountFilter.class.getSimpleName() + ":filter";
+            final String methodTag = TAG + ":filter";
 
             final List<ICacheRecord> result = new ArrayList<>();
 
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                try {
-                    if (!acctHomeAccountId.contains(acctLocalAccountId)) {
-                        result.add(cacheRecord);
-                    }
-                } catch (final NullPointerException e) {
-                    if (acctHomeAccountId == null) {
-                        Logger.warn(methodTag, "Home account id is null.");
-                    }
-                    if (acctLocalAccountId == null) {
-                        Logger.warn(methodTag, "Local account id is null.");
-                    }
+                boolean notNullorEmpty = true;
+                if (StringUtil.isNullOrEmpty(acctHomeAccountId)) {
+                    Logger.warn(methodTag, "Home account id is null or empty.");
+                    notNullorEmpty = false;
+                }
+                if (StringUtil.isNullOrEmpty(acctLocalAccountId)) {
+                    Logger.warn(methodTag, "Local account id is null or empty.");
+                    notNullorEmpty = false;
+                }
+                if (notNullorEmpty && !acctHomeAccountId.contains(acctLocalAccountId)) {
+                    result.add(cacheRecord);
                 }
             }
 
@@ -84,26 +85,27 @@ class AccountAdapter {
      * constructor initialization.
      */
     private static class HomeAccountFilter implements CacheRecordFilter {
+        final static String TAG = HomeAccountFilter.class.getSimpleName();
 
         @Override
         public List<ICacheRecord> filter(@NonNull final List<ICacheRecord> records) {
-            final String methodTag = HomeAccountFilter.class.getSimpleName() + ":filter";
+            final String methodTag = TAG + ":filter";
             final List<ICacheRecord> result = new ArrayList<>();
 
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                try {
-                    if (acctHomeAccountId.contains(acctLocalAccountId)) {
-                        result.add(cacheRecord);
-                    }
-                } catch (final NullPointerException e) {
-                    if (acctHomeAccountId == null) {
-                        Logger.warn(methodTag, "Home account id is null.");
-                    }
-                    if (acctLocalAccountId == null) {
-                        Logger.warn(methodTag, "Local account id is null.");
-                    }
+                boolean notNullorEmpty = true;
+                if (StringUtil.isNullOrEmpty(acctHomeAccountId)) {
+                    Logger.warn(methodTag, "Home account id is null or empty.");
+                    notNullorEmpty = false;
+                }
+                if (StringUtil.isNullOrEmpty(acctLocalAccountId)) {
+                    Logger.warn(methodTag, "Local account id is null or empty.");
+                    notNullorEmpty = false;
+                }
+                if (notNullorEmpty && acctHomeAccountId.contains(acctLocalAccountId)) {
+                    result.add(cacheRecord);
                 }
             }
 
@@ -116,13 +118,15 @@ class AccountAdapter {
      */
     private static final CacheRecordFilter guestAccountsWithNoHomeTenantAccountFilter = new CacheRecordFilter() {
 
+        final String TAG = CacheRecordFilter.class.getSimpleName();
+
         private boolean hasNoCorrespondingHomeAccount(@NonNull final ICacheRecord guestRecord,
                                                       @NonNull final List<ICacheRecord> homeRecords) {
-            final String methodTag = CacheRecordFilter.class.getSimpleName() + ":hasNoCorrespondingHomeAccount";
+            final String methodTag = TAG + ":hasNoCorrespondingHomeAccount";
             // Init our sought value
             final String guestAccountHomeAccountId = guestRecord.getAccount().getHomeAccountId();
-            if (guestAccountHomeAccountId == null){
-                Logger.warn(methodTag, "Guest account home account id is null.");
+            if (StringUtil.isNullOrEmpty(guestAccountHomeAccountId)){
+                Logger.warn(methodTag, "Guest account home account id is null or empty.");
                 return true;
             }
 


### PR DESCRIPTION
### Summary
There was an [incident](https://portal.microsofticm.com/imp/v3/incidents/incident/434102603/summary) opened up that reported some crashes for devices in SDM due to a NPE thrown within the AccountAdapter class. 
This PR adds handling and logging for any NPE errors thrown in the filter methods. Note that this is not a root cause fix for the incident, but will provide a mitigation.

Update: We also received a PR from a customer who noted they are also seeing crash reports due to the same NPE: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1927

### Related PR
- https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1847/files