### PR TITLE
Add suberror for network errors, Fixes AB#3064171

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+-[MINOR] Add suberror for network errors (#2218)
 -[MINOR] Migrate Base64 away from Msebera (#2210)
 
 Version 5.7.0

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -1647,7 +1647,7 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
             );
         }
 
-        return new MsalClientException(exception.getErrorCode(), exception.getMessage());
+        return MsalExceptionAdapter.msalExceptionFromBaseException(exception);
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
+++ b/msal/src/main/java/com/microsoft/identity/client/exception/MsalUiRequiredException.java
@@ -58,10 +58,9 @@ public final class MsalUiRequiredException extends MsalException {
      */
     public static final String NO_ACCOUNT_FOUND = ErrorStrings.NO_ACCOUNT_FOUND;
 
-    @Getter
-    @Accessors(prefix = "m")
-    @Nullable
-    private String mOauthSubErrorCode;
+    public String getOauthSubErrorCode(){
+        return super.getSubErrorCode();
+    }
 
     /**
      * Constructor of MsalUiRequiredException.
@@ -89,16 +88,5 @@ public final class MsalUiRequiredException extends MsalException {
      */
     public MsalUiRequiredException(final String errorCode, final String errorMessage, final Throwable throwable) {
         super(errorCode, errorMessage, throwable);
-    }
-
-    /**
-     * Constructor of MsalUiRequiredException.
-     * @param errorCode         String
-     * @param oauthSubErrorCode String
-     * @param errorMessage      String
-     */
-    public MsalUiRequiredException(final String errorCode, @Nullable final String oauthSubErrorCode, final String errorMessage) {
-        super(errorCode, errorMessage);
-        mOauthSubErrorCode = oauthSubErrorCode;
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/controllers/MsalExceptionAdapter.java
@@ -42,6 +42,12 @@ import com.microsoft.identity.common.java.exception.UserCancelException;
 public class MsalExceptionAdapter {
 
     public static MsalException msalExceptionFromBaseException(final BaseException e) {
+        final MsalException result = msalExceptionFromBaseExceptionInternal(e);
+        result.setSubErrorCode(e.getSubErrorCode());
+        return result;
+    }
+
+    private static MsalException msalExceptionFromBaseExceptionInternal(final BaseException e) {
         if (e instanceof MsalException) {
             return  (MsalException) e;
         }
@@ -69,8 +75,8 @@ public class MsalExceptionAdapter {
             final UiRequiredException uiRequiredException = ((UiRequiredException) e);
             return new MsalUiRequiredException(
                     uiRequiredException.getErrorCode(),
-                    uiRequiredException.getOAuthSubErrorCode(),
-                    uiRequiredException.getMessage()
+                    uiRequiredException.getMessage(),
+                    uiRequiredException
             );
         }
 

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockTest.java
@@ -118,8 +118,8 @@ public abstract class AcquireTokenMockTest extends AcquireTokenAbstractTest {
                             @NonNull HttpClient.HttpMethod httpMethod,
                             @NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,
-                            @Nullable byte[] requestContent) throws IOException {
-                        throw new IOException("Sending requests to server has been disabled for mocked unit tests");
+                            @Nullable byte[] requestContent) throws ClientException {
+                        throw new ClientException("Sending requests to server has been disabled for mocked unit tests");
                     }
                 });
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -37,6 +37,7 @@ import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelpe
 import com.microsoft.identity.common.java.eststelemetry.PublicApiId;
 import com.microsoft.identity.common.java.eststelemetry.EstsTelemetry;
 import com.microsoft.identity.common.java.eststelemetry.SchemaConstants;
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.net.HttpClient;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.http.HttpRequestInterceptor;
@@ -110,7 +111,7 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
                             @NonNull HttpClient.HttpMethod httpMethod,
                             @NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,
-                            @Nullable byte[] requestContent) throws IOException {
+                            @Nullable byte[] requestContent) throws ClientException {
                         final String correlationId = requestHeaders.get("client-request-id");
 
                         AcquireTokenMockedTelemetryTest.addCorrelationId(correlationId);

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CommandResultCachingTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/CommandResultCachingTest.java
@@ -28,6 +28,7 @@ import com.microsoft.identity.client.Logger;
 import com.microsoft.identity.client.claims.ClaimsRequest;
 import com.microsoft.identity.client.e2e.shadows.ShadowMockAuthority;
 import com.microsoft.identity.client.e2e.shadows.ShadowOpenIdProviderConfigurationClient;
+import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.net.HttpClient;
 import com.microsoft.identity.common.java.net.HttpResponse;
 import com.microsoft.identity.http.HttpRequestInterceptor;
@@ -83,8 +84,8 @@ public final class CommandResultCachingTest extends AcquireTokenAbstractTest {
                             @NonNull HttpClient.HttpMethod httpMethod,
                             @NonNull URL requestUrl,
                             @NonNull Map<String, String> requestHeaders,
-                            @Nullable byte[] requestContent) throws IOException {
-                        throw new IOException("Sending requests to server has been disabled for mocked unit tests");
+                            @Nullable byte[] requestContent) throws ClientException {
+                        throw new ClientException("Sending requests to server has been disabled for mocked unit tests");
                     }
                 });
 


### PR DESCRIPTION
Related: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2537

Also make sure that MsalClientException returns the sub error code. 

[AB#3064171](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3064171)