### PR TITLE
Remove duplicate dependency on testUtils project

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -228,7 +228,6 @@ dependencies {
         exclude module: 'common'
         exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
     }
-    testImplementation project(':testutils')
     testImplementation("org.mockito.kotlin:mockito-kotlin:$rootProject.ext.mockitoKotlinVersion") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
     }


### PR DESCRIPTION
#1947 added a duplicate dependency for testUtils project. This causes failure to run UTs in monthly pipeline, [Example run](https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1229805&view=logs&j=f84464c4-dbde-50dc-0e4a-70f8148db754&t=f5fe7ea9-b05a-52f9-d231-7977d552c77d)

Removing the duplicate dependency in this change, as testUtils dependency is already added for local and dist variant.

