### PR TITLE
Ignore NativeAuth unit tests

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
@@ -110,6 +110,7 @@ import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
 @RunWith(RobolectricTestRunner.class)
 @LooperMode(LEGACY)
 @Config(shadows = {ShadowAndroidSdkStorageEncryptionManager.class})
+@Ignore
 public class NativeAuthPublicClientApplicationJavaTest extends PublicClientApplicationAbstractTest {
 
     private Context context;

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -91,6 +91,7 @@ import java.util.concurrent.TimeoutException
 @ExperimentalCoroutinesApi
 @RunWith(RobolectricTestRunner::class)
 @Config(shadows = [ShadowAndroidSdkStorageEncryptionManager::class])
+@Ignore
 class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstractTest() {
     private lateinit var context: Context
     private lateinit var components: IPlatformComponents


### PR DESCRIPTION
Native Auth unit tests are marked as ignored because the mock API web service is not functioning.