### PR TITLE
Authority data is persisted across different SDK instances 

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Fix authority data being persisted across different SDK instances (#2151)
 
 Version 5.4.2
 ---------

--- a/changelog
+++ b/changelog
@@ -2,7 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [PATCH] Fix authority data being persisted across different SDK instances (#2151)
+- [PATCH] Fix Native Auth authority data being persisted across different SDK instances (#2159)
 
 Version 5.4.2
 ---------

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1141,7 +1141,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         if (authority != null) {
             config.getAuthorities().clear();
 
-            final Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority);
+            final Authority authorityObject = Authority.getAuthorityFromAuthorityUrl(authority, clientId);  // Get CIAMAuthority or NativeAuthCIAMAuthority
             authorityObject.setDefault(true);
             config.getAuthorities().add(authorityObject);
         }
@@ -1161,7 +1161,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         config.setIsSharedDevice(false);
 
         // Check whether account mode is SINGLE
-        config.validateConfiguration();
+        config.validateConfiguration();  // Valid configuration and convert CIAMAuthority to NativeAuthCIAMAuthority
         return new NativeAuthPublicClientApplication(config);
     }
 


### PR DESCRIPTION
### The target of this branch is dev

The working history please refer this closed PR https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2151

Company PR:  https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2462

### Investigation Summary:
Please refer company PR for root cause description. In this PR, we apply the new overload method in Authority to pass in the client id. Authority returns CIAM Authority when client id is null. In the later validation step, it will be converted into Native Authority.