### PR TITLE
Remove triggers from pipelines and execute ABID validator on label change

### DIFF
--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -7,7 +7,7 @@
 name: 'AB#ID Check'
 on: 
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, labeled]
 
 jobs:
 # This action checks your pull request to make sure it is linked to a work item using AB# before you can merge.

--- a/azure-pipelines/auth-client/msal-instrumented-test.yml
+++ b/azure-pipelines/auth-client/msal-instrumented-test.yml
@@ -2,9 +2,6 @@
 # Description: Run instrumented test for MSAL.
 name: Instrumented Tests
 
-trigger:
-- dev
-
 resources:
  repositories:
  - repository: android-complete

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -17,14 +17,6 @@ variables:
 - group: MSIDLABVARS
 - group: devex-ciam-test
 
-trigger:
-  branches:
-    include:
-    - dev
-    - master
-    - release/*
-  batch: True
-
 resources:
   repositories:
   - repository: common


### PR DESCRIPTION
Something changed on ADO and that caused the pipeline to stop running on PR, the solution was to remove the trigger tag.

If you didn't specify any triggers, and the [Disable implied YAML CI trigger](https://learn.microsoft.com/en-us/azure/devops/release-notes/2023/sprint-227-update#prevent-unintended-pipeline-runs) setting is not enabled, the default is as if you wrote:
````
trigger:
  branches:
    include:
    - '*'  # must quote since "*" is a YAML reserved character; we want a string
