### PR TITLE
Hotfix to consume common 16.1.1

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,8 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
+Version 4.9.2
+----------
+- [PATCH] Update common @16.1.1
+
 Version 4.9.1
 ----------
 - [PATCH] Fix NPE in SingleAccountPublicClientApplication.getPersistedCurrentAccount (#1933)

--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
-vNext
+Version 4.9.0
 ----------
+- [PATCH] Update common @16.1.0
 - [MINOR] Adding webauthn_capable property option for MSAL config files (#1895)
 
 Version 4.8.1

--- a/changelog
+++ b/changelog
@@ -1,4 +1,8 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
+Version 4.9.1
+----------
+- [PATCH] Fix NPE in SingleAccountPublicClientApplication.getPersistedCurrentAccount (#1933)
+
 Version 4.9.0
 ----------
 - [PATCH] Update common @16.1.0

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,7 +188,7 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "1.0.+"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "16.1.0"
 
 dependencies {
     //Please leave this in... desugaring is currently disabled by default; however it's required for running some tests
@@ -243,7 +243,7 @@ dependencies {
     }
 
     testLocalImplementation(testFixtures(project(":common4j")))
-    String common4jVersion = project.hasProperty("distCommon4jVersion") ? project.distCommon4jVersion : "1.0.+"
+    String common4jVersion = project.hasProperty("distCommon4jVersion") ? project.distCommon4jVersion : "13.1.0"
     testDistImplementation(testFixtures("com.microsoft.identity:common4j:${common4jVersion}"))
 
     implementation platform("io.opentelemetry:opentelemetry-bom:1.18.0")

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,7 +188,7 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "16.1.0"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "16.1.1"
 
 dependencies {
     //Please leave this in... desugaring is currently disabled by default; however it's required for running some tests

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -60,9 +60,7 @@ class AccountAdapter {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
 
-                // TODO: check the logic on broker side to make sure this value is NOT null.
-                if (acctLocalAccountId != null &&
-                        !acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (!acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }
@@ -84,7 +82,10 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                if (acctHomeAccountId.contains(acctLocalAccountId)) {
+
+                // TODO: check the logic on broker side to make sure this value is NOT null.
+                if (acctLocalAccountId != null &&
+                        acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -82,7 +82,7 @@ class AccountAdapter {
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
-                if (acctLocalAccountId != null && acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -60,7 +60,9 @@ class AccountAdapter {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
 
-                if (!acctHomeAccountId.contains(acctLocalAccountId)) {
+                // TODO: check the logic on broker side to make sure this value is NOT null.
+                if (acctLocalAccountId != null &&
+                        !acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.8.1
+versionName=4.9.0
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.9.0
+versionName=4.9.1
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.9.1
+versionName=4.9.2
 versionCode=0


### PR DESCRIPTION
Why this hotfix?
We have to give an MSAL build to Samsung for testing broker changes with LTW. Samsung also needs to consume MSAL lib. Prev month's release of MSAL does not consume common 16.1.1 which has some important bug fixes in broker discovery/election logic. Hence cutting this hotfix to just consume common 16.1.1.

NOTE : This is based on 4.9.1 MSAL version which also has this fix : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1927#issuecomment-1801353058