### PR TITLE
October UI Maintenance

### DIFF
--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -71,7 +71,7 @@ android {
 
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
-        animationsDisabled = true
+        animationsDisabled = false
     }
 
     buildTypes {

--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -71,7 +71,7 @@ android {
 
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
-        animationsDisabled = false
+        animationsDisabled = true
     }
 
     buildTypes {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833514.java
@@ -139,6 +139,8 @@ public class TestCase833514 extends AbstractMsalBrokerTest {
 
         final IAccount[] accounts = new IAccount[1];
 
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
+
         // perform get account from MSAL Automation App
         ((SingleAccountPublicClientApplication) mApplication).getCurrentAccountAsync(new ISingleAccountPublicClientApplication.CurrentAccountCallback() {
             @Override
@@ -166,7 +168,7 @@ public class TestCase833514 extends AbstractMsalBrokerTest {
 
         getAccountLatch.await(TokenRequestTimeout.SILENT);
 
-        Thread.sleep(TimeUnit.SECONDS.toMillis(8));
+        Thread.sleep(TimeUnit.SECONDS.toMillis(5));
 
         final TokenRequestLatch silentLatch = new TokenRequestLatch(1);
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase2016158.java
@@ -47,7 +47,6 @@ import java.util.Arrays;
 // [MSAL-Only] A single-tenant app makes a silent request with common authority. It should fail..
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/2016158
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure
 public class TestCase2016158 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 // Interactive Auth with select_account (no consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99267
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure
 public class TestCase99267 extends AbstractMsalUiTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99267.java
@@ -57,7 +57,6 @@ public class TestCase99267 extends AbstractMsalUiTest {
 
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(username)
                 .scopes(Arrays.asList(mScopes))
                 .promptParameter(Prompt.SELECT_ACCOUNT)
                 .msalConfigResourceId(getConfigFileResourceId())
@@ -68,7 +67,6 @@ public class TestCase99267 extends AbstractMsalUiTest {
             public void handleUserInteraction() {
                 final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                         .prompt(PromptParameter.SELECT_ACCOUNT)
-                        .loginHint(username)
                         .sessionExpected(false)
                         .consentPageExpected(true)
                         .speedBumpExpected(false)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99652.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/basic/TestCase99652.java
@@ -46,7 +46,6 @@ import java.util.Arrays;
 // Interactive auth with force_login for managed account (with consent record)
 // https://identitydivision.visualstudio.com/DefaultCollection/IDDP/_workitems/edit/99652
 @RunOnAPI29Minus("Consent Page")
-@RetryOnFailure
 public class TestCase99652 extends AbstractMsalUiTest {
 
     @Test


### PR DESCRIPTION
October UI Maintenance:

- Take in changes from common
- Include a short wait in 833514 to increase consistency
- Retry on failrue for api 29 and below result in intent failure (Could not launch intent)
- Make 99267 more consistent

Common: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2217