### PR TITLE
Move the getActiveBroker() invocation to background thread

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/MultipleAccountPublicClientApplication.java
@@ -125,9 +125,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
                 final CommandParameters params = CommandParametersAdapter.createCommandParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
                 final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                         params,
-                        new MSALControllerFactory(mPublicClientConfiguration).getAllControllers(
-                                mPublicClientConfiguration.getDefaultAuthority()
-                        ),
+                        new MSALControllerFactory(mPublicClientConfiguration),
                         getLoadAccountsCallback(callback),
                         publicApiId
                 );
@@ -219,9 +217,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
                 final CommandParameters params = CommandParametersAdapter.createCommandParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
                 final LoadAccountCommand loadAccountCommand = new LoadAccountCommand(
                         params,
-                        new MSALControllerFactory(mPublicClientConfiguration).getAllControllers(
-                                mPublicClientConfiguration.getDefaultAuthority()
-                        ),
+                        new MSALControllerFactory(mPublicClientConfiguration),
                         new CommandCallback<List<ICacheRecord>, BaseException>() {
                             @Override
                             public void onTaskCompleted(final List<ICacheRecord> result) {
@@ -355,9 +351,7 @@ public class MultipleAccountPublicClientApplication extends PublicClientApplicat
 
         final RemoveAccountCommand removeAccountCommand = new RemoveAccountCommand(
                 params,
-                new MSALControllerFactory(mPublicClientConfiguration).getAllControllers(
-                        mPublicClientConfiguration.getDefaultAuthority()
-                ),
+                new MSALControllerFactory(mPublicClientConfiguration),
                 new CommandCallback<Boolean, BaseException>() {
                     @Override
                     public void onError(BaseException error) {

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1092,8 +1092,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
         final GetDeviceModeCommand command = new GetDeviceModeCommand(
                 params,
-                new MSALControllerFactory(config).getDefaultController(
-                        config.getDefaultAuthority()),
+                new MSALControllerFactory(config),
                 new CommandCallback<Boolean, BaseException>() {
                     @Override
                     public void onError(BaseException error) {
@@ -1418,9 +1417,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
     }
 
     private void validateBrokerNotInUse() throws MsalClientException {
-        if (new MSALControllerFactory(mPublicClientConfiguration).brokerEligibleAndInstalled(
-                mPublicClientConfiguration.getDefaultAuthority()
-        )) {
+        if (new MSALControllerFactory(mPublicClientConfiguration).brokerEligibleAndInstalled()) {
             throw new MsalClientException(
                     "Cannot perform this action - broker is enabled."
             );
@@ -1486,12 +1483,10 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 mPublicClientConfiguration.getOAuth2TokenCache()
         );
 
-        final BaseController controller = new MSALControllerFactory(mPublicClientConfiguration)
-                .getDefaultController(CommandParametersAdapter.getRequestAuthority(mPublicClientConfiguration));
-
         final GetPreferredAuthMethodFromAuthenticator command = new GetPreferredAuthMethodFromAuthenticator(
                 params,
-                controller,
+                new MSALControllerFactory(mPublicClientConfiguration,
+                        CommandParametersAdapter.getRequestAuthority(mPublicClientConfiguration)),
                 new CommandCallback<PreferredAuthMethod, BaseException>() {
                     @Override
                     public void onError(BaseException error) {
@@ -1638,9 +1633,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
         return new GenerateShrCommand(
                 cmdParams,
-                new MSALControllerFactory(mPublicClientConfiguration).getAllControllers(
-                        mPublicClientConfiguration.getDefaultAuthority()
-                ),
+                new MSALControllerFactory(mPublicClientConfiguration),
                 cmdCallback,
                 publicApiId
         );
@@ -1820,8 +1813,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
                     final InteractiveTokenCommand command = new InteractiveTokenCommand(
                             params,
-                            new MSALControllerFactory(mPublicClientConfiguration).getDefaultController(
-                                    params.getAuthority()),
+                            new MSALControllerFactory(mPublicClientConfiguration, params.getAuthority()),
                             localAuthenticationCallback,
                             publicApiId
                     );
@@ -1902,9 +1894,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
 
                     final SilentTokenCommand silentTokenCommand = new SilentTokenCommand(
                             params,
-                            new MSALControllerFactory(mPublicClientConfiguration).getAllControllers(
-                                    params.getAuthority()
-                            ),
+                            new MSALControllerFactory(mPublicClientConfiguration, params.getAuthority()),
                             callback,
                             publicApiId
                     );
@@ -2147,8 +2137,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
                 final DeviceCodeFlowCommandCallback deviceCodeFlowCommandCallback = getDeviceCodeFlowCommandCallback(callback);
                 final DeviceCodeFlowCommand deviceCodeFlowCommand = new DeviceCodeFlowCommand(
                         commandParameters,
-                        new MSALControllerFactory(mPublicClientConfiguration).getDefaultController(
-                                commandParameters.getAuthority()),
+                        new MSALControllerFactory(mPublicClientConfiguration),
                         deviceCodeFlowCommandCallback,
                         PublicApiId.DEVICE_CODE_FLOW_WITH_CLAIMS_AND_CALLBACK
                 );
@@ -2182,7 +2171,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         // Telemetry with DEVICE_CODE_FLOW_CALLBACK
         final DeviceCodeFlowCommand deviceCodeFlowCommand = new DeviceCodeFlowCommand(
                 commandParameters,
-                new LocalMSALController(),
+                new LocalMSALController().asControllerFactory(),
                 deviceCodeFlowCommandCallback,
                 PublicApiId.DEVICE_CODE_FLOW_WITH_CALLBACK
         );
@@ -2212,7 +2201,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         // Telemetry with DEVICE_CODE_FLOW_CALLBACK
         final DeviceCodeFlowCommand deviceCodeFlowCommand = new DeviceCodeFlowCommand(
                 commandParameters,
-                new LocalMSALController(),
+                new LocalMSALController().asControllerFactory(),
                 deviceCodeFlowCommandCallback,
                 PublicApiId.DEVICE_CODE_FLOW_WITH_CALLBACK
         );

--- a/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/SingleAccountPublicClientApplication.java
@@ -126,12 +126,10 @@ public class SingleAccountPublicClientApplication
             @Override
             public void onMigrationFinished(int numberOfAccountsMigrated) {
                 final CommandParameters params = CommandParametersAdapter.createCommandParameters(mPublicClientConfiguration, mPublicClientConfiguration.getOAuth2TokenCache());
-                final List<BaseController> controllers = new MSALControllerFactory(mPublicClientConfiguration)
-                        .getAllControllers(mPublicClientConfiguration.getDefaultAuthority());
 
                 final GetCurrentAccountCommand command = new GetCurrentAccountCommand(
                         params,
-                        controllers,
+                        new MSALControllerFactory(mPublicClientConfiguration),
                         new CommandCallback<List<ICacheRecord>, BaseException>() {
                             @Override
                             public void onTaskCompleted(final List<ICacheRecord> result) {
@@ -503,12 +501,9 @@ public class SingleAccountPublicClientApplication
                         requestAccountRecord
                 );
 
-        final List<BaseController> controllers = new MSALControllerFactory(mPublicClientConfiguration)
-                .getAllControllers(mPublicClientConfiguration.getDefaultAuthority());
-
         final RemoveCurrentAccountCommand command = new RemoveCurrentAccountCommand(
                 params,
-                controllers,
+                new MSALControllerFactory(mPublicClientConfiguration),
                 new CommandCallback<Boolean, BaseException>() {
                     @Override
                     public void onError(BaseException error) {

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
@@ -113,12 +113,12 @@ class MSALControllerFactory(
     override fun getAllControllers(): List<BaseController> {
         val activeBroker = getActiveBrokerPackageName()
         val controllers: MutableList<BaseController> = ArrayList()
-        controllers.add(LocalMSALController())
         if (!activeBroker.isNullOrEmpty() && brokerEligible()) {
             controllers.add(
                 BrokerMsalController(applicationContext, platformComponents, activeBroker)
             )
         }
+        controllers.add(LocalMSALController())
 
         return controllers.toList()
     }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactory.kt
@@ -26,6 +26,7 @@ import android.content.Context
 import android.os.Build
 import android.os.PowerManager
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
 import com.microsoft.identity.client.PublicClientApplicationConfiguration
 import com.microsoft.identity.common.components.AndroidPlatformComponentsFactory
 import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClientFactory
@@ -34,6 +35,7 @@ import com.microsoft.identity.common.internal.controllers.LocalMSALController
 import com.microsoft.identity.common.java.authorities.Authority
 import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAuthority
 import com.microsoft.identity.common.java.controllers.BaseController
+import com.microsoft.identity.common.java.controllers.IControllerFactory
 import com.microsoft.identity.common.java.interfaces.IPlatformComponents
 import com.microsoft.identity.common.logging.Logger
 import com.microsoft.identity.msal.BuildConfig
@@ -41,17 +43,26 @@ import com.microsoft.identity.msal.BuildConfig
 class MSALControllerFactory(
     private val applicationContext: Context,
     private val platformComponents: IPlatformComponents,
-    private val applicationConfiguration: PublicClientApplicationConfiguration) {
+    private val authority: Authority,
+    private val applicationConfiguration: PublicClientApplicationConfiguration) :
+    IControllerFactory {
 
     private val discoveryClient = BrokerDiscoveryClientFactory.getInstanceForClientSdk(
         context = applicationContext,
         platformComponents = platformComponents
     )
 
+    // todo: always take in a component?
     constructor(applicationConfiguration: PublicClientApplicationConfiguration):
-        this(applicationConfiguration.appContext,
-             AndroidPlatformComponentsFactory.createFromContext(applicationConfiguration.appContext),
-             applicationConfiguration)
+        this(applicationConfiguration = applicationConfiguration,
+            authority = applicationConfiguration.defaultAuthority)
+
+    constructor(applicationConfiguration: PublicClientApplicationConfiguration,
+                authority: Authority):
+            this(applicationContext = applicationConfiguration.appContext,
+                platformComponents = AndroidPlatformComponentsFactory.createFromContext(applicationConfiguration.appContext),
+                authority = authority,
+                applicationConfiguration = applicationConfiguration)
 
     companion object {
         private val TAG = MSALControllerFactory::class.simpleName
@@ -71,7 +82,7 @@ class MSALControllerFactory(
      * 4) If broker is not installed use local controller
      * 5) Otherwise return broker controller
      */
-    fun getDefaultController(authority: Authority): BaseController {
+    override fun getDefaultController(): BaseController {
         if (BuildConfig.DEBUG) {
             injectedMockDefaultController?.let {
                 return it
@@ -79,7 +90,7 @@ class MSALControllerFactory(
         }
 
         val activeBroker = getActiveBrokerPackageName()
-        return if (!activeBroker.isNullOrEmpty() && brokerEligible(authority)) {
+        return if (!activeBroker.isNullOrEmpty() && brokerEligible()) {
             BrokerMsalController(applicationContext, platformComponents, activeBroker)
         } else {
             LocalMSALController()
@@ -99,15 +110,15 @@ class MSALControllerFactory(
      * 2) The client indicates it wants to use broker
      * 3) The authority is AAD
      */
-    fun getAllControllers(authority: Authority): List<BaseController> {
+    override fun getAllControllers(): List<BaseController> {
         val activeBroker = getActiveBrokerPackageName()
         val controllers: MutableList<BaseController> = ArrayList()
-        if (!activeBroker.isNullOrEmpty() && brokerEligible(authority)) {
+        controllers.add(LocalMSALController())
+        if (!activeBroker.isNullOrEmpty() && brokerEligible()) {
             controllers.add(
                 BrokerMsalController(applicationContext, platformComponents, activeBroker)
             )
         }
-        controllers.add(LocalMSALController())
 
         return controllers.toList()
     }
@@ -116,8 +127,8 @@ class MSALControllerFactory(
      * Returns true if the request is eligible to use broker (see [brokerEligible])
      * AND if a valid broker is found.
      **/
-    fun brokerEligibleAndInstalled(authority: Authority): Boolean {
-        return getActiveBrokerPackageName() != null && brokerEligible(authority)
+    fun brokerEligibleAndInstalled(): Boolean {
+        return getActiveBrokerPackageName() != null && brokerEligible()
     }
 
     /**
@@ -129,7 +140,7 @@ class MSALControllerFactory(
      *
      * Note: This method does NOT check if broker is installed.
      */
-    private fun brokerEligible(authority: Authority): Boolean {
+    private fun brokerEligible(): Boolean {
         val methodTag = "$TAG:brokerEligible"
         val logBrokerEligibleFalse = "Eligible to call broker? [false]. "
 
@@ -165,8 +176,11 @@ class MSALControllerFactory(
         }
     }
 
+    @WorkerThread
     private fun getActiveBrokerPackageName(): String? {
         val methodTag = "$TAG:getActiveBrokerPackageName"
+
+        // This operation *might* be long running, so this method should be invoked in a background thread.
         val activeBroker = discoveryClient.getActiveBroker(shouldSkipCache = false)
         activeBroker?.let {
             return it.packageName

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -128,7 +128,7 @@ class NativeAuthPublicClientApplication(
 
             val command = GetCurrentAccountCommand(
                 params,
-                LocalMSALController(),
+                LocalMSALController().asControllerFactory(),
                 object : CommandCallback<List<ICacheRecord?>?, BaseException?> {
                     override fun onTaskCompleted(result: List<ICacheRecord?>?) {
                         // Do nothing, handled by CommandDispatcher.submitSilentReturningFuture()

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
@@ -128,7 +128,7 @@ class AccountState private constructor(
 
             val removeCurrentAccountCommandParameters = RemoveCurrentAccountCommand(
                 params,
-                LocalMSALController(),
+                LocalMSALController().asControllerFactory(),
                 object : CommandCallback<Boolean?, BaseException?> {
                     override fun onError(error: BaseException?) {
                         // Do nothing, handled by CommandDispatcher.submitSilentReturningFuture()

--- a/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
@@ -42,7 +42,6 @@ import org.robolectric.annotation.Config
 class MSALControllerFactoryTest {
 
     private lateinit var pcaConfiguration: PublicClientApplicationConfiguration
-    private lateinit var msalControllerFactory: MSALControllerFactory
 
     @Before
     fun setup() {
@@ -50,20 +49,21 @@ class MSALControllerFactoryTest {
         pcaConfiguration = PublicClientApplicationConfigurationFactory.loadConfiguration(context, R.raw.msal_default_config)
         pcaConfiguration.appContext = context
         Assert.assertTrue(pcaConfiguration.useBroker)
-        msalControllerFactory = MSALControllerFactory(pcaConfiguration)
     }
     @Test
     fun testGetControllers() {
         val testAuthority = Authority.getAuthorityFromAuthorityUrl("https://login.microsoftonline.com/common")
-        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled(testAuthority))
-        Assert.assertEquals(2, msalControllerFactory.getAllControllers(testAuthority).size)
-        Assert.assertTrue(msalControllerFactory.getAllControllers(testAuthority)[0] is BrokerMsalController )
+        val msalControllerFactory = MSALControllerFactory(pcaConfiguration, testAuthority)
+        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled())
+        Assert.assertEquals(2, msalControllerFactory.getAllControllers().size)
+        Assert.assertTrue(msalControllerFactory.getAllControllers()[0] is BrokerMsalController )
     }
 
     @Test
     fun testGetDefaultController() {
         val testAuthority = Authority.getAuthorityFromAuthorityUrl("https://login.microsoftonline.com/common")
-        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled(testAuthority))
-        Assert.assertTrue(msalControllerFactory.getDefaultController(testAuthority) is BrokerMsalController )
+        val msalControllerFactory = MSALControllerFactory(pcaConfiguration, testAuthority)
+        Assert.assertTrue(msalControllerFactory.brokerEligibleAndInstalled())
+        Assert.assertTrue(msalControllerFactory.getDefaultController() is BrokerMsalController )
     }
 }


### PR DESCRIPTION
## Why?
Once the BrokerDiscoveryClientFactory.IS_NEW_DISCOVERY_ENABLED is set to true, 
the getActiveBroker() operation could be long running (due to the first time broker discovery operation).

In order to avoid ANR issue (in MSAL), I'm moving the operation to the background thread.

This is done by making all the commands retrieve MSAL Controllers in its execute() block, which is executed by CommandDispatcher. 

## Changes
- Create IControllerFactory interface, make MSALControllerFactory inherits from it.
- Make all commands take IControllerFactory instead of controller objects.

Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2352