### PR TITLE
Remove email attribute, Fixes AB#3080769

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/UserAttributes.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/UserAttributes.kt
@@ -34,7 +34,6 @@ class UserAttributes(internal val userAttributes: Map<String, String>) {
             private const val CITY = "city"
             private const val COUNTRY = "country"
             private const val DISPLAY_NAME = "displayName"
-            private const val EMAIL_ADDRESS = "email"
             private const val GIVEN_NAME = "givenName"
             private const val JOB_TITLE = "jobTitle"
             private const val POSTAL_CODE = "postalCode"
@@ -69,15 +68,6 @@ class UserAttributes(internal val userAttributes: Map<String, String>) {
          */
         fun displayName(displayName: String): Builder {
             userAttributes[DISPLAY_NAME] = displayName
-            return this
-        }
-
-        /**
-         * Sets the email address for the user
-         * @param emailAddress: Email address for the user
-         */
-        fun emailAddress(emailAddress: String): Builder {
-            userAttributes[EMAIL_ADDRESS] = emailAddress
             return this
         }
 


### PR DESCRIPTION
Remove "email" from the UserAttribute class. The email address is passed as "username" in the signUp process.

Bug item description: https://dev.azure.com/IdentityDivision/Engineering/_workitems/edit/3080769
[AB#3080769](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3080769)