### PR TITLE
Fix regression bug introduced by native auth additions to MSAL test app

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/NativeAuthFragment.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/NativeAuthFragment.kt
@@ -40,7 +40,7 @@ import com.microsoft.identity.client.testapp.nativeauth.PasswordResetFragment
  */
 class NativeAuthFragment : Fragment() {
     companion object {
-        private val TAG = MainActivity::class.java.simpleName
+        private val TAG = NativeAuthFragment::class.java.simpleName
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {

--- a/testapps/testapp/src/main/res/menu/activity_main_drawer.xml
+++ b/testapps/testapp/src/main/res/menu/activity_main_drawer.xml
@@ -31,14 +31,14 @@
             android:id="@+id/nav_acquire"
             android:title="AcquireToken" />
         <item
-            android:id="@+id/nav_native"
-            android:title="Native Auth" />
-        <item
             android:id="@+id/nav_result"
             android:title="Result" />
         <item
             android:id="@+id/nav_log"
             android:title="Log" />
+        <item
+            android:id="@+id/nav_native"
+            android:title="Native Auth" />
     </group>
 
 </menu>


### PR DESCRIPTION
Bug source:
MainActivity auth callback navigates based on menu item ID. Since adding native auth to the menu, the IDs had changed.

<img width="635" alt="image" src="https://github.com/AzureAD/microsoft-authentication-library-for-android/assets/1315628/29bc83dd-4170-4bad-b55c-9e58282b29c3">