### PR TITLE
Exclude nimbus classes JCASupport and AESCBC using proGuard, Fixes AB#3042434

### DIFF
--- a/msal/consumer-rules.pro
+++ b/msal/consumer-rules.pro
@@ -22,6 +22,8 @@
 
 ##---------------Begin: proguard configuration for Nimbus  ----------
 -keep class com.nimbusds.** { *; }
+-keep class !com.nimbusds.jose.jca.JCASupport, **  # Exclude `JCASupport` while keeping others
+-keep class !com.nimbusds.jose.crypto.impl.AESCBC, **  # Exclude `AESCBC` while keeping others
 
 ##---------------Begin: proguard configuration for Gson  --------
 # Gson uses generic type information stored in a class file when working with fields. Proguard


### PR DESCRIPTION
https://portal.microsofticm.com/imp/v5/incidents/details/543093195/summary
https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/2164
Couple of customers have reported vulnerabilities on the nimbus lib using MobSF.
The vulnerabilities are:

WE: CWE-649: Reliance on Obfuscation or
Encryption of Security-Relevant Inputs without
Integrity Checking
OWASP Top 10: M5: Insufficient Cryptography
OWASP MASVS: MSTG-CRYPTO-3

com/nimbusds/jose/crypto/AESCBC.java
com/nimbusds/jose/jca/JCASupport.java
![image](https://github.com/user-attachments/assets/c4676f1f-7978-4f6f-88a4-e63d5675a31e)

Nimbus already fix the padding issue, see https://bitbucket.org/connect2id/nimbus-jose-jwt/issues/516/insecure-encryption-mode-cbc-with-pkcs5
But they keep these libraries because the AES/CBC/HMAC mode is a current JOSE standard and as such it will be supported by the nimbus-jose-jwt lib, see https://datatracker.ietf.org/doc/html/rfc7519#section-8
So, they won't fix.

With this change we attempt to exclude these classes using ProGuard to exclude these classes.
Right now, we do not have MobSF setup to validate if this will work.
[AB#3042434](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3042434)


