### PR TITLE
Update error type returned from invalid OTP code response

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
@@ -183,7 +183,7 @@ class SignUpCodeRequiredState internal constructor(
 
                 is SignUpCommandResult.InvalidCode -> {
                     SubmitCodeError(
-                        errorType = ErrorTypes.BROWSER_REQUIRED,
+                        errorType = ErrorTypes.INVALID_CODE,
                         error = result.error,
                         errorMessage = result.errorDescription,
                         correlationId = result.correlationId,


### PR DESCRIPTION
Previously, receiving an invalid code error from the signup/continue endpoint would return the "browser_required" error type, which also caused the `isInvalidCode()` check to not function correctly. This PR updates the error type, and adds unit tests to cover this case.