### PR TITLE
Add support for OneBox Environment, Fixes AB#3113751

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/Constants.java
@@ -56,6 +56,7 @@ public class Constants {
         WEBVIEW_WITH_PPE,
 
         WEBVIEW_PPE_MSA,
+        ONEBOX
     }
 
     public static int getResourceIdFromConfigFile(ConfigFile configFile) {
@@ -120,6 +121,9 @@ public class Constants {
 
             case WEBVIEW_PPE_MSA:
                 return R.raw.msal_config_webview_ppe_msa;
+
+            case ONEBOX:
+                return R.raw.msal_config_onebox;
         }
 
         return R.raw.msal_config_default;

--- a/testapps/testapp/src/main/res/raw/msal_config_onebox.json
+++ b/testapps/testapp/src/main/res/raw/msal_config_onebox.json
@@ -1,0 +1,14 @@
+{
+  "client_id" : "4b0db8c2-9f26-4417-8bde-3f0e3656f8e0",
+  "authorization_user_agent" : "DEFAULT",
+  "redirect_uri" : "msauth://com.msft.identity.client.sample.local/1wIqXSqBj7w%2Bh11ZifsnqwgyKrY%3D",
+  "handle_null_taskaffinity": true,
+  "authorization_in_current_task": false,
+  "environment": "OneBox",
+  "authorities" : [
+    {
+      "type": "AAD",
+      "authority_url": "https://zurich.test.dnsdemo1.test:8478/common"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes [AB#3113751](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3113751)

Adds a new MSAL config file for the OneBox environment. This specifies exact authority that onebox is using. 

Related common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2559