### PR TITLE
Modifying NAA tests to run with broker host

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688459.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688459.java
@@ -30,6 +30,8 @@ import com.microsoft.identity.common.java.dto.AccountRecord;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
+import com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,6 +42,8 @@ import java.util.List;
 
 // Nested App auth silent request
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2688459
+@SupportedBrokers(brokers = BrokerHost.class)
+@LocalBrokerHostDebugUiTest
 @RunWith(Parameterized.class)
 public class TestCase2688459 extends AbstractMsalBrokerTest {
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688460.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688460.java
@@ -26,6 +26,8 @@ import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.LocalBrokerHostDebugUiTest;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
@@ -39,6 +41,8 @@ import java.util.List;
 
 // Nested app interactive request after hub does an interactive request
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2688460
+@SupportedBrokers(brokers = BrokerHost.class)
+@LocalBrokerHostDebugUiTest
 @RunWith(Parameterized.class)
 public class TestCase2688460 extends AbstractMsalBrokerTest {
     private final UserType mUserType;

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688462.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nestedAppAuth/TestCase2688462.java
@@ -43,6 +43,8 @@ import java.util.List;
 
 // Nested app's fresh AT interactive succeeds but silent request fails
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2688462
+@SupportedBrokers(brokers = BrokerHost.class)
+@LocalBrokerHostDebugUiTest
 @RunWith(Parameterized.class)
 public class TestCase2688462 extends AbstractMsalBrokerTest {
     private final UserType mUserType;


### PR DESCRIPTION
Issue : NAA Tests in this pipeline run are failing https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1270279&view=ms.vss-test-web.build-test-results-tab&runId=3448652&resultId=100001&paneView=debug because they can only run with brokerHost app. We have a logic https://github.com/AzureAD/microsoft-authentication-library-common-for-android/blob/12d96b11ac124211e0cb0c7e0c9e0dadd07199e1/common/src/main/java/com/microsoft/identity/common/internal/platform/AndroidPlatformUtil.java#L140 that checks if the broker app is a debug app that the tests depend on. 

Fix : CP and Auth app debug versions are not produced in the pipeline currently. So we have to rely on brokerHost debug apk produced.