### PR TITLE
Append the UserAttributes fix into the changelog as MINOR

### DIFF
--- a/changelog
+++ b/changelog
@@ -6,6 +6,7 @@ vNext
 Version 5.4.2
 ---------
 - [PATCH] Update common @17.6.1
+- [MINOR] Fix UserAttributesBuilder being a singleton bug (#2145)
 
 Version 5.4.0
 ----------


### PR DESCRIPTION
In this PR https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2145, I incorrectly added the "No-Changelog" label. However, this fix should has a record in the changelog. Add a record by this PR.