### PR TITLE
Edit test app to test QR + PIN feature

### DIFF
--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -28,6 +28,12 @@
           package="com.microsoft.identity.client.testapp"
           xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Camera permission is required for QR + PIN authorization method w/o broker-->
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
@@ -48,8 +48,11 @@ public class Constants {
 
         BROWSER_SKIP_BROKER,
 
-        WEBVIEW_SKIP_BROKER
+        WEBVIEW_SKIP_BROKER,
 
+        PPE,
+
+        WEBVIEW_WITH_PPE,
     }
 
     public static int getResourceIdFromConfigFile(ConfigFile configFile) {
@@ -104,6 +107,10 @@ public class Constants {
 
             case WEBVIEW_SKIP_BROKER:
                 return R.raw.msal_config_webview_skip_broker;
+            case PPE:
+                return R.raw.msal_config_ppe;
+            case WEBVIEW_WITH_PPE:
+                return R.raw.msal_config_webview_ppe;
         }
 
         return R.raw.msal_config_default;

--- a/testapps/testapp/src/main/res/raw/msal_config_ppe.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_ppe.json
@@ -1,0 +1,14 @@
+{
+  "client_id" : "8fcb9fc1-d8f9-49c0-b80e-a8a8a201d051",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "handle_null_taskaffinity": true,
+  "authorization_in_current_task": false,
+  "environment" : "PreProduction",
+  "authorities" : [
+    {
+      "type": "AAD",
+      "authority_url": "https://login.windows-ppe.net"
+    }
+  ]
+}

--- a/testapps/testapp/src/main/res/raw/msal_config_webview.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview.json
@@ -1,14 +1,13 @@
 {
-  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "client_id" : "29d9ed98-a469-4536-ade2-f981bc1d605e",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "webauthn_capable" : true,
+  "environment" : "PreProduction",
   "authorities" : [
     {
       "type": "AAD",
-      "audience": {
-        "type": "AzureADMultipleOrgs"
-      }
+      "authority_url": "https://login.windows-ppe.net"
     }
   ]
 }

--- a/testapps/testapp/src/main/res/raw/msal_config_webview_ppe.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_webview_ppe.json
@@ -1,14 +1,13 @@
 {
-  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "client_id" : "8fcb9fc1-d8f9-49c0-b80e-a8a8a201d051",
   "authorization_user_agent" : "WEBVIEW",
   "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
   "webauthn_capable" : true,
+  "environment" : "PreProduction",
   "authorities" : [
     {
       "type": "AAD",
-      "audience": {
-        "type": "AzureADMultipleOrgs"
-      }
+      "authority_url": "https://login.windows-ppe.net"
     }
   ]
 }


### PR DESCRIPTION
- Add camera permission to MSAL test app, this is needed to test QR + PIN flow w/o broker. MSAL consumer apps who want to opt in in QR + PIN flow they will need to add this permission on their manifest.
- Add a configuration for PPE and PPE WebView. This is possible now that we have the msal redirect url on PPE see: https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2852767
Thanks to Melissa and Ryan
