### PR TITLE
update nimbus version

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Update nimbus-jose-jwt 9.37.3 (#2042)
 
 Version 5.1.0
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -39,7 +39,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.9"
+    nimbusVersion = "9.37.3"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
Why?
A vulnerability was found in old versions of nimbus.
see: https://nvd.nist.gov/vuln/detail/CVE-2023-52428