### PR TITLE
Add consumer rule to remove native auth from msal by default

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 vNext
 ----------
+- [MINOR] Add consumer rule to remove native auth from msal by default (#1986)
 
 Version 4.10.0
 ----------

--- a/msal/consumer-rules.pro
+++ b/msal/consumer-rules.pro
@@ -17,7 +17,7 @@
 #}
 
 ##---------------Begin: proguard configuration for MSAL  --------
--keep class com.microsoft.identity.** { *; }
+-keep class !com.microsoft.identity.nativeauth.**, com.microsoft.identity.** { *; }
 -keep class com.microsoft.device.display.** { *; }
 
 ##---------------Begin: proguard configuration for Nimbus  ----------

--- a/msal/consumer-rules.pro
+++ b/msal/consumer-rules.pro
@@ -17,7 +17,7 @@
 #}
 
 ##---------------Begin: proguard configuration for MSAL  --------
--keep class !com.microsoft.identity.nativeauth.**, com.microsoft.identity.** { *; }
+-keep class !com.microsoft.identity.common.java.nativeauth.**, !com.microsoft.identity.common.nativeauth.**, !com.microsoft.identity.nativeauth.**, com.microsoft.identity.** { *; }
 -keep class com.microsoft.device.display.** { *; }
 
 ##---------------Begin: proguard configuration for Nimbus  ----------


### PR DESCRIPTION
Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2269