### PR TITLE
Putting renaming task back in afterEvaluate

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -306,6 +306,18 @@ task pmd(type: Pmd) {
 }
 
 afterEvaluate {
+    // Gradle 6.1.1 and Android Gradle Plugin 4.0.1 doesn't rename the file (see 'outputFileName' above)
+    // Adding this work around to have the file properly renamed.
+    tasks.named("assembleDistRelease").configure {
+        def buildFile = file("$buildDir/outputs/aar/${archivesBaseName}-dist-release.aar")
+        print "Build file $buildFile"
+        doLast {
+            println "Renaming build file $buildFile to '$buildDir${File.separator}outputs${File.separator}aar${File.separator}${archivesBaseName}-${version}.aar'"
+            if (!buildFile.renameTo("$buildDir${File.separator}outputs${File.separator}aar${File.separator}${archivesBaseName}-${version}.aar")) {
+                println "Rename failed!"
+            }
+        }
+    }
     publishing {
         publications {
             msal(MavenPublication) {


### PR DESCRIPTION
### Summary
Putting the task configuring logic to rename the msal AAR file back in afterEvaluate. It's needed for our maven release pipeline, though I'm not quite sure why this logic is specifically needed in MSAL and not common.