### PR TITLE
Revert "update nimbus"

### DIFF
--- a/changelog
+++ b/changelog
@@ -4,7 +4,6 @@ vNext
 ----------
 - [MINOR] Rename "is QR + PIN available" API to "get preferred auth method". (#2012)
 - [MINOR] Add support for CIAM custom domain (#2029)
-- [PATCH] Update nimbus-jose-jwt 9.37.3 (#2042)
 
 Version 5.1.0
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -39,7 +39,7 @@ ext {
     mockitoCoreVersion = "3.6.28"
     mockitoAndroidVersion = "3.6.28"
     multidexVersion = "2.0.1"
-    nimbusVersion = "9.37.3"
+    nimbusVersion = "9.9"
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"


### PR DESCRIPTION
This reverts #2042 

Why?
This change is breaking CP and blocking the release.
CP cannot update the library right now, because they need to do an IP scan before updating a lib. That would usually take a couple weeks to get the results back.
And because the severity part of this vulnerability is unclear, we will move this change to April release, giving more time to CP folks do their investigation. 
