### PR TITLE
Give BrokerMsalController higher priority than LocalMsalController if available

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+[MINOR] Give BrokerMsalController higher priority than LocalMsalController if available (#2040)
 
 Version 5.1.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
@@ -89,16 +89,15 @@ class MSALControllerFactory(
     /**
      * Returns one or more controllers to address a given request.
      *
-     * The order of the response matters.  The local controller should be returned first in order to
-     * ensure that any local refresh tokens are preferred over the use of the broker
+     * If requests is eligible for broker, {@link BrokerMsalController} will be
+     * added before {@link LocalMSALController}. otherwise only {@link LocalMSALController} will
+     * be returned.
      *
-     * Only return the broker controller when the following are true:
+     * Broker eligibility is determined if following conditions are true:
      *
-     * 1) The client indicates it wants to use broker
-     * 2) The authority is AAD
-     * 3) The audience is not AnyPersonalAccount
-     * 4) The broker is installed
-     * 5) The broker redirect URI for the client is registered
+     * 1) The broker is installed
+     * 2) The client indicates it wants to use broker
+     * 3) The authority is AAD
      */
     fun getAllControllers(authority: Authority): List<BaseController> {
         val activeBroker = getActiveBrokerPackageName()

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
@@ -103,12 +103,12 @@ class MSALControllerFactory(
     fun getAllControllers(authority: Authority): List<BaseController> {
         val activeBroker = getActiveBrokerPackageName()
         val controllers: MutableList<BaseController> = ArrayList()
-        controllers.add(LocalMSALController())
         if (!activeBroker.isNullOrEmpty() && brokerEligible(authority)) {
             controllers.add(
                 BrokerMsalController(applicationContext, platformComponents, activeBroker)
             )
         }
+        controllers.add(LocalMSALController())
 
         return controllers.toList()
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowLegacyBrokerDiscoveryClient.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowLegacyBrokerDiscoveryClient.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.client.e2e.shadows
+
+import com.microsoft.identity.common.internal.activebrokerdiscovery.LegacyBrokerDiscoveryClient
+import com.microsoft.identity.common.internal.broker.BrokerData
+import org.robolectric.annotation.Implements
+
+// A Shadow for mocking LegacyBrokerDiscoveryClient
+@Implements(LegacyBrokerDiscoveryClient::class)
+class ShadowLegacyBrokerDiscoveryClient {
+
+    fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
+        return BrokerData.debugBrokerHost
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
@@ -1,0 +1,69 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.internal.controllers
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.microsoft.identity.client.PublicClientApplicationConfiguration
+import com.microsoft.identity.client.PublicClientApplicationConfigurationFactory
+import com.microsoft.identity.client.e2e.shadows.ShadowLegacyBrokerDiscoveryClient
+import com.microsoft.identity.common.internal.controllers.BrokerMsalController
+import com.microsoft.identity.common.java.authorities.Authority
+import com.microsoft.identity.msal.test.R
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowLegacyBrokerDiscoveryClient::class] )
+class MSALControllerFactoryTest {
+
+    private lateinit var pcaConfiguration: PublicClientApplicationConfiguration
+    private lateinit var msalControllerFactory: MSALControllerFactory
+
+    @Before
+    fun setup() {
+        val context : Context = ApplicationProvider.getApplicationContext()
+        pcaConfiguration = PublicClientApplicationConfigurationFactory.loadConfiguration(context, R.raw.msal_default_config)
+        pcaConfiguration.appContext = context
+        Assert.assertTrue(pcaConfiguration.useBroker)
+        msalControllerFactory = MSALControllerFactory(pcaConfiguration)
+    }
+    @Test
+    fun testGetControllers() {
+        val testAuthority = Authority.getAuthorityFromAuthorityUrl("https://login.microsoftonline.com/common")
+        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled(testAuthority))
+        Assert.assertEquals(2, msalControllerFactory.getAllControllers(testAuthority).size)
+        Assert.assertTrue(msalControllerFactory.getAllControllers(testAuthority)[0] is BrokerMsalController )
+    }
+
+    @Test
+    fun testGetDefaultController() {
+        val testAuthority = Authority.getAuthorityFromAuthorityUrl("https://login.microsoftonline.com/common")
+        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled(testAuthority))
+        Assert.assertTrue(msalControllerFactory.getDefaultController(testAuthority) is BrokerMsalController )
+    }
+}


### PR DESCRIPTION
### What 
Giving BrokerMsalController higher priority than LocalMsalController if available. This means that if Broker is available, msal will first try to acquire token via broker before trying its localController

### Why
In order to push brokered auth as default when available. And reduce usage of regular RT, when PRT can be used which is bound to the device.

### How
Changing the order of controllers to put BrokerMsalController (if eligible) before LocalMsalController 

### Testing
Verified AcquireTokenSilent calls reach Broker first.