### PR TITLE
Add test verifications for removing account from account mgr, Fixes AB#3001904

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922530.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922530.java
@@ -30,6 +30,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerUpdateTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -52,6 +53,7 @@ public class TestCase1922530  extends AbstractMsalBrokerUpdateTest {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
+        ((BrokerMicrosoftAuthenticator) mBroker).setShouldUseDeviceSettingsPage(true);
         mBroker.performDeviceRegistration(username, password);
         final MsalSdk msalSdk = new MsalSdk();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922547.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/atpop/update/TestCase1922547.java
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerUpdateTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
@@ -54,6 +55,7 @@ public class TestCase1922547  extends AbstractMsalBrokerUpdateTest {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
+        ((BrokerMicrosoftAuthenticator) mBroker).setShouldUseDeviceSettingsPage(true);
         mBroker.performDeviceRegistration(username, password);
 
         final MsalSdk msalSdk = new MsalSdk();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/flw/TestCase833517.java
@@ -22,27 +22,40 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.flw;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import androidx.annotation.NonNull;
+
 import com.microsoft.identity.client.IAccount;
 import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.SingleAccountPublicClientApplication;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
 import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
 import com.microsoft.identity.client.ui.automation.constants.AuthScheme;
 import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
-import com.microsoft.identity.common.java.util.ThreadUtils;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.labapi.utilities.client.ILabAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserRole;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -54,13 +67,21 @@ import java.util.Arrays;
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
 @RetryOnFailure(retryCount = 2)
 public class TestCase833517 extends AbstractMsalBrokerTest {
-
+    final String TAG = TestCase833517.class.getSimpleName();
     @Test
     public void test_833517() throws Throwable{
-        final String username = mLabAccount.getUsername();
-        final String password = mLabAccount.getPassword();
+        final String deviceAdminUsername = mLabAccount.getUsername();
+        final String deviceAdminPassword = mLabAccount.getPassword();
 
-        mBroker.performSharedDeviceRegistration(username, password);
+        mBroker.performSharedDeviceRegistration(deviceAdminUsername, deviceAdminPassword);
+        final SingleAccountPublicClientApplication singleAccountPCA =
+                (SingleAccountPublicClientApplication) PublicClientApplication.create(mContext, getConfigFileResourceId());
+
+        Logger.i(TAG, "Fetching another user from same tenant from lab account");
+        final LabQuery labQuery = LabQuery.builder().userType(UserType.CLOUD).build();
+        final ILabAccount labAccount = mLabClient.getLabAccount(labQuery);
+        final String username = labAccount.getUsername();
+        final String password = labAccount.getPassword();
 
         final MsalSdk msalSdk = new MsalSdk();
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
@@ -92,13 +113,32 @@ public class TestCase833517 extends AbstractMsalBrokerTest {
 
         authResult.assertSuccess();
 
+        // uninstall the Azure Sample app to ensure clean state
+        final AzureSampleApp azureSampleApp = new AzureSampleApp();
+        azureSampleApp.uninstall();
+        Logger.i(TAG, "Launching azure sample app and confirming user signed in or not.");
+
+        // install and launch the Azure Sample app
+        azureSampleApp.install();
+        azureSampleApp.launch();
+        azureSampleApp.confirmSignedIn(username);
+        Logger.i(TAG, "Azure sample verified signed in account.");
+
+        final TokenRequestLatch signOutLatch = new TokenRequestLatch(1);
+        registerAccountChangeBroadcastReceiver(signOutLatch);
+
+        // Remove account from account settings page
         getSettingsScreen().removeAccount(username);
 
-        ThreadUtils.sleepSafely(15000, "Sleep", "Interrupted");
+        signOutLatch.await(TokenRequestTimeout.LONG);
 
-        //final IPublicClientApplication pca = PublicClientApplication.create(mActivity,getConfigFileResourceId());
-        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
+        Logger.i(TAG, "Confirming getCurrentAccount returns null.");
+        final IAccount account = singleAccountPCA.getCurrentAccount().getCurrentAccount();
         Assert.assertNull(account);
+
+        Logger.i(TAG, "Confirming account is signed out in Azure Sample.");
+        azureSampleApp.launch();
+        azureSampleApp.confirmSignedIn("None");
     }
 
     @Override
@@ -127,5 +167,20 @@ public class TestCase833517 extends AbstractMsalBrokerTest {
     @Override
     public int getConfigFileResourceId() {
         return R.raw.msal_config_default;
+    }
+
+    private void registerAccountChangeBroadcastReceiver(@NonNull final TokenRequestLatch signOutLatch){
+        mContext.registerReceiver(
+                new BroadcastReceiver() {
+                    @Override
+                    public void onReceive(Context context, Intent intent) {
+                        Logger.i(TAG, "Received broadcast.");
+                        signOutLatch.countDown();
+                    }
+                },
+                new IntentFilter("android.accounts.LOGIN_ACCOUNTS_CHANGED")
+                //[BUG] Removing account from settings page does not trigger the signout broadcast from broker.
+                //new IntentFilter("com.microsoft.identity.client.sharedmode.CURRENT_ACCOUNT_CHANGED")
+        );
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase833558.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase833558.java
@@ -1,0 +1,210 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.joined;
+
+import com.microsoft.identity.client.AcquireTokenParameters;
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
+import com.microsoft.identity.client.AuthenticationCallback;
+import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.IAuthenticationResult;
+import com.microsoft.identity.client.SilentAuthenticationCallback;
+import com.microsoft.identity.client.claims.ClaimsRequest;
+import com.microsoft.identity.client.claims.RequestedClaimAdditionalInformation;
+import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.interaction.InteractiveRequest;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestLatch;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.common.internal.util.StringUtil;
+import com.microsoft.identity.labapi.utilities.client.ILabAccount;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.exception.LabApiException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+
+// Broker Delete account via Account Manager
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833558
+@SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
+@RetryOnFailure(retryCount = 2)
+public class TestCase833558 extends AbstractMsalBrokerTest {
+    final String TAG = TestCase833558.class.getSimpleName();
+    private IAccount mTempAccount = null;
+    @Test
+    public void test_msal_833558() throws Throwable {
+        Logger.i(TAG, "Get user account from lab");
+        final String deviceRegistrationOwnerUsername = mLabAccount.getUsername();
+        final String deviceRegistrationOwnerPassword = mLabAccount.getPassword();
+
+        Logger.i(TAG, "Perform device registration with the user account from lab");
+        mBroker.performDeviceRegistration(deviceRegistrationOwnerUsername, deviceRegistrationOwnerPassword);
+
+        mBroker.forceStop();
+
+        String tempAccountUserName = createTempAccountAndAcquireToken(false);
+
+        Logger.i(TAG, "Remove temp account from settings page");
+        getSettingsScreen().removeAccount(tempAccountUserName);
+
+        Logger.i(TAG, "Perform silent token request for temp account, expects no_account_found error");
+        final TokenRequestLatch silentTokenLatch = new TokenRequestLatch(1);
+        final AcquireTokenSilentParameters silentParameters = new AcquireTokenSilentParameters.Builder()
+                .withScopes(Arrays.asList(mScopes))
+                .forceRefresh(false)
+                .fromAuthority(getAuthority())
+                .forAccount(mTempAccount)
+                .withCallback(failedSilentCallback(silentTokenLatch, "no_account_found"))
+                .build();
+        mApplication.acquireTokenSilentAsync(silentParameters);
+        silentTokenLatch.await(TokenRequestTimeout.SILENT);
+
+        Logger.i(TAG, "Remove device registration owner account from settings page");
+        getSettingsScreen().removeAccount(deviceRegistrationOwnerUsername);
+
+        createTempAccountAndAcquireToken(true);
+    }
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return "https://login.microsoftonline.com/common";
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+
+    private String createTempAccountAndAcquireToken(boolean registerPageExpected) throws LabApiException {
+        Logger.i(TAG, "Create temp account from lab");
+        final ILabAccount labAccount = mLabClient.createTempAccount(TempUserType.BASIC);
+        final String tempAccountUserName = labAccount.getUsername();
+        final String tempAccountPassword = labAccount.getPassword();
+
+        final TokenRequestLatch tokenRequestLatch = new TokenRequestLatch(1);
+        final AcquireTokenParameters parameters = new AcquireTokenParameters.Builder()
+                .startAuthorizationFromActivity(mActivity)
+                .withLoginHint(tempAccountUserName)
+                .withScopes(Arrays.asList(mScopes))
+                .withCallback(interactiveRequestCallback(tokenRequestLatch))
+                .withClaims(deviceIdClaimsRequest())
+                .build();
+
+        final InteractiveRequest interactiveRequest = new InteractiveRequest(
+                mApplication,
+                parameters,
+                () -> {
+                    final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                            .prompt(PromptParameter.SELECT_ACCOUNT)
+                            .loginHint(tempAccountUserName)
+                            .sessionExpected(false)
+                            .consentPageExpected(false)
+                            .registerPageExpected(registerPageExpected)
+                            .speedBumpExpected(false)
+                            .build();
+
+                    new AadPromptHandler(promptHandlerParameters)
+                            .handlePrompt(tempAccountUserName, tempAccountPassword);
+                }
+        );
+        Logger.i(TAG, "Perform interactive token request for temp account, with deviceid claim.");
+        interactiveRequest.execute();
+        tokenRequestLatch.await(TokenRequestTimeout.SHORT);
+        return tempAccountUserName;
+    }
+
+    private AuthenticationCallback interactiveRequestCallback(final CountDownLatch latch) {
+        return new AuthenticationCallback() {
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                Assert.assertFalse(StringUtil.isEmpty(authenticationResult.getAccessToken()));
+                mTempAccount = authenticationResult.getAccount();
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                Assert.fail(exception.getMessage());
+                latch.countDown();
+            }
+
+            @Override
+            public void onCancel() {
+                Assert.fail("User cancelled flow");
+                latch.countDown();
+            }
+        };
+    }
+
+    private SilentAuthenticationCallback failedSilentCallback(final CountDownLatch latch, final String errorCode) {
+        return new SilentAuthenticationCallback() {
+            @Override
+            public void onSuccess(IAuthenticationResult authenticationResult) {
+                Assert.fail("Unexpected success");
+                latch.countDown();
+            }
+
+            @Override
+            public void onError(MsalException exception) {
+                Assert.assertEquals(errorCode, exception.getErrorCode());
+                latch.countDown();
+            }
+        };
+    }
+
+    private ClaimsRequest deviceIdClaimsRequest() {
+        RequestedClaimAdditionalInformation information = new RequestedClaimAdditionalInformation();
+        information.setEssential(true);
+        ClaimsRequest claimsRequest = new ClaimsRequest();
+        claimsRequest.requestClaimInAccessToken("deviceid", information);
+        return claimsRequest;
+    }
+}


### PR DESCRIPTION
[SDM] Added verification that removing account from account settings page removes account from broker and all other apps 
[Non SDM] Added Test case to verify removing accounts (WPJ owner and non-owner).

[AB#3001904](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3001904)