### PR TITLE
Fix UserAttributesBuilder bug

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/UserAttributes.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/UserAttributes.kt
@@ -29,17 +29,19 @@ import com.microsoft.identity.common.java.util.ObjectMapper
  * operation in Native Auth
  */
 class UserAttributes(internal val userAttributes: Map<String, String>) {
-    companion object Builder {
-        private const val CITY = "city"
-        private const val COUNTRY = "country"
-        private const val DISPLAY_NAME = "displayName"
-        private const val EMAIL_ADDRESS = "email"
-        private const val GIVEN_NAME = "givenName"
-        private const val JOB_TITLE = "jobTitle"
-        private const val POSTAL_CODE = "postalCode"
-        private const val STATE = "state"
-        private const val STREET_ADDRESS = "streetAddress"
-        private const val SURNAME = "surname"
+    class Builder {
+        companion object {
+            private const val CITY = "city"
+            private const val COUNTRY = "country"
+            private const val DISPLAY_NAME = "displayName"
+            private const val EMAIL_ADDRESS = "email"
+            private const val GIVEN_NAME = "givenName"
+            private const val JOB_TITLE = "jobTitle"
+            private const val POSTAL_CODE = "postalCode"
+            private const val STATE = "state"
+            private const val STREET_ADDRESS = "streetAddress"
+            private const val SURNAME = "surname"
+        }
 
         private val userAttributes = mutableMapOf<String, String>()
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
@@ -2215,7 +2215,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // it's value in order to make it consistent with the subsequent call to mock API.
         mockCorrelationId(attributesRequiredState, correlationId);
 
-        UserAttributes invalidAttributes = UserAttributes.Builder.customAttribute("attribute", "invalid_attribute").build();
+        UserAttributes invalidAttributes = new UserAttributes.Builder().customAttribute("attribute", "invalid_attribute").build();
         SignUpSubmitUserAttributesTestCallback failedUserAttributesCallback = new SignUpSubmitUserAttributesTestCallback();
 
         attributesRequiredState.submitAttributes(invalidAttributes, failedUserAttributesCallback);
@@ -2232,7 +2232,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
                 MockApiResponseType.SIGNUP_CONTINUE_SUCCESS
         );
 
-        UserAttributes validAttributes = UserAttributes.Builder.customAttribute("attribute", "valid_attribute").build();
+        UserAttributes validAttributes = new UserAttributes.Builder().customAttribute("attribute", "valid_attribute").build();
         SignUpSubmitUserAttributesTestCallback validUserAttributesCallback = new SignUpSubmitUserAttributesTestCallback();
 
         attributesRequiredState.submitAttributes(validAttributes, validUserAttributesCallback);
@@ -2259,7 +2259,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         );
 
         // 1b. Call SDK interface
-        UserAttributes invalidAttributes = UserAttributes.Builder.customAttribute("attribute", "valid_attribute").build();
+        UserAttributes invalidAttributes = new UserAttributes.Builder().customAttribute("attribute", "valid_attribute").build();
         SignUpTestCallback signUpTestCallback = new SignUpTestCallback();
 
         application.signUp(username, password, invalidAttributes, signUpTestCallback);
@@ -2281,7 +2281,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         );
 
         // 2b. Call SDK interface again
-        UserAttributes validAttributes = UserAttributes.Builder.customAttribute("attribute", "valid_attribute").build();
+        UserAttributes validAttributes = new UserAttributes.Builder().customAttribute("attribute", "valid_attribute").build();
 
         SignUpTestCallback signUpSuccessCallback = new SignUpTestCallback();
 
@@ -2703,7 +2703,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         mockCorrelationId(attributesRequiredState, correlationId);
 
         SignUpSubmitUserAttributesTestCallback attributesRequiredCallback = new SignUpSubmitUserAttributesTestCallback();
-        UserAttributes attributes = UserAttributes.Builder.customAttribute("attribute", "attribute").build();
+        UserAttributes attributes = new UserAttributes.Builder().customAttribute("attribute", "attribute").build();
 
         attributesRequiredState.submitAttributes(attributes, attributesRequiredCallback);
         SignUpSubmitAttributesResult successResult = attributesRequiredCallback.get();
@@ -2783,7 +2783,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // it's value in order to make it consistent with the subsequent call to mock API.
         mockCorrelationId(attributesRequiredState, correlationId);
 
-        UserAttributes incompleteAttributes = UserAttributes.Builder.customAttribute("attribute", "incomplete_attribute").build();
+        UserAttributes incompleteAttributes = new UserAttributes.Builder().customAttribute("attribute", "incomplete_attribute").build();
         SignUpSubmitUserAttributesTestCallback attributesRequiredCallback = new SignUpSubmitUserAttributesTestCallback();
 
         attributesRequiredState.submitAttributes(incompleteAttributes, attributesRequiredCallback);
@@ -2804,7 +2804,7 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // it's value in order to make it consistent with the subsequent call to mock API.
         mockCorrelationId(additionalAttributesRequiredState, correlationId);
 
-        UserAttributes attributes = UserAttributes.Builder.customAttribute("attribute", "attribute").build();
+        UserAttributes attributes = new UserAttributes.Builder().customAttribute("attribute", "attribute").build();
         SignUpSubmitUserAttributesTestCallback additionalAttributesRequiredCallback = new SignUpSubmitUserAttributesTestCallback();
 
         additionalAttributesRequiredState.submitAttributes(attributes, additionalAttributesRequiredCallback);

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -1812,7 +1812,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         // it's value in order to make it consistent with the subsequent call to mock API.
         attributesRequiredState.mockCorrelationId(correlationId)
 
-        val invalidAttributes = UserAttributes.Builder.customAttribute("attribute", "invalid_attribute").build()
+        val invalidAttributes = UserAttributes.Builder().customAttribute("attribute", "invalid_attribute").build()
         val attributesFailedResult = attributesRequiredState.submitAttributes(invalidAttributes)
 
         assertTrue(attributesFailedResult is SignUpSubmitAttributesError)
@@ -1826,7 +1826,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
             responseType = MockApiResponseType.SIGNUP_CONTINUE_SUCCESS
         )
 
-        val validAttributes = UserAttributes.Builder.customAttribute("attribute", "valid_attribute").build()
+        val validAttributes = UserAttributes.Builder().customAttribute("attribute", "valid_attribute").build()
         val successResult = attributesRequiredState.submitAttributes(validAttributes)
 
         // 4b. Server accepts password, returns tokens
@@ -1851,7 +1851,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         )
 
         // 1b. Call SDK interface
-        val invalidAttributes = UserAttributes.Builder.customAttribute("attribute", "invalid_attribute").build()
+        val invalidAttributes = UserAttributes.Builder().customAttribute("attribute", "invalid_attribute").build()
         val invalidAttributesResult = application.signUp(username, password, invalidAttributes)
 
         assertTrue(invalidAttributesResult is SignUpError)
@@ -1870,7 +1870,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         )
 
         // 2b. Call SDK interface again
-        val validAttributes = UserAttributes.Builder.customAttribute("attribute", "valid_attribute").build()
+        val validAttributes = UserAttributes.Builder().customAttribute("attribute", "valid_attribute").build()
         val result = application.signUp(username, password, validAttributes)
         assertTrue(result is SignUpResult.CodeRequired)
     }
@@ -2239,7 +2239,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         // it's value in order to make it consistent with the subsequent call to mock API.
         attributesRequiredState.mockCorrelationId(correlationId)
 
-        val attributes = UserAttributes.Builder.customAttribute("attribute", "attribute").build()
+        val attributes = UserAttributes.Builder().customAttribute("attribute", "attribute").build()
         val successResult = attributesRequiredState.submitAttributes(attributes)
 
         // 4b. Server accepts attributes, returns tokens
@@ -2311,7 +2311,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         // it's value in order to make it consistent with the subsequent call to mock API.
         attributesRequiredState.mockCorrelationId(correlationId)
 
-        val incompleteAttributes = UserAttributes.Builder.customAttribute("attribute", "incomplete_attribute").build()
+        val incompleteAttributes = UserAttributes.Builder().customAttribute("attribute", "incomplete_attribute").build()
         val additionalAttributesRequiredResult = attributesRequiredState.submitAttributes(incompleteAttributes)
 
         assertTrue(additionalAttributesRequiredResult is SignUpResult.AttributesRequired)
@@ -2329,7 +2329,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         // it's value in order to make it consistent with the subsequent call to mock API.
         additionalAttributesRequiredState.mockCorrelationId(correlationId)
 
-        val attributes = UserAttributes.Builder.customAttribute("attribute", "attribute").build()
+        val attributes = UserAttributes.Builder().customAttribute("attribute", "attribute").build()
         val successResult = additionalAttributesRequiredState.submitAttributes(attributes)
 
         // 4b. Server accepts password, returns tokens


### PR DESCRIPTION
When using UserAttributes.Builder multiple times, e.g. when submitting attributes across multiple steps/screens, previously set data is persisted. This is due to the Builder (unintentionally) being a singleton. The impact of this is that unexpected/unintended user attributes are sent to the server, causing an incorrect user flow.

This PR extract related changes from https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2124/commits/0c8665134a8daa58526fc9a77832b8bac3067b7c