### PR TITLE
Fixing label in CommandParameters tests

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ClientException;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -180,110 +181,102 @@ public class CommandParametersTest {
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_UnsetPropertyAndNullInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    null,
-                    getConfiguration(AAD_NONE_CONFIG_FILE)
-            );
-            Assert.assertNull(combinedQueryParameters);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                null,
+                getConfiguration(AAD_NONE_CONFIG_FILE)
+        );
+        Assert.assertNull(combinedQueryParameters);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_UnsetPropertyAndNonNullInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-            queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(AAD_NONE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 1);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+        queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(AAD_NONE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 1);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndNullInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    null,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 1);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                null,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 1);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndNonNullInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-            queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 2);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+        queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 2);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndParameterAlreadyPresent() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-            queryParameters.add(new AbstractMap.SimpleEntry<>(FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD, FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 1);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+        queryParameters.add(new AbstractMap.SimpleEntry<>(FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD, FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 1);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndSingletonListInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>("field1", "property1"));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 2);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>("field1", "property1"));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 2);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndArraysAsListInput() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = Arrays.asList(
-                    new AbstractMap.SimpleEntry<>("field1", "property1"),
-                    new AbstractMap.SimpleEntry<>("field2", "property2"));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 3);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = Arrays.asList(
+                new AbstractMap.SimpleEntry<>("field1", "property1"),
+                new AbstractMap.SimpleEntry<>("field2", "property2"));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 3);
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndParameterAlreadyPresentInImmutableList() {
-        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
-            final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>(
-                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD,
-                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
-            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                    queryParameters,
-                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-            );
-            Assert.assertNotNull(combinedQueryParameters);
-            Assert.assertEquals(combinedQueryParameters.size(), 1);
-        }
+        Assume.assumeTrue(FidoConstants.IS_PASSKEY_SUPPORT_READY);
+        final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>(
+                FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD,
+                FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
+        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                queryParameters,
+                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+        );
+        Assert.assertNotNull(combinedQueryParameters);
+        Assert.assertEquals(combinedQueryParameters.size(), 1);
     }
 
     private ClaimsRequest getAccessTokenClaimsRequest(@NonNull String claimName, @NonNull String claimValue) {

--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import java.util.UUID;
 
 @RunWith(RobolectricTestRunner.class)
-@Ignore("Passkey feature in development.")
 public class CommandParametersTest {
 
     private static final String AAD_CP1_CONFIG_FILE = "src/test/res/raw/aad_capabilities_cp1.json";
@@ -181,94 +180,110 @@ public class CommandParametersTest {
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_UnsetPropertyAndNullInput() {
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                null,
-                getConfiguration(AAD_NONE_CONFIG_FILE)
-        );
-        Assert.assertNull(combinedQueryParameters);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    null,
+                    getConfiguration(AAD_NONE_CONFIG_FILE)
+            );
+            Assert.assertNull(combinedQueryParameters);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_UnsetPropertyAndNonNullInput() {
-        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-        queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(AAD_NONE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 1);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+            queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(AAD_NONE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 1);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndNullInput() {
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                null,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 1);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    null,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 1);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndNonNullInput() {
-        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-        queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 2);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+            queryParameters.add(new AbstractMap.SimpleEntry<>("field1", "property1"));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 2);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndParameterAlreadyPresent() {
-        final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
-        queryParameters.add(new AbstractMap.SimpleEntry<>(FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD, FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 1);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = new ArrayList<>();
+            queryParameters.add(new AbstractMap.SimpleEntry<>(FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD, FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 1);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndSingletonListInput() {
-        final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>("field1", "property1"));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 2);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>("field1", "property1"));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 2);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndArraysAsListInput() {
-        final List<Map.Entry<String, String>> queryParameters = Arrays.asList(
-                new AbstractMap.SimpleEntry<>("field1", "property1"),
-                new AbstractMap.SimpleEntry<>("field2", "property2"));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 3);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = Arrays.asList(
+                    new AbstractMap.SimpleEntry<>("field1", "property1"),
+                    new AbstractMap.SimpleEntry<>("field2", "property2"));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 3);
+        }
     }
 
     @Test
     public void testAppendToExtraQueryParametersIfWebAuthnCapable_setPropertyAndParameterAlreadyPresentInImmutableList() {
-        final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>(
-                FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD,
-                FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
-        final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
-                queryParameters,
-                getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
-        );
-        Assert.assertNotNull(combinedQueryParameters);
-        Assert.assertEquals(combinedQueryParameters.size(), 1);
+        if (FidoConstants.IS_PASSKEY_SUPPORT_READY) {
+            final List<Map.Entry<String, String>> queryParameters = Collections.singletonList(new AbstractMap.SimpleEntry<>(
+                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_FIELD,
+                    FidoConstants.WEBAUTHN_QUERY_PARAMETER_VALUE));
+            final List<Map.Entry<String, String>> combinedQueryParameters = CommandParametersAdapter.appendToExtraQueryParametersIfWebAuthnCapable(
+                    queryParameters,
+                    getConfiguration(WEBAUTHN_CAPABLE_CONFIG_FILE)
+            );
+            Assert.assertNotNull(combinedQueryParameters);
+            Assert.assertEquals(combinedQueryParameters.size(), 1);
+        }
     }
 
     private ClaimsRequest getAccessTokenClaimsRequest(@NonNull String claimName, @NonNull String claimValue) {

--- a/testapps/testapp/src/main/res/raw/msal_config_msa.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_msa.json
@@ -1,7 +1,8 @@
 {
   "client_id" : "9668f2bd-6103-4292-9024-84fa2d1b6fb2",
-  "authorization_user_agent" : "DEFAULT",
+  "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "webauthn_capable": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_msa.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_msa.json
@@ -1,8 +1,7 @@
 {
   "client_id" : "9668f2bd-6103-4292-9024-84fa2d1b6fb2",
-  "authorization_user_agent" : "WEBVIEW",
+  "authorization_user_agent" : "DEFAULT",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "webauthn_capable": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -2,7 +2,6 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "webauthn_capable": true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -2,6 +2,7 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "webauthn_capable": true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
### Summary
Removing the Ignore modifier I accidently put on the CommandParametersTest class, and putting all the passkey specific classes behind a flag (makes it easier to find them later). 