### PR TITLE
Updating unit test for error code common PR

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
@@ -200,7 +200,7 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                 .withLoginHint(username)
                 .withScopes(Arrays.asList(mScopes))
                 .fromAuthority(getAuthority())
-                .withCallback(AcquireTokenTestHelper.failureInteractiveCallback(ErrorCodes.UNKNOWN_ERROR_CODE))
+                .withCallback(AcquireTokenTestHelper.failureInteractiveCallback(ErrorCodes.NULL_POINTER_ERROR_CDOE))
                 .build();
 
         mApplication.acquireToken(parameters);

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/utils/ErrorCodes.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/utils/ErrorCodes.java
@@ -29,4 +29,5 @@ public class ErrorCodes {
     public static final String NO_ACCOUNT_FOUND_ERROR_CODE = "no_account_found";
     public static final String NO_CURRENT_ACCOUNT_ERROR_CODE = "no_current_account";
     public static final String INTERNAL_SERVER_ERROR_CODE = "internal_server_error";
+    public static final String NULL_POINTER_ERROR_CDOE = "null_pointer_error";
 }


### PR DESCRIPTION
### Summary
See https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2460.
With the null_pointer_error code, this unit test needs to be updated to compare with the null_pointer_error code vs the unknown_error code.