### PR TITLE
Update Native Auth password reset response to include sign in state

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -966,6 +966,7 @@ class NativeAuthPublicClientApplication(
                     ResetPasswordStartResult.CodeRequired(
                         nextState = ResetPasswordCodeRequiredState(
                             continuationToken = result.continuationToken,
+                            username = username,
                             config = nativeAuthConfig
                         ),
                         codeLength = result.codeLength,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -38,7 +38,7 @@ import com.microsoft.identity.nativeauth.statemachine.results.SignUpResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpUsingPasswordResult
 import com.microsoft.identity.nativeauth.statemachine.states.Callback
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState
+import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState
 import com.microsoft.identity.nativeauth.statemachine.states.SignInCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignInPasswordRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpAttributesRequiredState
@@ -609,7 +609,7 @@ class NativeAuthPublicClientApplication(
                     rawCommandResult.checkAndWrapCommandResultType<SignUpStartCommandResult>()) {
                     is SignUpCommandResult.Complete -> {
                         SignUpResult.Complete(
-                            nextState = SignInAfterSignUpState(
+                            nextState = SignInContinuationState(
                                 continuationToken = result.continuationToken,
                                 username = username,
                                 config = nativeAuthConfig
@@ -791,7 +791,7 @@ class NativeAuthPublicClientApplication(
             return@withContext when (val result = rawCommandResult.checkAndWrapCommandResultType<SignUpStartCommandResult>()) {
                 is SignUpCommandResult.Complete -> {
                     SignUpResult.Complete(
-                        nextState = SignInAfterSignUpState(
+                        nextState = SignInContinuationState(
                             continuationToken = result.continuationToken,
                             username = username,
                             config = nativeAuthConfig

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
@@ -25,6 +25,7 @@ package com.microsoft.identity.nativeauth.statemachine.results
 
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState
+import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState
 
 /**
  * Self-service password reset.
@@ -35,10 +36,11 @@ interface ResetPasswordResult : Result {
      * Complete Result, which indicates the reset password flow completed successfully.
      * i.e. the password is successfully reset.
      *
-     * @param resultValue null
+     * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState] the current state of the flow with follow-on methods.
      */
-    object Complete :
-        Result.CompleteResult(resultValue = null),
+    class Complete(
+        override val nextState: SignInAfterSignUpState
+    ) : Result.CompleteWithNextStateResult(resultValue = null, nextState = nextState),
         ResetPasswordResult,
         ResetPasswordSubmitPasswordResult
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
@@ -25,7 +25,7 @@ package com.microsoft.identity.nativeauth.statemachine.results
 
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState
+import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterPasswordResetState
 
 /**
  * Self-service password reset.
@@ -39,7 +39,7 @@ interface ResetPasswordResult : Result {
      * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState] the current state of the flow with follow-on methods.
      */
     class Complete(
-        override val nextState: SignInAfterSignUpState
+        override val nextState: SignInAfterPasswordResetState
     ) : Result.CompleteWithNextStateResult(resultValue = null, nextState = nextState),
         ResetPasswordResult,
         ResetPasswordSubmitPasswordResult

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
@@ -25,7 +25,7 @@ package com.microsoft.identity.nativeauth.statemachine.results
 
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterPasswordResetState
+import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState
 
 /**
  * Self-service password reset.
@@ -36,10 +36,10 @@ interface ResetPasswordResult : Result {
      * Complete Result, which indicates the reset password flow completed successfully.
      * i.e. the password is successfully reset.
      *
-     * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState] the current state of the flow with follow-on methods.
+     * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState] the current state of the flow with follow-on methods.
      */
     class Complete(
-        override val nextState: SignInAfterPasswordResetState
+        override val nextState: SignInContinuationState
     ) : Result.CompleteWithNextStateResult(resultValue = null, nextState = nextState),
         ResetPasswordResult,
         ResetPasswordSubmitPasswordResult

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/SignUpResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/SignUpResult.kt
@@ -23,7 +23,7 @@
 package com.microsoft.identity.nativeauth.statemachine.results
 
 import com.microsoft.identity.nativeauth.RequiredUserAttribute
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState
+import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpAttributesRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpPasswordRequiredState
@@ -37,10 +37,10 @@ interface SignUpResult : Result {
      * CompleteResult which indicates the sign up flow is complete,
      * i.e. the user account is created and can now be used to sign in with.
      *
-     * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState] the current state of the flow with follow-on methods.
+     * @param nextState [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState] the current state of the flow with follow-on methods.
      */
     class Complete(
-        override val nextState: SignInAfterSignUpState
+        override val nextState: SignInContinuationState
     ) : Result.CompleteWithNextStateResult(resultValue = null, nextState = nextState),
         SignUpResult,
         SignUpSubmitCodeResult,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -65,6 +65,7 @@ import java.io.Serializable
  */
 class ResetPasswordCodeRequiredState internal constructor(
     override val continuationToken: String,
+    private val username: String,
     private val config: NativeAuthPublicClientApplicationConfiguration
 ) : BaseState(continuationToken), State, Serializable {
     private val TAG: String = ResetPasswordCodeRequiredState::class.java.simpleName
@@ -121,6 +122,7 @@ class ResetPasswordCodeRequiredState internal constructor(
                     ResetPasswordSubmitCodeResult.PasswordRequired(
                         nextState = ResetPasswordPasswordRequiredState(
                             continuationToken = result.continuationToken,
+                            username = username,
                             config = config
                         )
                     )
@@ -213,6 +215,7 @@ class ResetPasswordCodeRequiredState internal constructor(
                     ResetPasswordResendCodeResult.Success(
                         nextState = ResetPasswordCodeRequiredState(
                             continuationToken = result.continuationToken,
+                            username = username,
                             config = config
                         ),
                         codeLength = result.codeLength,
@@ -256,6 +259,7 @@ class ResetPasswordCodeRequiredState internal constructor(
  */
 class ResetPasswordPasswordRequiredState internal constructor(
     override val continuationToken: String,
+    private val username: String,
     private val config: NativeAuthPublicClientApplicationConfiguration
 ) : BaseState(continuationToken), State, Serializable {
     private val TAG: String = ResetPasswordPasswordRequiredState::class.java.simpleName
@@ -311,7 +315,13 @@ class ResetPasswordPasswordRequiredState internal constructor(
                 return@withContext when (val result =
                     rawCommandResult.checkAndWrapCommandResultType<ResetPasswordSubmitNewPasswordCommandResult>()) {
                     is ResetPasswordCommandResult.Complete -> {
-                        ResetPasswordResult.Complete
+                        ResetPasswordResult.Complete(
+                            nextState = SignInAfterSignUpState(
+                                continuationToken = result.continuationToken,
+                                username = username,
+                                config = config
+                            )
+                        )
                     }
 
                     is ResetPasswordCommandResult.PasswordNotAccepted -> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -317,7 +317,7 @@ class ResetPasswordPasswordRequiredState internal constructor(
                     rawCommandResult.checkAndWrapCommandResultType<ResetPasswordSubmitNewPasswordCommandResult>()) {
                     is ResetPasswordCommandResult.Complete -> {
                         ResetPasswordResult.Complete(
-                            nextState = SignInAfterPasswordResetState(
+                            nextState = SignInContinuationState(
                                 continuationToken = result.continuationToken,
                                 username = username,
                                 config = config
@@ -373,45 +373,5 @@ class ResetPasswordPasswordRequiredState internal constructor(
                 StringUtil.overwriteWithNull(parameters.newPassword)
             }
         }
-    }
-}
-
-/**
- * Native Auth uses a state machine to denote state of and transitions within a flow.
- * SignInAfterPasswordResetState class represents a state where the user must sign in after a successful
- * password reset flow.
- * @property continuationToken: Token to be passed in the next request
- * @property username: Email address of the user
- * @property config Configuration used by Native Auth
- */
-class SignInAfterPasswordResetState internal constructor(
-    override val continuationToken: String?,
-    override val username: String,
-    private val config: NativeAuthPublicClientApplicationConfiguration
-) : SignInAfterFlowCompletionBaseState(continuationToken, username, config) {
-    private val TAG: String = SignInAfterSignUpState::class.java.simpleName
-    interface SignInAfterPasswordResetCallback : SignInAfterFlowCompletionCallback
-
-    /**
-     * Signs in with the sign-in-after-reset-password verification code; callback variant.
-     *
-     * @param scopes (Optional) the scopes to request.
-     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState.SignInAfterSignUpCallback] to receive the result on.
-     * @return The results of the sign-in-after-reset-password action.
-     */
-    fun signIn(scopes: List<String>? = null, callback: SignInAfterPasswordResetCallback) {
-        LogSession.logMethodCall(TAG, "${TAG}.signIn")
-        return signInAfterFlowCompletion(scopes = scopes, callback = callback)
-    }
-
-    /**
-     * Signs in with the sign-in-after-reset-password verification code; Kotlin coroutines variant.
-     *
-     * @param scopes (Optional) the scopes to request.
-     * @return The results of the sign-in-after-reset-password action.
-     */
-    suspend fun signIn(scopes: List<String>? = null): SignInResult {
-        LogSession.logMethodCall(TAG, "${TAG}.signIn(scopes: List<String>)")
-        return signInAfterFlowCompletion(scopes = scopes)
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -260,6 +260,7 @@ class ResetPasswordCodeRequiredState internal constructor(
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeString(continuationToken)
+        parcel.writeString(username)
         parcel.writeSerializable(config)
     }
 
@@ -411,6 +412,7 @@ class ResetPasswordPasswordRequiredState internal constructor(
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
         parcel.writeString(continuationToken)
+        parcel.writeString(username)
         parcel.writeSerializable(config)
     }
 

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -51,6 +51,7 @@ import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
+import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -316,7 +317,7 @@ class ResetPasswordPasswordRequiredState internal constructor(
                     rawCommandResult.checkAndWrapCommandResultType<ResetPasswordSubmitNewPasswordCommandResult>()) {
                     is ResetPasswordCommandResult.Complete -> {
                         ResetPasswordResult.Complete(
-                            nextState = SignInAfterSignUpState(
+                            nextState = SignInAfterPasswordResetState(
                                 continuationToken = result.continuationToken,
                                 username = username,
                                 config = config
@@ -372,5 +373,45 @@ class ResetPasswordPasswordRequiredState internal constructor(
                 StringUtil.overwriteWithNull(parameters.newPassword)
             }
         }
+    }
+}
+
+/**
+ * Native Auth uses a state machine to denote state of and transitions within a flow.
+ * SignInAfterPasswordResetState class represents a state where the user must sign in after a successful
+ * password reset flow.
+ * @property continuationToken: Token to be passed in the next request
+ * @property username: Email address of the user
+ * @property config Configuration used by Native Auth
+ */
+class SignInAfterPasswordResetState internal constructor(
+    override val continuationToken: String?,
+    override val username: String,
+    private val config: NativeAuthPublicClientApplicationConfiguration
+) : SignInAfterFlowCompletionBaseState(continuationToken, username, config) {
+    private val TAG: String = SignInAfterSignUpState::class.java.simpleName
+    interface SignInAfterPasswordResetCallback : SignInAfterFlowCompletionCallback
+
+    /**
+     * Signs in with the sign-in-after-reset-password verification code; callback variant.
+     *
+     * @param scopes (Optional) the scopes to request.
+     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState.SignInAfterSignUpCallback] to receive the result on.
+     * @return The results of the sign-in-after-reset-password action.
+     */
+    fun signIn(scopes: List<String>? = null, callback: SignInAfterPasswordResetCallback) {
+        LogSession.logMethodCall(TAG, "${TAG}.signIn")
+        return signInAfterFlowCompletion(scopes = scopes, callback = callback)
+    }
+
+    /**
+     * Signs in with the sign-in-after-reset-password verification code; Kotlin coroutines variant.
+     *
+     * @param scopes (Optional) the scopes to request.
+     * @return The results of the sign-in-after-reset-password action.
+     */
+    suspend fun signIn(scopes: List<String>? = null): SignInResult {
+        LogSession.logMethodCall(TAG, "${TAG}.signIn(scopes: List<String>)")
+        return signInAfterFlowCompletion(scopes = scopes)
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -382,55 +382,54 @@ class SignInPasswordRequiredState(
 
 /**
  * Native Auth uses a state machine to denote state of and transitions within a flow.
- * SignInAfterSignUpBaseState class is an abstract class to represent signin state after
- * successfull signup
- * in the signin flow.
+ * SignInAfterFlowCompletionBaseState class is an abstract class to represent a sign in state after
+ * a successful signup or password reset.
  * @property continuationToken: Continuation token from signup APIS
  * @property username: Username of the user
  * @property config Configuration used by Native Auth
  */
-abstract class SignInAfterSignUpBaseState(
+abstract class SignInAfterFlowCompletionBaseState(
     override val continuationToken: String?,
     internal open val username: String,
     private val config: NativeAuthPublicClientApplicationConfiguration
 ) : BaseState(continuationToken), State, Serializable {
-    private val TAG: String = SignInAfterSignUpBaseState::class.java.simpleName
+    private val TAG: String = SignInAfterFlowCompletionBaseState::class.java.simpleName
 
     /**
-     * SignInAfterSignUpCallback receives the result for sign in after signup for Native Auth
+     * SignInAfterFlowCompletionCallback receives the result for sign in after flow completion for Native Auth
      */
-    interface SignInAfterSignUpCallback : Callback<SignInResult>
+    interface SignInAfterFlowCompletionCallback : Callback<SignInResult>
 
     /**
-     * Submits the sign-in-after-sign-up verification code to the server; callback variant.
+     * Submits the sign-in-after-flow-completion verification code to the server; callback variant.
      *
      * @param scopes (Optional) The scopes to request.
-     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpBaseState.SignInAfterSignUpCallback] to receive the result on.
+     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterFlowCompletionBaseState.SignInAfterFlowCompletionCallback] to receive the result on.
      * @return The results of the sign-in-after-sign-up action.
      */
-    fun signInAfterSignUp(scopes: List<String>? = null, callback: SignInAfterSignUpCallback) {
-        LogSession.logMethodCall(TAG, "${TAG}.signInAfterSignUp")
+    fun signInAfterFlowCompletion(scopes: List<String>? = null, callback: SignInAfterFlowCompletionCallback) {
+        LogSession.logMethodCall(TAG, "${TAG}.signInAfterFlowCompletion")
 
         NativeAuthPublicClientApplication.pcaScope.launch {
             try {
-                val result = signInAfterSignUp(scopes)
+                val result = signInAfterFlowCompletion(scopes)
                 callback.onResult(result)
             } catch (e: MsalException) {
-                Logger.error(TAG, "Exception thrown in signInAfterSignUp", e)
+                Logger.error(TAG, "Exception thrown in signInAfterFlowCompletion", e)
                 callback.onError(e)
             }
         }
     }
 
     /**
-     * Submits the sign-in-after-sign-up verification code to the server; Kotlin coroutines variant.
+     * Submits the sign-in-after-flow-completion verification code to the server; Kotlin coroutines variant.
      *
      * @param scopes (Optional) The scopes to request.
      * @return The results of the sign-in-after-sign-up action.
      */
-    suspend fun signInAfterSignUp(scopes: List<String>? = null): SignInResult {
+    suspend fun signInAfterFlowCompletion(scopes: List<String>? = null): SignInResult {
         return withContext(Dispatchers.IO) {
-            LogSession.logMethodCall(TAG, "${TAG}.signInAfterSignUp(scopes: List<String>)")
+            LogSession.logMethodCall(TAG, "${TAG}.signInAfterFlowCompletion(scopes: List<String>)")
 
             // Check if verification code was passed. If not, return an UnknownError with instructions to call the other
             // sign in flows (code or password).

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -382,54 +382,54 @@ class SignInPasswordRequiredState(
 
 /**
  * Native Auth uses a state machine to denote state of and transitions within a flow.
- * SignInAfterFlowCompletionBaseState class is an abstract class to represent a sign in state after
+ * SignInContinuationState is a class to represent a sign in state after
  * a successful signup or password reset.
  * @property continuationToken: Continuation token from signup APIS
  * @property username: Username of the user
  * @property config Configuration used by Native Auth
  */
-abstract class SignInAfterFlowCompletionBaseState(
+class SignInContinuationState(
     override val continuationToken: String?,
-    internal open val username: String,
+    internal val username: String,
     private val config: NativeAuthPublicClientApplicationConfiguration
 ) : BaseState(continuationToken), State, Serializable {
-    private val TAG: String = SignInAfterFlowCompletionBaseState::class.java.simpleName
+    private val TAG: String = SignInContinuationState::class.java.simpleName
 
     /**
-     * SignInAfterFlowCompletionCallback receives the result for sign in after flow completion for Native Auth
+     * SignInContinuationCallback receives the result for sign in after flow completion for Native Auth
      */
-    interface SignInAfterFlowCompletionCallback : Callback<SignInResult>
+    interface SignInContinuationCallback : Callback<SignInResult>
 
     /**
-     * Submits the sign-in-after-flow-completion verification code to the server; callback variant.
+     * Submits the sign-in-continuation verification code to the server; callback variant.
      *
      * @param scopes (Optional) The scopes to request.
-     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterFlowCompletionBaseState.SignInAfterFlowCompletionCallback] to receive the result on.
-     * @return The results of the sign-in-after-sign-up action.
+     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState.SignInContinuationCallback] to receive the result on.
+     * @return The results of the sign-in-continuation action.
      */
-    fun signInAfterFlowCompletion(scopes: List<String>? = null, callback: SignInAfterFlowCompletionCallback) {
-        LogSession.logMethodCall(TAG, "${TAG}.signInAfterFlowCompletion")
+    fun signIn(scopes: List<String>? = null, callback: SignInContinuationCallback) {
+        LogSession.logMethodCall(TAG, "${TAG}.signIn")
 
         NativeAuthPublicClientApplication.pcaScope.launch {
             try {
-                val result = signInAfterFlowCompletion(scopes)
+                val result = signIn(scopes)
                 callback.onResult(result)
             } catch (e: MsalException) {
-                Logger.error(TAG, "Exception thrown in signInAfterFlowCompletion", e)
+                Logger.error(TAG, "Exception thrown in signIn", e)
                 callback.onError(e)
             }
         }
     }
 
     /**
-     * Submits the sign-in-after-flow-completion verification code to the server; Kotlin coroutines variant.
+     * Submits the sign-in-continuation verification code to the server; Kotlin coroutines variant.
      *
      * @param scopes (Optional) The scopes to request.
      * @return The results of the sign-in-after-sign-up action.
      */
-    suspend fun signInAfterFlowCompletion(scopes: List<String>? = null): SignInResult {
+    suspend fun signIn(scopes: List<String>? = null): SignInResult {
         return withContext(Dispatchers.IO) {
-            LogSession.logMethodCall(TAG, "${TAG}.signInAfterFlowCompletion(scopes: List<String>)")
+            LogSession.logMethodCall(TAG, "${TAG}.signIn(scopes: List<String>)")
 
             // Check if verification code was passed. If not, return an UnknownError with instructions to call the other
             // sign in flows (code or password).

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
@@ -150,7 +150,7 @@ class SignUpCodeRequiredState internal constructor(
 
                 is SignUpCommandResult.Complete -> {
                     SignUpResult.Complete(
-                        nextState = SignInAfterSignUpState(
+                        nextState = SignInContinuationState(
                             continuationToken = result.continuationToken,
                             username = username,
                             config = config
@@ -360,7 +360,7 @@ class SignUpPasswordRequiredState internal constructor(
                     rawCommandResult.checkAndWrapCommandResultType<SignUpSubmitPasswordCommandResult>()) {
                     is SignUpCommandResult.Complete -> {
                         SignUpResult.Complete(
-                            nextState = SignInAfterSignUpState(
+                            nextState = SignInContinuationState(
                                 continuationToken = result.continuationToken,
                                 username = username,
                                 config = config
@@ -523,7 +523,7 @@ class SignUpAttributesRequiredState internal constructor(
                 }
                 is SignUpCommandResult.Complete -> {
                     SignUpResult.Complete(
-                        nextState = SignInAfterSignUpState(
+                        nextState = SignInContinuationState(
                             continuationToken = result.continuationToken,
                             username = username,
                             config = config
@@ -572,45 +572,5 @@ class SignUpAttributesRequiredState internal constructor(
                 }
             }
         }
-    }
-}
-
-/**
- * Native Auth uses a state machine to denote state of and transitions within a flow.
- * SignInAfterSignUpState class represents a state where the user must sign in after a successful
- * signup flow.
- * @property continuationToken: Token to be passed in the next request
- * @property username: Email address of the user
- * @property config Configuration used by Native Auth
- */
-class SignInAfterSignUpState internal constructor(
-    override val continuationToken: String?,
-    override val username: String,
-    private val config: NativeAuthPublicClientApplicationConfiguration
-) : SignInAfterFlowCompletionBaseState(continuationToken, username, config) {
-    private val TAG: String = SignInAfterSignUpState::class.java.simpleName
-    interface SignInAfterSignUpCallback : SignInAfterFlowCompletionCallback
-
-    /**
-     * Signs in with the sign-in-after-sign-up verification code; callback variant.
-     *
-     * @param scopes (Optional) the scopes to request.
-     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState.SignInAfterSignUpCallback] to receive the result on.
-     * @return The results of the sign-in-after-sign-up action.
-     */
-    fun signIn(scopes: List<String>? = null, callback: SignInAfterSignUpCallback) {
-        LogSession.logMethodCall(TAG, "${TAG}.signIn")
-        return signInAfterFlowCompletion(scopes = scopes, callback = callback)
-    }
-
-    /**
-     * Signs in with the sign-in-after-sign-up verification code; Kotlin coroutines variant.
-     *
-     * @param scopes (Optional) the scopes to request.
-     * @return The results of the sign-in-after-sign-up action.
-     */
-    suspend fun signIn(scopes: List<String>? = null): SignInResult {
-        LogSession.logMethodCall(TAG, "${TAG}.signIn(scopes: List<String>)")
-        return signInAfterFlowCompletion(scopes = scopes)
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
@@ -577,7 +577,7 @@ class SignUpAttributesRequiredState internal constructor(
 
 /**
  * Native Auth uses a state machine to denote state of and transitions within a flow.
- * SignInAfterSignUpState class represents a state where the user must signin after successful
+ * SignInAfterSignUpState class represents a state where the user must sign in after a successful
  * signup flow.
  * @property continuationToken: Token to be passed in the next request
  * @property username: Email address of the user
@@ -587,9 +587,9 @@ class SignInAfterSignUpState internal constructor(
     override val continuationToken: String?,
     override val username: String,
     private val config: NativeAuthPublicClientApplicationConfiguration
-) : SignInAfterSignUpBaseState(continuationToken, username, config) {
+) : SignInAfterFlowCompletionBaseState(continuationToken, username, config) {
     private val TAG: String = SignInAfterSignUpState::class.java.simpleName
-    interface SignInAfterSignUpCallback : SignInAfterSignUpBaseState.SignInAfterSignUpCallback
+    interface SignInAfterSignUpCallback : SignInAfterFlowCompletionCallback
 
     /**
      * Signs in with the sign-in-after-sign-up verification code; callback variant.
@@ -600,7 +600,7 @@ class SignInAfterSignUpState internal constructor(
      */
     fun signIn(scopes: List<String>? = null, callback: SignInAfterSignUpCallback) {
         LogSession.logMethodCall(TAG, "${TAG}.signIn")
-        return signInAfterSignUp(scopes = scopes, callback = callback)
+        return signInAfterFlowCompletion(scopes = scopes, callback = callback)
     }
 
     /**
@@ -611,6 +611,6 @@ class SignInAfterSignUpState internal constructor(
      */
     suspend fun signIn(scopes: List<String>? = null): SignInResult {
         LogSession.logMethodCall(TAG, "${TAG}.signIn(scopes: List<String>)")
-        return signInAfterSignUp(scopes = scopes)
+        return signInAfterFlowCompletion(scopes = scopes)
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
@@ -63,9 +63,8 @@ import com.microsoft.identity.nativeauth.statemachine.results.SignUpUsingPasswor
 import com.microsoft.identity.nativeauth.statemachine.states.AccountState;
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState;
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState;
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterPasswordResetState;
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignInCodeRequiredState;
+import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpAttributesRequiredState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpCodeRequiredState;
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory;
@@ -1010,7 +1009,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // Setup - sign up the user, so that we don't have to construct the SLT state manually
         // as this doesn't allow for the NativeAuthPublicClientApplicationConfiguration to be set
         // up, meaning it would need to be mocked (which we don't want in these tests).
-        SignInAfterSignUpState signInWithSLTState = signUpUser();
+        SignInContinuationState signInWithSLTState = signUpUser();
 
         // 1a. sign in with (valid) SLT
         String correlationId = UUID.randomUUID().toString();
@@ -1022,7 +1021,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
 
         // 1b. server returns token
         final ResultFuture<SignInResult> resultFuture = new ResultFuture<>();
-        SignInAfterSignUpState.SignInAfterSignUpCallback callback = new SignInAfterSignUpState.SignInAfterSignUpCallback() {
+        SignInContinuationState.SignInContinuationCallback callback = new SignInContinuationState.SignInContinuationCallback() {
             @Override
             public void onResult(SignInResult result) {
                 resultFuture.setResult(result);
@@ -1054,9 +1053,9 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
 
         // 1b. client returns error
         final NativeAuthPublicClientApplicationConfiguration config = Mockito.mock(NativeAuthPublicClientApplicationConfiguration.class);
-        final SignInAfterSignUpState state = new SignInAfterSignUpState(null, username, config);
+        final SignInContinuationState state = new SignInContinuationState(null, username, config);
         final ResultFuture<SignInResult> resultFuture = new ResultFuture<>();
-        SignInAfterSignUpState.SignInAfterSignUpCallback callback = new SignInAfterSignUpState.SignInAfterSignUpCallback() {
+        SignInContinuationState.SignInContinuationCallback callback = new SignInContinuationState.SignInContinuationCallback() {
             @Override
             public void onResult(SignInResult result) {
                 resultFuture.setResult(result);
@@ -1089,7 +1088,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // Setup - sign up the user, so that we don't have to construct the SLT state manually
         // as this doesn't allow for the NativeAuthPublicClientApplicationConfiguration to be set
         // up, meaning it would need to be mocked (which we don't want in these tests).
-        SignInAfterSignUpState signInWithSLTState = signUpUser();
+        SignInContinuationState signInWithSLTState = signUpUser();
 
         // 1a. sign in with (expired) SLT
         String correlationId = UUID.randomUUID().toString();
@@ -1101,7 +1100,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
 
         // 1b. server returns error
         final ResultFuture<SignInResult> resultFuture = new ResultFuture<>();
-        SignInAfterSignUpState.SignInAfterSignUpCallback callback = new SignInAfterSignUpState.SignInAfterSignUpCallback() {
+        SignInContinuationState.SignInContinuationCallback callback = new SignInContinuationState.SignInContinuationCallback() {
             @Override
             public void onResult(SignInResult result) {
                 resultFuture.setResult(result);
@@ -1322,7 +1321,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         ResetPasswordSubmitPasswordResult submitPasswordResult = submitPasswordCallback.get();
         assertTrue(submitPasswordResult instanceof ResetPasswordResult.Complete);
         // 3c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end
-        SignInAfterPasswordResetState signInState = ((ResetPasswordResult.Complete) submitPasswordResult).getNextState();
+        SignInContinuationState signInState = ((ResetPasswordResult.Complete) submitPasswordResult).getNextState();
 
         // 4a. Sign in with (valid) continuation token
         MockApiUtils.configureMockApi(
@@ -1331,7 +1330,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
                 MockApiResponseType.TOKEN_SUCCESS
         );
 
-        SignInAfterPasswordResetTestCallback signInCallback = new SignInAfterPasswordResetTestCallback();
+        SignInContinuationTestCallback signInCallback = new SignInContinuationTestCallback();
         signInState.signIn(null, signInCallback);
 
         SignInResult signInResult = signInCallback.get();
@@ -1725,7 +1724,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
 
     // Helper methods
     // TODO update this after sign up SDK tests PR
-    private SignInAfterSignUpState signUpUser() throws ExecutionException, InterruptedException, TimeoutException {
+    private SignInContinuationState signUpUser() throws ExecutionException, InterruptedException, TimeoutException {
         // 1. sign up with password
         // 1a. Setup server response
         String correlationId = UUID.randomUUID().toString();
@@ -2832,7 +2831,7 @@ class SignUpSubmitPasswordTestCallback extends TestCallback<SignUpSubmitPassword
     }
 }
 
-class SignInAfterPasswordResetTestCallback extends TestCallback<SignInResult> implements SignInAfterPasswordResetState.SignInAfterPasswordResetCallback {
+class SignInContinuationTestCallback extends TestCallback<SignInResult> implements SignInContinuationState.SignInContinuationCallback {
 
     @Override
     public void onResult(SignInResult result) {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
@@ -34,7 +34,6 @@ import com.microsoft.identity.client.e2e.tests.PublicClientApplicationAbstractTe
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.client.exception.MsalClientException;
 import com.microsoft.identity.client.exception.MsalException;
-import com.microsoft.identity.common.java.nativeauth.BuildValues;
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError;
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError;
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError;
@@ -64,6 +63,7 @@ import com.microsoft.identity.nativeauth.statemachine.results.SignUpUsingPasswor
 import com.microsoft.identity.nativeauth.statemachine.states.AccountState;
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState;
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState;
+import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterPasswordResetState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignInCodeRequiredState;
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpAttributesRequiredState;
@@ -1322,7 +1322,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         ResetPasswordSubmitPasswordResult submitPasswordResult = submitPasswordCallback.get();
         assertTrue(submitPasswordResult instanceof ResetPasswordResult.Complete);
         // 3c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end
-        SignInAfterSignUpState signInState = ((ResetPasswordResult.Complete) submitPasswordResult).getNextState();
+        SignInAfterPasswordResetState signInState = ((ResetPasswordResult.Complete) submitPasswordResult).getNextState();
 
         // 4a. Sign in with (valid) continuation token
         MockApiUtils.configureMockApi(
@@ -1331,7 +1331,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
                 MockApiResponseType.TOKEN_SUCCESS
         );
 
-        SignInAfterSignUpTestCallback signInCallback = new SignInAfterSignUpTestCallback();
+        SignInAfterPasswordResetTestCallback signInCallback = new SignInAfterPasswordResetTestCallback();
         signInState.signIn(null, signInCallback);
 
         SignInResult signInResult = signInCallback.get();
@@ -2832,7 +2832,7 @@ class SignUpSubmitPasswordTestCallback extends TestCallback<SignUpSubmitPassword
     }
 }
 
-class SignInAfterSignUpTestCallback extends TestCallback<SignInResult> implements SignInAfterSignUpState.SignInAfterSignUpCallback {
+class SignInAfterPasswordResetTestCallback extends TestCallback<SignInResult> implements SignInAfterPasswordResetState.SignInAfterPasswordResetCallback {
 
     @Override
     public void onResult(SignInResult result) {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -646,8 +646,88 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
         val submitPasswordResult = nextState.submitPassword(password = password)
         // 3b. Transform /submit(success) +/poll_completion(success) to Result(Complete).
         assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
-        // 3c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end. Continuation token as resultValue will be returned after private preview.
-        val resultValue = (submitPasswordResult as ResetPasswordResult.Complete).resultValue
+    }
+
+    /**
+     * Test SSPR scenario 3.2.2:
+     * 1 -> USER click resetPassword
+     * 1 <- user found, SERVER requires code verification
+     * 2 -> USER submit valid code
+     * 2 <- code valid, SERVER requires new password to be set
+     * 3 -> USER submit valid password
+     * 3 <- password reset succeeds
+     * 4 -> USER calls sign in on the provided state
+     * 4 <- SERVER returns tokens
+     */
+    @Test
+    fun testSSPRScenario3_2_2() = runTest {
+        var nextState: Any?
+        // 1. Click reset password
+        // 1_mock_api. Setup server response - endpoint: resetpassword/start - Server returns Success
+        val correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRStart,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SSPR_START_SUCCESS
+        )
+        // 1_mock_api. Setup server response - endpoint: resetpassword/challenge - Server returns Success: challenge_type = OOB
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.CHALLENGE_TYPE_OOB
+        )
+        // 1a. Call SDK interface - resetPassword(ResetPasswordStart)
+        val resetPasswordResult = application.resetPassword(username = username)
+        // 1b. Transform /start(success) +/challenge(challenge_type=OOB) to Result(CodeRequired).
+        assertTrue(resetPasswordResult is ResetPasswordStartResult.CodeRequired)
+        // 1c. Respond to Result(Code Required): shifting from start to ResetPasswordCodeRequired state.
+        nextState = (resetPasswordResult as ResetPasswordStartResult.CodeRequired).nextState
+
+        // 2. Submit valid code
+        // 2_mock_api. Setup server response - endpoint: resetpassowrd/continue - Server returns Success
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRContinue,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SSPR_CONTINUE_SUCCESS
+        )
+        // 2a. Call SDK interface - submitCode()
+        val submitCodeResult = nextState.submitCode(code = code)
+        // 2b. Transform /continue(success) to Result(PasswordRequired).
+        assertTrue(submitCodeResult is ResetPasswordSubmitCodeResult.PasswordRequired)
+        // 2c. Respond to Result(PasswordRequired): shifting from ResetPasswordCodeRequired to ResetPasswordPasswordRequired state.
+        nextState = (submitCodeResult as ResetPasswordSubmitCodeResult.PasswordRequired).nextState
+
+        // 3. Submit valid password
+        // 3_mock_api. Setup server response - endpoint: resetpassword/submit - Server returns Success
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRSubmit,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SSPR_SUBMIT_SUCCESS
+        )
+        // 3_mock_api. Setup server response - endpoint: resetpassword/poll_completion - Server returns Success
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRPoll,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SSPR_POLL_SUCCESS
+        )
+        // 3a. Call SDK interface - submitPassword()
+        val submitPasswordResult = nextState.submitPassword(password = password)
+        // 3b. Transform /submit(success) +/poll_completion(success) to Result(Complete).
+        assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
+        // 3c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end.
+        assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
+        val signInWithContinuationTokenState = (submitPasswordResult as ResetPasswordResult.Complete).nextState
+
+        // 4a. Sign in with (valid) continuation token
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInToken,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.TOKEN_SUCCESS
+        )
+
+        // 4b. Server returns tokens
+        val result = signInWithContinuationTokenState.signIn(scopes = null)
+        assertTrue(result is SignInResult.Complete)
     }
 
     /**
@@ -729,8 +809,6 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
         submitPasswordResult = nextState.submitPassword(password = password)
         // 4b. Transform /submit(error) + /resetpassword/poll_completion(success) to Result(Complete).
         assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
-        // 4c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end. Continuation token as resultValue will be returned after private preview.
-        val resultValue = (submitPasswordResult as ResetPasswordResult.Complete).resultValue
     }
 
     /**
@@ -812,8 +890,6 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
         val submitPasswordResult = nextState.submitPassword(password = password)
         // 4b. Transform /submit(success) +/poll_completion(success) to Result(Complete).
         assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
-        // 4c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end. Continuation token as resultValue will be returned after private preview.
-        val resultValue = (submitPasswordResult as ResetPasswordResult.Complete).resultValue
     }
 
     /**
@@ -964,8 +1040,6 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
         val submitPasswordResult = nextState.submitPassword(password = password)
         // 4b. Transform /submit(success) +/poll_completion(success) to Result(Complete).
         assertTrue(submitPasswordResult is ResetPasswordResult.Complete)
-        // 4c. Respond to Result(Complete): shifting from ResetPasswordPasswordRequired to end. Continuation token as resultValue will be returned after private preview.
-        val resultValue = (submitPasswordResult as ResetPasswordResult.Complete).resultValue
     }
 
     /**

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -52,7 +52,6 @@ import com.microsoft.identity.nativeauth.statemachine.results.SignInUsingPasswor
 import com.microsoft.identity.nativeauth.statemachine.results.SignOutResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpResendCodeResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpResult
-import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpState
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper
 import com.microsoft.identity.common.nativeauth.MockApiEndpoint
@@ -63,6 +62,7 @@ import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.java.nativeauth.BuildValues
 import com.microsoft.identity.common.java.util.ResultFuture
 import com.microsoft.identity.internal.testutils.TestUtils
+import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
@@ -414,7 +414,7 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
 
         // 1b. client returns error
         val config = mock<NativeAuthPublicClientApplicationConfiguration>()
-        val continuationTokenState = SignInAfterSignUpState(continuationToken = null, username = username, config = config)
+        val continuationTokenState = SignInContinuationState(continuationToken = null, username = username, config = config)
         val result = continuationTokenState.signIn(scopes = null)
         assertTrue(result is SignInError)
         assertTrue((result as SignInError).errorType == null)
@@ -1290,7 +1290,7 @@ class NativeAuthPublicClientApplicationKotlinTest : PublicClientApplicationAbstr
         InterruptedException::class,
         TimeoutException::class
     )
-    private suspend fun signUpUser(): SignInAfterSignUpState {
+    private suspend fun signUpUser(): SignInContinuationState {
         // 1. sign up with password
         // 1a. Setup server response
         val correlationId = UUID.randomUUID().toString()

--- a/msal/src/test/res/raw/native_auth_native_only_test_config.json
+++ b/msal/src/test/res/raw/native_auth_native_only_test_config.json
@@ -1,5 +1,6 @@
 {
   "client_id" : "0e565df2-c350-47f2-9cd4-c6c7a464b8bf",
+  "use_mock_api_for_native_auth": "true",
   "authorities" : [
     {
       "type": "CIAM",

--- a/msal/src/test/res/raw/native_auth_native_only_test_config.json
+++ b/msal/src/test/res/raw/native_auth_native_only_test_config.json
@@ -1,6 +1,5 @@
 {
   "client_id" : "0e565df2-c350-47f2-9cd4-c6c7a464b8bf",
-  "use_mock_api_for_native_auth": "true",
   "authorities" : [
     {
       "type": "CIAM",


### PR DESCRIPTION
Summary of changes:

* Updates the reset password completion state to return a sign in state with the required continuation token.
* Adds scenario tests for signing in after completing the reset password flow

Related PR in common repo: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2281
PR for the sample application: https://github.com/Azure-Samples/ms-identity-ciam-native-auth-android-sample/pull/9