### PR TITLE
Move all parts of PCA creation to the same thread

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,6 +4,7 @@ vNext
 ----------
 - [MINOR] Add isQRPinAvailable API to MSAL IPublicClientApplication (#1931)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#1964)
+- [PATCH] Move locking methods in PCA initialization to a background thread (#2008)
 
 Version 5.0.0
 ----------

--- a/changelog
+++ b/changelog
@@ -4,7 +4,7 @@ vNext
 ----------
 - [MINOR] Add isQRPinAvailable API to MSAL IPublicClientApplication (#1931)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#1964)
-- [PATCH] Move locking methods in PCA initialization to a background thread (#2008)
+- [PATCH] Move all parts of PCA creation to the same thread (#2008)
 
 Version 5.0.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1270,8 +1270,9 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final Context context = mPublicClientConfiguration.getAppContext();
         setupTelemetry(context, mPublicClientConfiguration);
 
-        // Currently, PCA initialization happens on the main thread, both of the methods below use locks and
-        // shouldn't be ran on the main thread. Running them on a background thread instead.
+        // Today, this method runs on the main thread. AzureActiveDirectory.setEnvironment() and Authority.addKnownAuthorities()
+        // utilize thread locks to avoid race conditions, but locks shouldn't be used on the main thread to avoid Android Not Responding Crashes.
+        // Running them on a background thread instead.
         runOnBackground(new Runnable() {
             @Override
             public void run() {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -154,11 +154,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1270,8 +1270,15 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final Context context = mPublicClientConfiguration.getAppContext();
         setupTelemetry(context, mPublicClientConfiguration);
 
-        AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
-        Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+        // Currently, PCA initialization happens on the main thread, both of the methods below use locks and
+        // shouldn't be ran on the main thread. Running them on a background thread instead.
+        runOnBackground(new Runnable() {
+            @Override
+            public void run() {
+                AzureActiveDirectory.setEnvironment(mPublicClientConfiguration.getEnvironment());
+                Authority.addKnownAuthorities(mPublicClientConfiguration.getAuthorities());
+            }
+        });
 
         initializeLoggerSettings(mPublicClientConfiguration.getLoggerConfiguration());
 


### PR DESCRIPTION
Relevant Bugs: 
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2502611
https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2502610

**What**
We received some bugs from Teams regarding users experiencing Android Not Responding crashes while using teams (Bugs linked above). During PCA creation, the foreground thread would get blocked while waiting on a lock to open in `AzureActiveDirectory`. This shouldn't be happening, as PCA creation should be happening in the background thread, or specifically marked with the @WorkerThread annotation.

The culprit is the final stage of the PCA creation process where a new PCA instance is actually created, which calls `initializeApplication()`, a method that involves some synchronized method calls. This instance creation happens in a command callback for getDeviceMode, which is always ran on the main foreground thread today (see `AndroidPlatformUtil.postCommandResult()`). This is not ideal for PCA creation, because it means some part of it is happening in the main thread and could cause ANRs despite the user calling it from a background context. To fix this, This PR moves the PCA instance creation to the same thread that initially calls getDeviceMode.

**How**
I've extracted the instance creation outside of the command callback for getDeviceMode. Instead, we now use a future to get the command result, waiting for the command to finish so that we can instantiate the PCA on the background thread, rather than the foreground.

**Why**
This fix will remove this possibility of causing an ANR while creating the PCA and make sure that the PCA creation happens on the same thread.

**Testing**
Before the fix, debugging through PCA creation in msaltestapp would show `setEnvironment()` being ran on the main thread.
After the fix, this part of PCA creation runs on the same thread as the rest of the method (thread 2, in my case).