### PR TITLE
fix tests when broker discovery is enabled

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDiscoveryClient.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowDiscoveryClient.kt
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package com.microsoft.identity.client.e2e.shadows
+
+import com.microsoft.identity.common.internal.activebrokerdiscovery.BrokerDiscoveryClient
+import com.microsoft.identity.common.internal.broker.BrokerData
+import org.robolectric.annotation.Implements
+
+// A Shadow for mocking BrokerDiscoveryClient
+@Implements(BrokerDiscoveryClient::class)
+class ShadowBrokerDiscoveryClient {
+
+    fun getActiveBroker(shouldSkipCache: Boolean): BrokerData? {
+        return BrokerData.debugBrokerHost
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/internal/controllers/MSALControllerFactoryTest.kt
@@ -26,6 +26,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.microsoft.identity.client.PublicClientApplicationConfiguration
 import com.microsoft.identity.client.PublicClientApplicationConfigurationFactory
+import com.microsoft.identity.client.e2e.shadows.ShadowBrokerDiscoveryClient
 import com.microsoft.identity.client.e2e.shadows.ShadowLegacyBrokerDiscoveryClient
 import com.microsoft.identity.common.internal.controllers.BrokerMsalController
 import com.microsoft.identity.common.java.authorities.Authority
@@ -38,7 +39,9 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(shadows = [ShadowLegacyBrokerDiscoveryClient::class] )
+@Config(shadows = [
+    ShadowLegacyBrokerDiscoveryClient::class,
+    ShadowBrokerDiscoveryClient::class] )
 class MSALControllerFactoryTest {
 
     private lateinit var pcaConfiguration: PublicClientApplicationConfiguration


### PR DESCRIPTION
![Screenshot 2024-04-02 at 4 09 26 PM](https://github.com/AzureAD/microsoft-authentication-library-for-android/assets/19558668/49e27112-12d1-4b7a-9498-96c203aebbcf)

They fail if the broker discovery flag is enabled .... because we didn't mock/shadow the new implementation.

(Note that the new implementation is still flagged as "OFF" by default)

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1278820&view=results