### PR TITLE
Enable Cert based auth in daily and PR pipelines

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -76,7 +76,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=${{variables.LabVaultAppCert}} -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -63,10 +63,19 @@ jobs:
       jdkArchitecture: $(BuildParameters.jdkArchitecture)
       sqGradlePluginVersion: 2.0.1
   - task: CodeQL3000Finalize@0
+  - task: PowerShell@2
+    name: setvarStep
+    displayName: Set cert path
+    inputs:
+      targetType: inline
+      script: |
+        $pfxCertPath = '$(Build.SourcesDirectory)' + "\LabVaultAccessCert.pfx"
+        $certPathVar = $pfxCertPath -replace "\\", "\\\\"
+        Write-Host "##vso[task.setvariable variable=LabVaultAppCert]$($certPathVar)"  
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppSecret) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=${{variables.LabVaultAppCert}} -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}}
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -64,15 +64,6 @@ jobs:
       jdkArchitecture: $(BuildParameters.jdkArchitecture)
       sqGradlePluginVersion: 2.0.1
   - task: CodeQL3000Finalize@0
-  - task: PowerShell@2
-    name: setvarStep
-    displayName: Set cert path
-    inputs:
-      targetType: inline
-      script: |
-        $pfxCertPath = '$(Build.SourcesDirectory)' + "\LabVaultAccessCert.pfx"
-        $certPathVar = $pfxCertPath -replace "\\", "\\\\"
-        Write-Host "##vso[task.setvariable variable=LabVaultAppCert]$($certPathVar)"  
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -45,6 +45,7 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
     displayName: Use Java 11
     inputs:


### PR DESCRIPTION
The secret key for lab vault has been replaced with the certificate.

Pipeline run : https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1297001&view=results