### PR TITLE
Hotfix for consuming common 16.1.1

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,4 +1,8 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
+Version 4.9.2
+----------
+- [PATCH] Update common @16.1.1
+
 Version 4.9.1
 ----------
 - [PATCH] Fix NPE in SingleAccountPublicClientApplication.getPersistedCurrentAccount (#1933)

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,7 +188,7 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "16.1.0"
+String commonVersion = project.hasProperty("distCommonVersion") ? project.distCommonVersion : "16.1.1"
 
 dependencies {
     //Please leave this in... desugaring is currently disabled by default; however it's required for running some tests

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=4.9.1
+versionName=4.9.2
 versionCode=0


### PR DESCRIPTION
Why this hotfix?
We have to give an MSAL build to Samsung for testing broker changes with LTW. Samsung also needs to consume MSAL lib. Prev month's release of MSAL does not consume common 16.1.1 which has some important bug fixes in broker discovery/election logic. Hence cutting this hotfix to just consume common 16.1.1.

NOTE : This is based on 4.9.1 MSAL version which also has this fix : https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/1939