### PR TITLE
[Test ] Verify "Sign in from other device" tests

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,7 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [PATCH] Add tests to verify "Sign in from other device" option and remote device login URL
+- [PATCH] Add tests to verify "Sign in from other device" option and remote device login URL (#2033)
 - [PATCH] Fix MSAL Issue #1864 (#2003)
 - [MINOR] Add isQRPinAvailable API to MSAL IPublicClientApplication (#1931)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#1964)

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Add tests to verify "Sign in from other device" option and remote device login URL
 - [PATCH] Fix MSAL Issue #1864 (#2003)
 - [MINOR] Add isQRPinAvailable API to MSAL IPublicClientApplication (#1931)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#1964)

--- a/changelog
+++ b/changelog
@@ -2,7 +2,6 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [PATCH] Add tests to verify "Sign in from other device" option and remote device login URL (#2033)
 - [PATCH] Fix MSAL Issue #1864 (#2003)
 - [MINOR] Add isQRPinAvailable API to MSAL IPublicClientApplication (#1931)
 - [MINOR] Add PreferredAuthMethod to interactive token flow (#1964)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 
 // Brokered Auth verify "Sign In from other device" option.
-//@RetryOnFailure(retryCount = 2)
 abstract class AbstractSignInFromOtherDeviceTest extends AbstractMsalBrokerTest {
 
     private final AzureEnvironment mAzureEnvironment;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
@@ -1,0 +1,99 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.dcf;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+// Brokered Auth verify "Sign In from other device" option.
+//@RetryOnFailure(retryCount = 2)
+abstract class AbstractSignInFromOtherDeviceTest extends AbstractMsalBrokerTest {
+
+    private final AzureEnvironment mAzureEnvironment;
+
+    public AbstractSignInFromOtherDeviceTest(@NonNull AzureEnvironment environment) {
+        mAzureEnvironment = environment;
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .azureEnvironment(mAzureEnvironment)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    protected void testSignInFromOtherDevice() throws Throwable {
+        final MsalSdk msalSdk = new MsalSdk();
+        final List<Map.Entry<String, String>> extraQP = new ArrayList<>();
+        extraQP.add(new AbstractMap.SimpleEntry<>("is_remote_login_allowed", Boolean.toString(true)));
+
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .scopes(Arrays.asList(mScopes))
+                .msalConfigResourceId(getConfigFileResourceId())
+                .extraQueryParameters(extraQP)
+                .build();
+
+        msalSdk.acquireTokenInteractiveAsync(authTestParams, () ->
+                new AadLoginComponentHandler().handleSignInFromOtherDevice(getExpectedDeviceCodeUrl()), TokenRequestTimeout.MEDIUM);
+    }
+
+    abstract protected String getExpectedDeviceCodeUrl();
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828864.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828864.java
@@ -20,27 +20,35 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.sdk;
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.dcf;
 
-import com.microsoft.identity.client.Prompt;
-import com.microsoft.identity.client.claims.ClaimsRequest;
-import com.microsoft.identity.client.ui.automation.sdk.AuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 
-import java.util.List;
-import java.util.Map;
+import org.junit.Test;
 
-import lombok.Getter;
-import lombok.experimental.SuperBuilder;
+// Brokered Auth verify "Sign In from other device" option and remote login url.
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2828864
+@RetryOnFailure(retryCount = 2)
+public class TestCase2828864 extends AbstractSignInFromOtherDeviceTest {
 
-// MSAL Test Parameters Class which has all the parameters required for MSAL with or w/o Broker Automation TestCases
-@Getter
-@SuperBuilder
-public class MsalAuthTestParams extends AuthTestParams {
+    public TestCase2828864() {
+        super(AzureEnvironment.AZURE_CLOUD);
+    }
 
-    private final Prompt promptParameter;
-    private final boolean forceRefresh;
-    private final int msalConfigResourceId;
-    private final List<String> scopes;
-    private final ClaimsRequest claims;
-    private final List<Map.Entry<String, String>> extraQueryParameters;
+    @Test
+    public void test_2828864() throws Throwable {
+        this.testSignInFromOtherDevice();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+
+    @Override
+    protected String getExpectedDeviceCodeUrl() {
+        return "https://microsoft.com/devicelogin";
+    }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828868.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828868.java
@@ -20,27 +20,34 @@
 //  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
-package com.microsoft.identity.client.msal.automationapp.sdk;
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.dcf;
 
-import com.microsoft.identity.client.Prompt;
-import com.microsoft.identity.client.claims.ClaimsRequest;
-import com.microsoft.identity.client.ui.automation.sdk.AuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 
-import java.util.List;
-import java.util.Map;
+import org.junit.Test;
 
-import lombok.Getter;
-import lombok.experimental.SuperBuilder;
+// Brokered Auth verify "Sign In from other device" option for Us Gov and and remote login url.
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2828868
+@RetryOnFailure(retryCount = 2)
+public class TestCase2828868 extends AbstractSignInFromOtherDeviceTest {
+    public TestCase2828868() {
+        super(AzureEnvironment.AZURE_US_GOVERNMENT);
+    }
 
-// MSAL Test Parameters Class which has all the parameters required for MSAL with or w/o Broker Automation TestCases
-@Getter
-@SuperBuilder
-public class MsalAuthTestParams extends AuthTestParams {
+    @Test
+    public void test_2828868() throws Throwable {
+        this.testSignInFromOtherDevice();
+    }
 
-    private final Prompt promptParameter;
-    private final boolean forceRefresh;
-    private final int msalConfigResourceId;
-    private final List<String> scopes;
-    private final ClaimsRequest claims;
-    private final List<Map.Entry<String, String>> extraQueryParameters;
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_arlington;
+    }
+
+    @Override
+    protected String getExpectedDeviceCodeUrl() {
+        return "https://microsoft.com/deviceloginus";
+    }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2836426.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2836426.java
@@ -1,0 +1,96 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.dcf;
+
+import static com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler.SIGN_IN_FROM_OTHER_DEVICE;
+
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadLoginComponentHandler;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// Brokered Auth verify "Sign In from other device" option is not present
+// if "is_remote_login_allowed=true" query parameter is not present.
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2836426
+@RetryOnFailure(retryCount = 2)
+public class TestCase2836426 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_2836426() throws Throwable {
+        final MsalSdk msalSdk = new MsalSdk();
+
+        // don't pass "is_remote_login_allowed=true" query parameter
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .scopes(Arrays.asList(mScopes))
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        msalSdk.acquireTokenInteractiveAsync(authTestParams, () ->
+                new AadLoginComponentHandler().handleSignInOptions(), TokenRequestTimeout.MEDIUM);
+
+        // ensure "Sign in from other device" option is no present.
+        Assert.assertFalse(UiAutomatorUtils.obtainUiObjectWithText(SIGN_IN_FROM_OTHER_DEVICE).exists());
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2836426.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2836426.java
@@ -42,7 +42,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// Brokered Auth verify "Sign In from other device" option is not present
+// Brokered Auth to verify "Sign In from other device" option is not present
 // if "is_remote_login_allowed=true" query parameter is not present.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2836426
 @RetryOnFailure(retryCount = 2)


### PR DESCRIPTION
Adding test to execute "Sign in from other device" flow and verify if if remote login url is shown to the user.

The flow works only in brokered auth and if "is_remote_login_allowed=true" is passedin extra query auth parameters.

Since Sov cloud and WW have different remote login urls
There are two test cases.

Supporting PR in common:
Common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2308

Related PR in broker: https://github.com/AzureAD/ad-accounts-for-android/pull/2696