### PR TITLE
Add device id claim to "update cp/authapp" tests

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateAuthenticator.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateAuthenticator.kt
@@ -23,6 +23,8 @@
 package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.update
 
 import com.microsoft.identity.client.Prompt
+import com.microsoft.identity.client.claims.ClaimsRequest
+import com.microsoft.identity.client.claims.RequestedClaimAdditionalInformation
 import com.microsoft.identity.client.msal.automationapp.R
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams
@@ -55,13 +57,20 @@ class TestCaseUpdateAuthenticator : AbstractMsalCustomBrokerInstallationTest() {
 
         val mAuthenticator: BrokerMicrosoftAuthenticator = installOldAuthenticator()
 
+        // request the deviceid claim in ID Token
+        val claimsRequest = ClaimsRequest()
+        val requestedClaimAdditionalInformation = RequestedClaimAdditionalInformation()
+        requestedClaimAdditionalInformation.essential = true
+        claimsRequest.requestClaimInIdToken("deviceid", requestedClaimAdditionalInformation)
+
         val msalSdk = MsalSdk()
         val authTestParams = MsalAuthTestParams.builder()
             .activity(mActivity)
             .loginHint(username)
-            .scopes(Arrays.asList(*mScopes))
+            .scopes(listOf(*mScopes))
             .promptParameter(Prompt.LOGIN)
             .authScheme(AuthScheme.BEARER)
+            .claims(claimsRequest)
             .msalConfigResourceId(configFileResourceId)
             .build()
 
@@ -72,6 +81,7 @@ class TestCaseUpdateAuthenticator : AbstractMsalCustomBrokerInstallationTest() {
                 .sessionExpected(false)
                 .consentPageExpected(false)
                 .speedBumpExpected(false)
+                .registerPageExpected(true)
                 .broker(mAuthenticator)
                 .expectingBrokerAccountChooserActivity(false)
                 .build()
@@ -92,6 +102,7 @@ class TestCaseUpdateAuthenticator : AbstractMsalCustomBrokerInstallationTest() {
             .scopes(Arrays.asList(*mScopes))
             .authority(authority)
             .authScheme(AuthScheme.BEARER)
+            .claims(claimsRequest)
             .msalConfigResourceId(configFileResourceId)
             .build()
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateCompanyPortal.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/update/TestCaseUpdateCompanyPortal.kt
@@ -23,6 +23,8 @@
 package com.microsoft.identity.client.msal.automationapp.testpass.msalonly.update
 
 import com.microsoft.identity.client.Prompt
+import com.microsoft.identity.client.claims.ClaimsRequest
+import com.microsoft.identity.client.claims.RequestedClaimAdditionalInformation
 import com.microsoft.identity.client.msal.automationapp.R
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams
@@ -55,13 +57,20 @@ class TestCaseUpdateCompanyPortal : AbstractMsalCustomBrokerInstallationTest() {
 
         val mCompanyPortal: BrokerCompanyPortal = installOldCompanyPortal()
 
+        // request the deviceid claim in ID Token
+        val claimsRequest = ClaimsRequest()
+        val requestedClaimAdditionalInformation = RequestedClaimAdditionalInformation()
+        requestedClaimAdditionalInformation.essential = true
+        claimsRequest.requestClaimInIdToken("deviceid", requestedClaimAdditionalInformation)
+
         val msalSdk = MsalSdk()
         val authTestParams = MsalAuthTestParams.builder()
             .activity(mActivity)
             .loginHint(username)
-            .scopes(Arrays.asList(*mScopes))
+            .scopes(listOf(*mScopes))
             .promptParameter(Prompt.LOGIN)
             .authScheme(AuthScheme.BEARER)
+            .claims(claimsRequest)
             .msalConfigResourceId(configFileResourceId)
             .build()
 
@@ -72,6 +81,7 @@ class TestCaseUpdateCompanyPortal : AbstractMsalCustomBrokerInstallationTest() {
                 .sessionExpected(false)
                 .consentPageExpected(false)
                 .speedBumpExpected(false)
+                .registerPageExpected(true)
                 .broker(mCompanyPortal)
                 .expectingBrokerAccountChooserActivity(false)
                 .build()
@@ -92,6 +102,7 @@ class TestCaseUpdateCompanyPortal : AbstractMsalCustomBrokerInstallationTest() {
             .scopes(Arrays.asList(*mScopes))
             .authority(authority)
             .authScheme(AuthScheme.BEARER)
+            .claims(claimsRequest)
             .msalConfigResourceId(configFileResourceId)
             .build()
 


### PR DESCRIPTION
Increase the coverage of the upgrade scenario - by making them do WPJ+PRT set up.

This will make sure that WPJ+PRT artifacts are still intact after upgrade (or after turning the broker discovery on).

![Screenshot 2023-11-15 at 2 54 10 PM](https://github.com/AzureAD/microsoft-authentication-library-for-android/assets/19558668/5c12671d-bdfc-466b-8d58-02f6a65f1e26)
