### PR TITLE
Remove dependency on testutils project

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -228,7 +228,6 @@ dependencies {
         exclude module: 'common'
         exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
     }
-    testImplementation project(':testutils')
     testImplementation("org.mockito.kotlin:mockito-kotlin:$rootProject.ext.mockitoKotlinVersion") {
         exclude group: 'org.jetbrains.kotlin', module: 'kotlin-stdlib'
     }


### PR DESCRIPTION
Testutils project is not required by MSAL so removing it.