### PR TITLE
Adding CredMan version; enabling passkey feature for testapp WebView config 

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,6 +1,7 @@
 MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-android/wiki
 vNext
 ----------
+- [MAJOR] Consuming Credential Manager from common (brings minCompileSdk 34) (#1987)
 
 Version 4.10.0
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -78,6 +78,7 @@ ext {
     openTelemetryVersion = "1.18.0"
     jetpackDataStoreVersion = "1.0.0"
     lifecycleKtxVersion="2.5.1"
+    AndroidCredentialsVersion="1.2.0"
 
     // microsoft-diagnostics-uploader app versions
     powerliftVersion = "0.14.7"

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -2,6 +2,7 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "webauthn_cgitapable" : true,
   "authorities" : [
     {
       "type": "AAD",

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -2,7 +2,7 @@
   "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
-  "webauthn_cgitapable" : true,
+  "webauthn_capable" : true,
   "authorities" : [
     {
       "type": "AAD",


### PR DESCRIPTION
### Summary
Please see the main common PR for details regarding Credential Manager and the passkey feature: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2267
This PR also adds `webauthn_capable` = true to our msalTestApp WebView config file.