### PR TITLE
Manage test configuration through config file

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "microsoft-authentication-library-common-for-android"]
 	path = common
 	url = https://github.com/AzureAD/microsoft-authentication-library-common-for-android.git
+	branch = yuki/key-vault-test

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -31,7 +31,7 @@ resources:
   - repository: common
     type: github
     name: AzureAD/microsoft-authentication-library-common-for-android
-    ref: dev
+    ref: yuki/key-vault-test
     endpoint: ANDROID_GITHUB
 
 pool:

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -16,6 +16,7 @@ variables:
   value: 33
 - group: MSIDLABVARS
 - group: devex-ciam-test
+- group: dexex-nativeauth
 
 trigger:
   branches:
@@ -42,6 +43,7 @@ jobs:
   variables:
     Codeql.Enabled: true
   steps:
+  - script: echo $(EmailOTPNoAttributes)
   - checkout: self
     clean: true
     submodules: recursive

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -69,7 +69,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthEmailOTPNoAttributes=$(EmailOTPNoAttributes) -PnativeAuthSSPRTestsUsernameValue=$(NativeAuthSSPRTestsUsernameValue) -PnativeAuthSignInTestsUsernameValue=$(NativeAuthSignInTestsUsernameValue) -PnativeAuthLabsEmailPasswordAppIdValue=$(NativeAuthLabsEmailPasswordAppId) -PnativeAuthLabsAuthorityUrlValue=$(NativeAuthLabsAuthorityUrlValue)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(NativeAuthTestConfig)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -66,12 +66,6 @@ jobs:
       jdkArchitecture: $(BuildParameters.jdkArchitecture)
       sqGradlePluginVersion: 2.0.1
   - task: CodeQL3000Finalize@0
-  - task: PowerShell@2
-    displayName: Print Native Auth Test Configuration
-    inputs:
-      targetType: 'inline'
-      script: |
-        Write-Host "Native Auth Test Config: $(native_auth_test_config)"
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -66,6 +66,12 @@ jobs:
       jdkArchitecture: $(BuildParameters.jdkArchitecture)
       sqGradlePluginVersion: 2.0.1
   - task: CodeQL3000Finalize@0
+  - task: PowerShell@2
+    displayName: Print Native Auth Test Configuration
+    inputs:
+      targetType: 'inline'
+      script: |
+        Write-Host "Native Auth Test Config: $(native_auth_test_config)"
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -68,7 +68,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthSSPRTestsUsernameValue=$(NativeAuthSSPRTestsUsernameValue) -PnativeAuthSignInTestsUsernameValue=$(NativeAuthSignInTestsUsernameValue) -PnativeAuthLabsEmailPasswordAppIdValue=$(NativeAuthLabsEmailPasswordAppId) -PnativeAuthLabsAuthorityUrlValue=$(NativeAuthLabsAuthorityUrlValue) -PnativeAuthEmployeeWriteAllScopeValue=$(NativeAuthEmployeeWriteAllScopeValue) -PnativeAuthEmployeeReadAllScopeValue=$(NativeAuthEmployeeReadAllScopeValue) -PnativeAuthCustomerWriteAllScopeValue=$(NativeAuthCustomerWriteAllScopeValue) -PnativeAuthCustomerReadAllScopeValue=$(NativeAuthCustomerReadAllScopeValue)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -69,7 +69,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(EmailOTPNoAttributes)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(native_auth_test_config)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -69,7 +69,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(NativeAuthTestConfig)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(EmailOTPNoAttributes)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -43,7 +43,6 @@ jobs:
   variables:
     Codeql.Enabled: true
   steps:
-  - script: echo $(EmailOTPNoAttributes)
   - checkout: self
     clean: true
     submodules: recursive
@@ -70,7 +69,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthSSPRTestsUsernameValue=$(NativeAuthSSPRTestsUsernameValue) -PnativeAuthSignInTestsUsernameValue=$(NativeAuthSignInTestsUsernameValue) -PnativeAuthLabsEmailPasswordAppIdValue=$(NativeAuthLabsEmailPasswordAppId) -PnativeAuthLabsAuthorityUrlValue=$(NativeAuthLabsAuthorityUrlValue)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthEmailOTPNoAttributes=$(EmailOTPNoAttributes) -PnativeAuthSSPRTestsUsernameValue=$(NativeAuthSSPRTestsUsernameValue) -PnativeAuthSignInTestsUsernameValue=$(NativeAuthSignInTestsUsernameValue) -PnativeAuthLabsEmailPasswordAppIdValue=$(NativeAuthLabsEmailPasswordAppId) -PnativeAuthLabsAuthorityUrlValue=$(NativeAuthLabsAuthorityUrlValue)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -69,7 +69,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthTestConfig=$(native_auth_test_config)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.11
 - job: spotbugs

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/GetAccessTokenTests.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/GetAccessTokenTests.kt
@@ -53,12 +53,14 @@ class GetAccessTokenTests : NativeAuthPublicClientApplicationAbstractTest() {
      */
     @Test
     fun testGetAccessTokenForInvalidScope() = runTest {
-        val username = NativeAuthCredentialHelper.nativeAuthSignInUsername
+        // Turn valid scope into an invalid one
+        val scopeA = resources[0].scopes[0] + "LorumIpsum"
+
         val password = getSafePassword()
         val result = application.signIn(
-            username = username,
+            username = config.email,
             password = password.toCharArray(),
-            scopes = listOf(INVALID_SCOPE)
+            scopes = listOf(scopeA)
         )
         assertState<SignInError>(result)
         Assert.assertEquals("invalid_grant", (result as SignInError).error)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -34,7 +34,7 @@ import com.microsoft.identity.client.e2e.tests.IPublicClientApplicationTest
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper
 import com.microsoft.identity.internal.testutils.TestUtils
-import com.microsoft.identity.internal.testutils.labutils.KeyVaultHelper
+import com.microsoft.identity.internal.testutils.labutils.KeyVaultFetchHelper
 import com.microsoft.identity.internal.testutils.labutils.LabConstants
 import com.microsoft.identity.internal.testutils.labutils.LabUserHelper
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery
@@ -104,7 +104,7 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = KeyVaultHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
+        val secretValue = KeyVaultFetchHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
         val type = TypeToken.getParameterized(
             Map::class.java,
             String::class.java,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -93,7 +93,7 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = LabHelper.getSecret("msalandroidnativeauthautomationconfjsonfile")
+        val secretValue = LabHelper.getSecret("native-auth-test-config")
         val type = object : TypeToken<Map<String, NativeAuthTestConfig.Config>>() {}.type
         return Gson().fromJson(
             secretValue,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -34,8 +34,8 @@ import com.microsoft.identity.client.e2e.tests.IPublicClientApplicationTest
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper
 import com.microsoft.identity.internal.testutils.TestUtils
+import com.microsoft.identity.internal.testutils.labutils.KeyVaultHelper
 import com.microsoft.identity.internal.testutils.labutils.LabConstants
-import com.microsoft.identity.internal.testutils.labutils.LabHelper
 import com.microsoft.identity.internal.testutils.labutils.LabUserHelper
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery
 import com.microsoft.identity.internal.testutils.nativeauth.api.models.NativeAuthTestConfig
@@ -93,12 +93,14 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = LabHelper.getSecret("native-auth-test-config")
-        val type = object : TypeToken<Map<String, NativeAuthTestConfig.Config>>() {}.type
-        return Gson().fromJson(
-            secretValue,
-            type
-        )
+        val secretValue = KeyVaultHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
+        val type = TypeToken.getParameterized(
+            Map::class.java,
+            String::class.java,
+            NativeAuthTestConfig.Config::class.java
+        ).type
+
+        return Gson().fromJson(secretValue, type)
     }
 
     fun setupPCA(configType: String) {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -93,7 +93,7 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = LabHelper.getSecret("native-auth")
+        val secretValue = LabHelper.getSecret("msalandroidnativeauthautomationconfjsonfile")
         val type = object : TypeToken<Map<String, NativeAuthTestConfig.Config>>() {}.type
         return Gson().fromJson(
             secretValue,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -93,7 +93,7 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = LabHelper.getSecret("buildautomation")
+        val secretValue = LabHelper.getSecret("msalandroidnativeauthautomationconfjsonfile")
         val type = object : TypeToken<Map<String, NativeAuthTestConfig.Config>>() {}.type
         return Gson().fromJson(
             secretValue,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -26,24 +26,17 @@ import android.app.Activity
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import com.google.gson.Gson
-import com.google.gson.GsonBuilder
 import com.microsoft.identity.client.Logger
 import com.microsoft.identity.client.PublicClientApplication
 import com.microsoft.identity.client.e2e.tests.IPublicClientApplicationTest
 import com.microsoft.identity.client.exception.MsalException
-import com.microsoft.identity.client.internal.configuration.LogLevelDeserializer
-import com.microsoft.identity.common.internal.authorities.AzureActiveDirectoryAudienceDeserializer
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper
-import com.microsoft.identity.common.java.authorities.Authority
-import com.microsoft.identity.common.java.authorities.AuthorityDeserializer
-import com.microsoft.identity.common.java.authorities.AzureActiveDirectoryAudience
 import com.microsoft.identity.internal.testutils.TestUtils
 import com.microsoft.identity.internal.testutils.labutils.LabConstants
 import com.microsoft.identity.internal.testutils.labutils.LabUserHelper
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery
-import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
+import com.microsoft.identity.internal.testutils.nativeauth.api.models.NativeAuthTestConfig
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
-import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -73,7 +66,6 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
         context = ApplicationProvider.getApplicationContext()
         activity = Mockito.mock(Activity::class.java)
         Mockito.`when`(activity.applicationContext).thenReturn(context)
-        setupPCA()
         Logger.getInstance().setEnableLogcatLog(true)
         Logger.getInstance().setEnablePII(true)
         Logger.getInstance().setLogLevel(Logger.LogLevel.VERBOSE)
@@ -94,40 +86,19 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
         return credential.password
     }
 
-    private fun setupPCA() {
-        val nativeConfig = getGsonForLoadingConfiguration()?.fromJson(
-            NativeAuthCredentialHelper.nativeAuthConfig,
-            NativeAuthPublicClientApplicationConfiguration::class.java
-        )
+    fun setupPCA(config: NativeAuthTestConfig.Config) {
         val challengeTypes = listOf("password", "oob")
 
         try {
             application = PublicClientApplication.createNativeAuthPublicClientApplication(
                 context,
-                nativeConfig!!.clientId,
-                nativeConfig.defaultAuthority.authorityURL.toString(),
+                config.client_id,
+                config.authority_url,
                 null,
                 challengeTypes
             )
         } catch (e: MsalException) {
             Assert.fail(e.message)
         }
-    }
-
-    private fun getGsonForLoadingConfiguration(): Gson? {
-        return GsonBuilder()
-            .registerTypeAdapter(
-                Authority::class.java,
-                AuthorityDeserializer()
-            )
-            .registerTypeAdapter(
-                AzureActiveDirectoryAudience::class.java,
-                AzureActiveDirectoryAudienceDeserializer()
-            )
-            .registerTypeAdapter(
-                Logger.LogLevel::class.java,
-                LogLevelDeserializer()
-            )
-            .create()
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -102,7 +102,8 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     fun setupPCA(configType: String) {
-        config = getConfigsThroughSecretValue()?.get(configType) ?: throw IllegalStateException("Config not found")
+        val secretValue = getConfigsThroughSecretValue()
+        config = secretValue?.get(configType) ?: throw IllegalStateException("Config not $secretValue")
         val challengeTypes = listOf("password", "oob")
 
         try {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -93,7 +93,7 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = LabHelper.getSecret("msalandroidnativeauthautomationconfjsonfile")
+        val secretValue = LabHelper.getSecret("buildautomation")
         val type = object : TypeToken<Map<String, NativeAuthTestConfig.Config>>() {}.type
         return Gson().fromJson(
             secretValue,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
@@ -45,7 +45,7 @@ class SSPRTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SSPR
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SSPR"]!!
 
     @Before
     override fun setup() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
@@ -45,15 +45,18 @@ class SSPRTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SSPR
+
     @Before
     override fun setup() {
         super.setup()
+        setupPCA(config)
         Dispatchers.setMain(testDispatcher)
     }
 
     @Test
     fun testSSPRErrorSimple() = runTest {
-        val user = NativeAuthCredentialHelper.nativeAuthSSPRUsername
+        val user = config.email
         // Turn correct username into an incorrect one
         val invalidUser = user + "x"
         val result = application.resetPassword(invalidUser)
@@ -71,7 +74,7 @@ class SSPRTest : NativeAuthPublicClientApplicationAbstractTest() {
 
         while (shouldRetry) {
             try {
-                val user = NativeAuthCredentialHelper.nativeAuthSSPRUsername
+                val user = config.email
                 val result = application.resetPassword(user)
                 Assert.assertTrue(result is ResetPasswordStartResult.CodeRequired)
                 val otp = tempEmailApi.retrieveCodeFromInbox(user)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SSPRTest.kt
@@ -23,7 +23,6 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
-import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
 import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordResult
@@ -45,12 +44,10 @@ class SSPRTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SSPR"]!!
-
     @Before
     override fun setup() {
         super.setup()
-        setupPCA(config)
+        setupPCA("SSPR")
         Dispatchers.setMain(testDispatcher)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
@@ -23,20 +23,16 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
+import com.microsoft.identity.internal.testutils.nativeauth.ConfigType
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
 class SignInTest : NativeAuthPublicClientApplicationAbstractTest() {
 
-    @Before
-    override fun setup() {
-        super.setup()
-        setupPCA("SIGN_IN_PASSWORD")
-    }
+    override val configType = ConfigType.SIGN_IN_PASSWORD
 
     @Test
     fun testSignInErrorSimple() = runTest {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
@@ -23,24 +23,19 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
-import com.microsoft.identity.internal.testutils.BuildConfig
-import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
 
 class SignInTest : NativeAuthPublicClientApplicationAbstractTest() {
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SIGN_IN_PASSWORD"]!!
 
     @Before
     override fun setup() {
         super.setup()
-        setupPCA(config)
+        setupPCA("SIGN_IN_PASSWORD")
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
@@ -23,18 +23,29 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
+import com.microsoft.identity.internal.testutils.BuildConfig
 import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 
 class SignInTest : NativeAuthPublicClientApplicationAbstractTest() {
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SIGN_IN_PASSWORD
+
+    @Before
+    override fun setup() {
+        super.setup()
+        setupPCA(config)
+    }
 
     @Test
     fun testSignInErrorSimple() = runTest {
-        val username = NativeAuthCredentialHelper.nativeAuthSignInUsername
+        val username = config.email
         val password = getSafePassword()
         // Turn correct password into an incorrect one
         val alteredPassword = password + "1234"
@@ -45,7 +56,7 @@ class SignInTest : NativeAuthPublicClientApplicationAbstractTest() {
 
     @Test
     fun testSignInSuccessSimple() = runTest {
-        val username = NativeAuthCredentialHelper.nativeAuthSignInUsername
+        val username = config.email
         val password = getSafePassword()
         val result = application.signIn(username, password.toCharArray())
         Assert.assertTrue(result is SignInResult.Complete)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInTest.kt
@@ -35,7 +35,7 @@ import org.junit.Before
 import org.junit.Test
 
 class SignInTest : NativeAuthPublicClientApplicationAbstractTest() {
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SIGN_IN_PASSWORD
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SIGN_IN_PASSWORD"]!!
 
     @Before
     override fun setup() {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -56,36 +56,36 @@ class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
         Assert.assertTrue((result as SignUpError).isInvalidPassword())
     }
 
-//    /**
-//     * Running with runBlocking to avoid default 10 second execution timeout.
-//     */
-//    @Test
-//    fun testSignUpSuccessSimple() = runBlocking {
-//        var retryCount = 0
-//        var signUpResult: SignUpResult
-//        var otp: String
-//        var shouldRetry = true
-//
-//        while (shouldRetry) {
-//            try {
-//                val user = tempEmailApi.generateRandomEmailAddress()
-//                val password = getSafePassword()
-//                signUpResult = application.signUp(user, password.toCharArray())
-//                Assert.assertTrue(signUpResult is SignUpResult.CodeRequired)
-//                otp = tempEmailApi.retrieveCodeFromInbox(user)
-//                val submitCodeResult = (signUpResult as SignUpResult.CodeRequired).nextState.submitCode(otp)
-//                Assert.assertTrue(submitCodeResult is SignUpResult.Complete)
-//                shouldRetry = false
-//                break
-//            } catch (e: IllegalStateException) {
-//                // Re-run this test if the OTP retrieval fails. 1SecMail is known for emails to sometimes never arrive.
-//                // In that case, restart the test case with a new email address and try again, to make test less flaky.
-//                if (retryCount == 3) {
-//                    Assert.fail()
-//                    shouldRetry = false
-//                }
-//                retryCount++
-//            }
-//        }
-//    }
+    /**
+     * Running with runBlocking to avoid default 10 second execution timeout.
+     */
+    @Test
+    fun testSignUpSuccessSimple() = runBlocking {
+        var retryCount = 0
+        var signUpResult: SignUpResult
+        var otp: String
+        var shouldRetry = true
+
+        while (shouldRetry) {
+            try {
+                val user = tempEmailApi.generateRandomEmailAddress()
+                val password = getSafePassword()
+                signUpResult = application.signUp(user, password.toCharArray())
+                Assert.assertTrue(signUpResult is SignUpResult.CodeRequired)
+                otp = tempEmailApi.retrieveCodeFromInbox(user)
+                val submitCodeResult = (signUpResult as SignUpResult.CodeRequired).nextState.submitCode(otp)
+                Assert.assertTrue(submitCodeResult is SignUpResult.Complete)
+                shouldRetry = false
+                break
+            } catch (e: IllegalStateException) {
+                // Re-run this test if the OTP retrieval fails. 1SecMail is known for emails to sometimes never arrive.
+                // In that case, restart the test case with a new email address and try again, to make test less flaky.
+                if (retryCount == 3) {
+                    Assert.fail()
+                    shouldRetry = false
+                }
+                retryCount++
+            }
+        }
+    }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -56,36 +56,36 @@ class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
         Assert.assertTrue((result as SignUpError).isInvalidPassword())
     }
 
-    /**
-     * Running with runBlocking to avoid default 10 second execution timeout.
-     */
-    @Test
-    fun testSignUpSuccessSimple() = runBlocking {
-        var retryCount = 0
-        var signUpResult: SignUpResult
-        var otp: String
-        var shouldRetry = true
-
-        while (shouldRetry) {
-            try {
-                val user = tempEmailApi.generateRandomEmailAddress()
-                val password = getSafePassword()
-                signUpResult = application.signUp(user, password.toCharArray())
-                Assert.assertTrue(signUpResult is SignUpResult.CodeRequired)
-                otp = tempEmailApi.retrieveCodeFromInbox(user)
-                val submitCodeResult = (signUpResult as SignUpResult.CodeRequired).nextState.submitCode(otp)
-                Assert.assertTrue(submitCodeResult is SignUpResult.Complete)
-                shouldRetry = false
-                break
-            } catch (e: IllegalStateException) {
-                // Re-run this test if the OTP retrieval fails. 1SecMail is known for emails to sometimes never arrive.
-                // In that case, restart the test case with a new email address and try again, to make test less flaky.
-                if (retryCount == 3) {
-                    Assert.fail()
-                    shouldRetry = false
-                }
-                retryCount++
-            }
-        }
-    }
+//    /**
+//     * Running with runBlocking to avoid default 10 second execution timeout.
+//     */
+//    @Test
+//    fun testSignUpSuccessSimple() = runBlocking {
+//        var retryCount = 0
+//        var signUpResult: SignUpResult
+//        var otp: String
+//        var shouldRetry = true
+//
+//        while (shouldRetry) {
+//            try {
+//                val user = tempEmailApi.generateRandomEmailAddress()
+//                val password = getSafePassword()
+//                signUpResult = application.signUp(user, password.toCharArray())
+//                Assert.assertTrue(signUpResult is SignUpResult.CodeRequired)
+//                otp = tempEmailApi.retrieveCodeFromInbox(user)
+//                val submitCodeResult = (signUpResult as SignUpResult.CodeRequired).nextState.submitCode(otp)
+//                Assert.assertTrue(submitCodeResult is SignUpResult.Complete)
+//                shouldRetry = false
+//                break
+//            } catch (e: IllegalStateException) {
+//                // Re-run this test if the OTP retrieval fails. 1SecMail is known for emails to sometimes never arrive.
+//                // In that case, restart the test case with a new email address and try again, to make test less flaky.
+//                if (retryCount == 3) {
+//                    Assert.fail()
+//                    shouldRetry = false
+//                }
+//                retryCount++
+//            }
+//        }
+//    }
 }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -23,6 +23,7 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
+import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
 import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpResult
@@ -42,9 +43,12 @@ class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SIGN_UP_PASSWORD
+
     @Before
     override fun setup() {
         super.setup()
+        setupPCA(config)
         Dispatchers.setMain(testDispatcher)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -23,7 +23,6 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
-import com.microsoft.identity.internal.testutils.nativeauth.NativeAuthCredentialHelper
 import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpResult
@@ -43,12 +42,10 @@ class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SIGN_UP_PASSWORD"]!!
-
     @Before
     override fun setup() {
         super.setup()
-        setupPCA(config)
+        setupPCA("SIGN_UP_PASSWORD")
         Dispatchers.setMain(testDispatcher)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -23,31 +23,20 @@
 
 package com.microsoft.identity.client.e2e.tests.network.nativeauth
 
+import com.microsoft.identity.internal.testutils.nativeauth.ConfigType
 import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.results.SignUpResult
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 
 class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
 
     private val tempEmailApi = TemporaryEmailService()
 
-    // Remove default Coroutine test timeout of 10 seconds.
-    private val testDispatcher = StandardTestDispatcher()
-
-    @Before
-    override fun setup() {
-        super.setup()
-        setupPCA("SIGN_UP_PASSWORD")
-        Dispatchers.setMain(testDispatcher)
-    }
+    override val configType = ConfigType.SIGN_UP_PASSWORD
 
     @Test
     fun testSignUpErrorSimple() = runTest {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignUpTest.kt
@@ -43,7 +43,7 @@ class SignUpTest : NativeAuthPublicClientApplicationAbstractTest() {
     // Remove default Coroutine test timeout of 10 seconds.
     private val testDispatcher = StandardTestDispatcher()
 
-    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.SIGN_UP_PASSWORD
+    private val config = NativeAuthCredentialHelper.nativeAuthTestConfig.configs["SIGN_UP_PASSWORD"]!!
 
     @Before
     override fun setup() {


### PR DESCRIPTION
Labs API doesn't have support for the various applications, users, etc. that are needed for native auth test cases. Instead, we manage these values manually - currently through environment variables (CI env. vars. and Gradle parameters). These variables don't scale, so we're moving to having all the variables that are needed in a configuration file that's stored in a Labs KeyVault.

MSAL common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2439