### PR TITLE
Fix crash when redirect is received as a ResendCodeError.

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -243,7 +243,8 @@ class ResetPasswordCodeRequiredState internal constructor(
                         errorMessage = (result as INativeAuthCommandResult.Error).errorDescription,
                         error = (result as INativeAuthCommandResult.Error).error,
                         correlationId = (result as INativeAuthCommandResult.Error).correlationId,
-                        exception = (result as INativeAuthCommandResult.UnknownError).exception
+                        errorCodes = (result as INativeAuthCommandResult.Error).errorCodes,
+                        exception = if (result is INativeAuthCommandResult.UnknownError) result.exception else null
                     )
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -255,7 +255,7 @@ class SignInCodeRequiredState internal constructor(
                         error = (result as INativeAuthCommandResult.Error).error,
                         correlationId = (result as INativeAuthCommandResult.Error).correlationId,
                         errorCodes = (result as INativeAuthCommandResult.Error).errorCodes,
-                        exception = (result as INativeAuthCommandResult.UnknownError).exception
+                        exception = if (result is INativeAuthCommandResult.UnknownError) result.exception else null
                     )
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
@@ -281,7 +281,8 @@ class SignUpCodeRequiredState internal constructor(
                         errorMessage = (result as INativeAuthCommandResult.Error).errorDescription,
                         error = (result as INativeAuthCommandResult.Error).error,
                         correlationId = (result as INativeAuthCommandResult.Error).correlationId,
-                        exception = (result as INativeAuthCommandResult.UnknownError).exception
+                        errorCodes = (result as INativeAuthCommandResult.Error).errorCodes,
+                        exception = if (result is INativeAuthCommandResult.UnknownError) result.exception else null
                     )
                 }
             }


### PR DESCRIPTION
A crash happened when a redirect response was received because of an unchecked cast when creating a ResendCodeError result.