### PR TITLE
Introduce specific MFA errors

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
@@ -5,7 +5,7 @@ import com.microsoft.identity.nativeauth.statemachine.results.MFARequiredResult
 import com.microsoft.identity.nativeauth.statemachine.results.MFASubmitChallengeResult
 
 /**
- * MFA error. Use the utility methods of this class
+ * MFA request challenge error. Use the utility methods of this class
  * to identify and handle the error. This error is produced by
  * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.requestChallenge] and
  * [com.microsoft.identity.nativeauth.statemachine.states.AwaitingMFAState.requestChallenge].
@@ -27,7 +27,7 @@ class MFARequestChallengeError(
 ): MFARequiredResult, BrowserRequiredError, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 
 /**
- * MFA error. Use the utility methods of this class
+ * MFA get authentication methods error. Use the utility methods of this class
  * to identify and handle the error. This error is produced by
  * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.getAuthMethods]
  * @param errorType the error type value of the error that occurred.
@@ -37,7 +37,7 @@ class MFARequestChallengeError(
  * @param errorCodes a list of specific error codes returned by the authentication server.
  * @param exception an internal unexpected exception that happened.
  */
-class GetAuthMethodsError(
+class MFAGetAuthMethodsError(
     override val errorType: String? = null,
     override val error: String? = null,
     override val errorMessage: String?,
@@ -48,7 +48,7 @@ class GetAuthMethodsError(
 ): MFAGetAuthMethodsResult, BrowserRequiredError, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 
 /**
- * MFA error. The user should use the utility methods of this class
+ * MFA submit challenge error. The user should use the utility methods of this class
  * to identify and handle the error. This error is produced by
  * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.submitChallenge]
  * @param errorType the error type value of the error that occurred.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
@@ -5,9 +5,10 @@ import com.microsoft.identity.nativeauth.statemachine.results.MFARequiredResult
 import com.microsoft.identity.nativeauth.statemachine.results.MFASubmitChallengeResult
 
 /**
- * MFA error. The user should use the utility methods of this class
- * to identify and handle the error. This error is produced by the various
- * MFA operations.
+ * MFA error. Use the utility methods of this class
+ * to identify and handle the error. This error is produced by
+ * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.requestChallenge] and
+ * [com.microsoft.identity.nativeauth.statemachine.states.AwaitingMFAState.requestChallenge].
  * @param errorType the error type value of the error that occurred.
  * @param error the error returned by the authentication server.
  * @param errorMessage the error message returned by the authentication server.
@@ -15,14 +16,36 @@ import com.microsoft.identity.nativeauth.statemachine.results.MFASubmitChallenge
  * @param errorCodes a list of specific error codes returned by the authentication server.
  * @param exception an internal unexpected exception that happened.
  */
-class MFAError(
+class MFARequestChallengeError(
     override val errorType: String? = null,
     override val error: String? = null,
     override val errorMessage: String?,
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
+    val subError: String? = null,
     override var exception: Exception? = null
-): MFARequiredResult, BrowserRequiredError, MFAGetAuthMethodsResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): MFARequiredResult, BrowserRequiredError, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+
+/**
+ * MFA error. Use the utility methods of this class
+ * to identify and handle the error. This error is produced by
+ * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.getAuthMethods]
+ * @param errorType the error type value of the error that occurred.
+ * @param error the error returned by the authentication server.
+ * @param errorMessage the error message returned by the authentication server.
+ * @param correlationId a unique identifier for the request that can help in diagnostics.
+ * @param errorCodes a list of specific error codes returned by the authentication server.
+ * @param exception an internal unexpected exception that happened.
+ */
+class GetAuthMethodsError(
+    override val errorType: String? = null,
+    override val error: String? = null,
+    override val errorMessage: String?,
+    override val correlationId: String,
+    override val errorCodes: List<Int>? = null,
+    val subError: String? = null,
+    override var exception: Exception? = null
+): MFAGetAuthMethodsResult, BrowserRequiredError, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 
 /**
  * MFA error. The user should use the utility methods of this class
@@ -35,7 +58,7 @@ class MFAError(
  * @param errorCodes a list of specific error codes returned by the authentication server.
  * @param exception an internal unexpected exception that happened.
  */
-class SubmitChallengeError(
+class MFASubmitChallengeError(
     override val errorType: String? = null,
     override val error: String? = null,
     override val errorMessage: String?,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/MFAResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/MFAResult.kt
@@ -68,6 +68,6 @@ interface MFAGetAuthMethodsResult : Result
 
 /**
  * Results related to MFA submit challenge operation, produced by
- *  * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.submitChallenge]
+ * [com.microsoft.identity.nativeauth.statemachine.states.MFARequiredState.submitChallenge]
  */
 interface MFASubmitChallengeResult : Result

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/ResetPasswordResult.kt
@@ -23,7 +23,6 @@
 
 package com.microsoft.identity.nativeauth.statemachine.results
 
-import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordPasswordRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
@@ -47,7 +47,7 @@ import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
-import com.microsoft.identity.nativeauth.statemachine.errors.GetAuthMethodsError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFAGetAuthMethodsError
 import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeError
 import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeError
 import com.microsoft.identity.nativeauth.statemachine.results.MFAGetAuthMethodsResult
@@ -311,7 +311,7 @@ class MFARequiredState(
                             "getAuthMethods() received unexpected result: ",
                             result
                         )
-                        GetAuthMethodsError(
+                        MFAGetAuthMethodsError(
                             errorMessage = result.errorDescription,
                             error = result.error,
                             correlationId = result.correlationId,
@@ -320,7 +320,7 @@ class MFARequiredState(
                         )
                     }
                     is INativeAuthCommandResult.Redirect -> {
-                        GetAuthMethodsError(
+                        MFAGetAuthMethodsError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.errorDescription,
@@ -329,7 +329,7 @@ class MFARequiredState(
                     }
                 }
             } catch (e: Exception) {
-                GetAuthMethodsError(
+                MFAGetAuthMethodsError(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in getAuthMethods().",
                     exception = e,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
@@ -25,7 +25,6 @@ package com.microsoft.identity.nativeauth.statemachine.states
 
 import android.os.Parcel
 import android.os.Parcelable
-import androidx.annotation.experimental.Experimental
 import com.microsoft.identity.client.AuthenticationResultAdapter
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.client.internal.CommandParametersAdapter
@@ -48,8 +47,9 @@ import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
-import com.microsoft.identity.nativeauth.statemachine.errors.MFAError
-import com.microsoft.identity.nativeauth.statemachine.errors.SubmitChallengeError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAuthMethodsError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeError
 import com.microsoft.identity.nativeauth.statemachine.results.MFAGetAuthMethodsResult
 import com.microsoft.identity.nativeauth.statemachine.results.MFARequiredResult
 import com.microsoft.identity.nativeauth.statemachine.results.MFASubmitChallengeResult
@@ -164,7 +164,7 @@ class AwaitingMFAState(
                             "requestChallenge() received unexpected result: ",
                             result
                         )
-                        MFAError(
+                        MFARequestChallengeError(
                             errorMessage = result.errorDescription,
                             error = result.error,
                             correlationId = result.correlationId,
@@ -173,7 +173,7 @@ class AwaitingMFAState(
                         )
                     }
                     is INativeAuthCommandResult.Redirect -> {
-                        MFAError(
+                        MFARequestChallengeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.errorDescription,
@@ -182,7 +182,7 @@ class AwaitingMFAState(
                     }
                 }
             } catch (e: Exception) {
-                MFAError(
+                MFARequestChallengeError(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in requestChallenge().",
                     exception = e,
@@ -311,7 +311,7 @@ class MFARequiredState(
                             "getAuthMethods() received unexpected result: ",
                             result
                         )
-                        MFAError(
+                        GetAuthMethodsError(
                             errorMessage = result.errorDescription,
                             error = result.error,
                             correlationId = result.correlationId,
@@ -320,7 +320,7 @@ class MFARequiredState(
                         )
                     }
                     is INativeAuthCommandResult.Redirect -> {
-                        MFAError(
+                        GetAuthMethodsError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.errorDescription,
@@ -329,7 +329,7 @@ class MFARequiredState(
                     }
                 }
             } catch (e: Exception) {
-                MFAError(
+                GetAuthMethodsError(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in getAuthMethods().",
                     exception = e,
@@ -452,7 +452,7 @@ class MFARequiredState(
                             "requestChallenge(authMethod) received unexpected result: ",
                             result
                         )
-                        MFAError(
+                        MFARequestChallengeError(
                             errorMessage = result.errorDescription,
                             error = result.error,
                             correlationId = result.correlationId,
@@ -461,7 +461,7 @@ class MFARequiredState(
                         )
                     }
                     is INativeAuthCommandResult.Redirect -> {
-                        MFAError(
+                        MFARequestChallengeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.errorDescription,
@@ -470,7 +470,7 @@ class MFARequiredState(
                     }
                 }
             } catch (e: Exception) {
-                MFAError(
+                MFARequestChallengeError(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in requestChallenge(authMethod).",
                     exception = e,
@@ -560,7 +560,7 @@ class MFARequiredState(
                         )
                     }
                     is SignInCommandResult.IncorrectCode -> {
-                        SubmitChallengeError(
+                        MFASubmitChallengeError(
                             errorType = ErrorTypes.INVALID_CODE,
                             error = result.error,
                             errorMessage = result.errorDescription,
@@ -577,7 +577,7 @@ class MFARequiredState(
                             "submitChallenge(challenge) received unexpected result: ",
                             result
                         )
-                        SubmitChallengeError(
+                        MFASubmitChallengeError(
                             errorMessage = result.errorDescription,
                             error = result.error,
                             correlationId = result.correlationId,
@@ -587,7 +587,7 @@ class MFARequiredState(
                     }
                 }
             } catch (e: Exception) {
-                SubmitChallengeError(
+                MFASubmitChallengeError(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in submitChallenge(challenge)",
                     exception = e,

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInMFATest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInMFATest.kt
@@ -27,12 +27,11 @@ import com.microsoft.identity.client.e2e.utils.assertResult
 import com.microsoft.identity.internal.testutils.nativeauth.ConfigType
 import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
 import com.microsoft.identity.internal.testutils.nativeauth.api.models.NativeAuthTestConfig
-import com.microsoft.identity.nativeauth.statemachine.errors.SubmitChallengeError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.MFARequiredResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
 import kotlinx.coroutines.runBlocking
-import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
@@ -94,8 +93,8 @@ class SignInMFATest : NativeAuthPublicClientApplicationAbstractTest() {
 
                 // Submit incorrect challenge
                 val submitIncorrectChallengeResult = sendChallengeResult.nextState.submitChallenge("invalid")
-                assertResult<SubmitChallengeError>(submitIncorrectChallengeResult)
-                assertTrue((submitIncorrectChallengeResult as SubmitChallengeError).isInvalidChallenge())
+                assertResult<MFASubmitChallengeError>(submitIncorrectChallengeResult)
+                assertTrue((submitIncorrectChallengeResult as MFASubmitChallengeError).isInvalidChallenge())
 
                 // Request new challenge
                 val requestNewChallengeResult = sendChallengeResult.nextState.requestChallenge()

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -46,7 +46,7 @@ import com.microsoft.identity.internal.testutils.TestUtils
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenErrorTypes
-import com.microsoft.identity.nativeauth.statemachine.errors.GetAuthMethodsError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFAGetAuthMethodsError
 import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
@@ -2779,8 +2779,8 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
 
         // Call /introspect to get all auth methods
         val getAuthMethodsResult = nextState2.getAuthMethods()
-        assertResult<GetAuthMethodsError>(getAuthMethodsResult)
-        assertTrue((getAuthMethodsResult as GetAuthMethodsError).isBrowserRequired())
+        assertResult<MFAGetAuthMethodsError>(getAuthMethodsResult)
+        assertTrue((getAuthMethodsResult as MFAGetAuthMethodsError).isBrowserRequired())
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -46,14 +46,15 @@ import com.microsoft.identity.internal.testutils.TestUtils
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenErrorTypes
-import com.microsoft.identity.nativeauth.statemachine.errors.MFAError
+import com.microsoft.identity.nativeauth.statemachine.errors.GetAuthMethodsError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpSubmitAttributesError
-import com.microsoft.identity.nativeauth.statemachine.errors.SubmitChallengeError
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SubmitCodeError
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -2707,8 +2708,8 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
 
         nextState.mockCorrelationId(correlationId)
         val sendChallengeResult = nextState.requestChallenge()
-        assertResult<MFAError>(sendChallengeResult)
-        assertTrue((sendChallengeResult as MFAError).isBrowserRequired())
+        assertResult<MFARequestChallengeError>(sendChallengeResult)
+        assertTrue((sendChallengeResult as MFARequestChallengeError).isBrowserRequired())
     }
 
     @Test
@@ -2778,8 +2779,8 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
 
         // Call /introspect to get all auth methods
         val getAuthMethodsResult = nextState2.getAuthMethods()
-        assertResult<MFAError>(getAuthMethodsResult)
-        assertTrue((getAuthMethodsResult as MFAError).isBrowserRequired())
+        assertResult<GetAuthMethodsError>(getAuthMethodsResult)
+        assertTrue((getAuthMethodsResult as GetAuthMethodsError).isBrowserRequired())
     }
 
     @Test
@@ -2849,8 +2850,8 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         nextState4.mockCorrelationId(correlationId)
 
         val submitChallengeResult = nextState4.submitChallenge(code)
-        assertResult<SubmitChallengeError>(submitChallengeResult)
-        assertTrue((submitChallengeResult as SubmitChallengeError).isInvalidChallenge())
+        assertResult<MFASubmitChallengeError>(submitChallengeResult)
+        assertTrue((submitChallengeResult as MFASubmitChallengeError).isInvalidChallenge())
 
         // 5. Submit (valid) code
         // 5a. Setup server response
@@ -2980,8 +2981,8 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         nextState4.mockCorrelationId(correlationId)
 
         val submitChallengeResult = nextState4.submitChallenge(code)
-        assertResult<SubmitChallengeError>(submitChallengeResult)
-        assertTrue((submitChallengeResult as SubmitChallengeError).isInvalidChallenge())
+        assertResult<MFASubmitChallengeError>(submitChallengeResult)
+        assertTrue((submitChallengeResult as MFASubmitChallengeError).isInvalidChallenge())
 
         // 7. Submit (valid) code
         // 7a. Setup server response


### PR DESCRIPTION
- specific error classes makes sense when you have errors that can only happen in one method. E.g. `invalidAttributesError()` should only be available after `submitAttributes()`, i.e. we wrap that utility method in `SignUpSubmitAttributesError` which is emitted from `submitAttributes()`
- this has worked well so far: every method we have has method-specific errors, so there has always been a reason to create dedicated error classes
- however, for MFA this is not the case. Only `submitChallenge()` has a specific error (invalid challenge), all the rest doesn't. 
- however, we should still introduce specific MFA error classes anyway, because without it it would either be a breaking change when we add it (e.g. `requestChallenge()` will not longer emit `MFAError`, but now emit `MFASubmitChallengeError`), or developers are going to need to check for both error classes (e.g. `if error is MFAError || error is MFASubmitChallengeError`)