### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -20,7 +20,7 @@ msal/src/main/java/com/microsoft/identity/client/RequiredUserAttributeOptions.kt
 msal/src/main/java/com/microsoft/identity/client/UserAttributes.kt @AzureAD/NativeAuthTeam
 msal/src/main/java/com/microsoft/identity/client/statemachine/ @AzureAD/NativeAuthTeam
 msal/src/test/java/com/microsoft/identity/client/nativeauth/ @AzureAD/NativeAuthTeam
-
+msal/src/androidTest/java/com/microsoft/identity/client/NativeAuthPublicApplicationKotlinTest.kt
 
 # If you are interested in reviewing or getting notified of changes in a particular area
 # Please add your alias against that specific path below

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,6 +10,18 @@
 # Area Owners
 #---------------------
 
+# @AzureAD/NativeAuthTeam owns any files related to CIAM native authentication.
+msal/src/main/java/com/microsoft/identity/client/INativeAuthPublicClientApplication.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplication.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplicationConfiguration.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplicationConfigurationFactory.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/RequiredUserAttribute.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/RequiredUserAttributeOptions.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/UserAttributes.kt @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/statemachine/ @AzureAD/NativeAuthTeam
+msal/src/test/java/com/microsoft/identity/client/nativeauth/ @AzureAD/NativeAuthTeam
+
+
 # If you are interested in reviewing or getting notified of changes in a particular area
 # Please add your alias against that specific path below
 # Example:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,16 +11,8 @@
 #---------------------
 
 # @AzureAD/NativeAuthTeam owns any files related to CIAM native authentication.
-msal/src/main/java/com/microsoft/identity/client/INativeAuthPublicClientApplication.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplication.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplicationConfiguration.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/NativeAuthPublicClientApplicationConfigurationFactory.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/RequiredUserAttribute.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/RequiredUserAttributeOptions.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/UserAttributes.kt @AzureAD/NativeAuthTeam
-msal/src/main/java/com/microsoft/identity/client/statemachine/ @AzureAD/NativeAuthTeam
-msal/src/test/java/com/microsoft/identity/client/nativeauth/ @AzureAD/NativeAuthTeam
-msal/src/androidTest/java/com/microsoft/identity/client/NativeAuthPublicApplicationKotlinTest.kt
+msal/src/main/java/com/microsoft/identity/nativeauth/ @AzureAD/NativeAuthTeam
+msal/src/test/java/com/microsoft/identity/nativeauth/ @AzureAD/NativeAuthTeam
 
 # If you are interested in reviewing or getting notified of changes in a particular area
 # Please add your alias against that specific path below


### PR DESCRIPTION
With CIAM native auth being merged into dev, set NativeAuthTeam as the owners for the respective files (as agreed with Shahzaib, Fadi and Moumita).