### PR TITLE
Test fixes for disabling browser access with keystore flight enabled, Fixes AB#3039504

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582294.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582294.java
@@ -81,12 +81,6 @@ public class TestCase2582294 extends AbstractMsalBrokerTest {
         final String state = brokerHostWithoutBrokerSelection.getDeviceState();
         Assert.assertTrue("Assert that the device state is true", state.contains("true"));
 
-        // click on "install cert" button
-        // popup to select certificate type is shown
-        // Choose "Vpn and app user cert" and click on ok
-        // popup with name of cert is shown. let the default name be there. Upon clicking on ok, a toast message with "Certificate is installed" is shown
-        brokerHostWithoutBrokerSelection.enableBrowserAccess(username);
-
         // click on "get wpj upn" button
         // You should see the upn with which we performed join
         final String upn = brokerHostWithoutBrokerSelection.getAccountUpn();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582295.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582295.java
@@ -82,12 +82,6 @@ public class TestCase2582295 extends AbstractMsalBrokerTest {
         final String state = brokerHostWithoutBrokerSelection.getDeviceState();
         Assert.assertTrue("Assert that the device state is true", state.contains("true"));
 
-        // click on "install cert" button
-        // popup to select certificate type is shown
-        // Choose "Vpn and app user cert" and click on ok
-        // popup with name of cert is shown. let the default name be there. Upon clicking on ok, a toast message with "Certificate is installed" is shown
-        brokerHostWithoutBrokerSelection.enableBrowserAccess(username);
-
         // click on "get wpj upn" button
         // You should see the upn with which we performed join
         final String upn = brokerHostWithoutBrokerSelection.getAccountUpn();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582296.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582296.java
@@ -99,9 +99,6 @@ public class TestCase2582296 extends AbstractMsalBrokerTest {
         final String state = brokerHostWithoutBrokerSelection.multipleWpjApiFragment.getDeviceState(username);
         Assert.assertTrue(state.contains("DEVICE_VALID"));
 
-        // Click on "Install certificate" button
-        brokerHostWithoutBrokerSelection.multipleWpjApiFragment.installCertificate(username);
-
         // Click on "Get device token" button
         final String token = brokerHostWithoutBrokerSelection.multipleWpjApiFragment.getDeviceToken(username);
         Assert.assertTrue(!TextUtils.isEmpty(token.replace("Device token:", "")));

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582297.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2582297.java
@@ -101,9 +101,6 @@ public class TestCase2582297 extends AbstractMsalBrokerTest {
         final String state = brokerHostWithoutBrokerSelection.multipleWpjApiFragment.getDeviceState(username);
         Assert.assertTrue(state.contains("DEVICE_VALID"));
 
-        // Click on "Install certificate" button
-        brokerHostWithoutBrokerSelection.multipleWpjApiFragment.installCertificate(username);
-
         // Click on "Get device token" button
         final String token = brokerHostWithoutBrokerSelection.multipleWpjApiFragment.getDeviceToken(username);
         Assert.assertTrue(!TextUtils.isEmpty(token.replace("Device token:", "")));

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2519783.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2519783.kt
@@ -49,15 +49,17 @@ class TestCase2519783 : AbstractMsalBrokerTest() {
 
     @Test
     fun test_2519783() {
-        // Register 2 accounts from different tenants
-        mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mLabAccount.username, mLabAccount.password)
-        mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mUsGovAccount.username, mUsGovAccount.password)
-        val deviceRegistrationRecords = mBrokerHostApp.multipleWpjApiFragment.allRecords
-        Assert.assertEquals(2, deviceRegistrationRecords.size)
+        if (!mBrokerHostApp.flights.contains("\"EnableKeyStoreKeyFactory\":\"true\"")) {
+            // Register 2 accounts from different tenants
+            mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mLabAccount.username, mLabAccount.password)
+            mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mUsGovAccount.username, mUsGovAccount.password)
+            val deviceRegistrationRecords = mBrokerHostApp.multipleWpjApiFragment.allRecords
+            Assert.assertEquals(2, deviceRegistrationRecords.size)
 
-        // Install WPJ certificate for browser access in both registrations.
-        mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[0]["TenantId"] as String)
-        mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[1]["TenantId"] as String)
+            // Install WPJ certificate for browser access in both registrations.
+            mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[0]["TenantId"] as String)
+            mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[1]["TenantId"] as String)
+        }
     }
 
     override fun getLabQuery(): LabQuery {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2519783.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2519783.kt
@@ -34,6 +34,7 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment
 import com.microsoft.identity.labapi.utilities.constants.TempUserType
 import com.microsoft.identity.labapi.utilities.constants.UserType
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Before
 import org.junit.Test
 
@@ -49,17 +50,15 @@ class TestCase2519783 : AbstractMsalBrokerTest() {
 
     @Test
     fun test_2519783() {
-        if (!mBrokerHostApp.flights.contains("\"EnableKeyStoreKeyFactory\":\"true\"")) {
-            // Register 2 accounts from different tenants
-            mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mLabAccount.username, mLabAccount.password)
-            mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mUsGovAccount.username, mUsGovAccount.password)
-            val deviceRegistrationRecords = mBrokerHostApp.multipleWpjApiFragment.allRecords
-            Assert.assertEquals(2, deviceRegistrationRecords.size)
+        // Register 2 accounts from different tenants
+        mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mLabAccount.username, mLabAccount.password)
+        mBrokerHostApp.multipleWpjApiFragment.performDeviceRegistration(mUsGovAccount.username, mUsGovAccount.password)
+        val deviceRegistrationRecords = mBrokerHostApp.multipleWpjApiFragment.allRecords
+        Assert.assertEquals(2, deviceRegistrationRecords.size)
 
-            // Install WPJ certificate for browser access in both registrations.
-            mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[0]["TenantId"] as String)
-            mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[1]["TenantId"] as String)
-        }
+        // Install WPJ certificate for browser access in both registrations.
+        mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[0]["TenantId"] as String)
+        mBrokerHostApp.multipleWpjApiFragment.installCertificate(deviceRegistrationRecords[1]["TenantId"] as String)
     }
 
     override fun getLabQuery(): LabQuery {
@@ -83,6 +82,8 @@ class TestCase2519783 : AbstractMsalBrokerTest() {
     fun before() {
         mUsGovAccount = mLabClient.getLabAccount(getUsGovLabQuery())
         mBrokerHostApp = broker as BrokerHost
+        Assume.assumeFalse( "EnableKeyStoreKeyFactory flight is set, Test will be skipped",
+            mBrokerHostApp.flights.contains("\"EnableKeyStoreKeyFactory\":\"true\""));
         mBrokerHostApp.enableMultipleWpj()
     }
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2563668.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mwpj/TestCase2563668.kt
@@ -81,8 +81,10 @@ class TestCase2563668 : AbstractMsalBrokerTest() , ICustomBrokerInstallationTest
         Assert.assertTrue(claims.containsKey("deviceid"))
         Assert.assertEquals(deviceIdObtainedUsingLegacyBroker, claims["deviceid"])
 
-        //Install certificate
-        mBrokerHostApp.multipleWpjApiFragment.installCertificate(mLabAccount.username)
+        if (!mBrokerHostApp.flights.contains("\"EnableKeyStoreKeyFactory\":\"true\"")) {
+            //Install certificate
+            mBrokerHostApp.multipleWpjApiFragment.installCertificate(mLabAccount.username)
+        }
 
         //Get device state
         val deviceState = mBrokerHostApp.multipleWpjApiFragment.getDeviceState(mLabAccount.username)


### PR DESCRIPTION
Fixes for disabling browser access operation when keystore flight is enabled.
- Skipped the install cert operation when the flight is enabled
- Removed the step from LTW tests as the test cases are verifying passthrough communication is working fine, which is being verified with multiple other operations.
[AB#3039504](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3039504)