### PR TITLE
Move native auth interface towards parameters class methods, Fixes AB#3117217

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MINOR] Move native auth public methods to parameter class (#2245)
 
 Version 5.9.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
@@ -25,6 +25,9 @@ package com.microsoft.identity.nativeauth
 import com.microsoft.identity.client.IPublicClientApplication
 import com.microsoft.identity.client.exception.MsalClientException
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.nativeauth.parameters.NativeAuthResetPasswordParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignUpParameters
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
 import com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
@@ -78,17 +81,34 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
     suspend fun signIn(username: String, password: CharArray? = null,  scopes: List<String>? = null): SignInResult
 
     /**
+     * Sign in a user for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for signIn operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
+     * @throws [MsalException] if an account is already signed in.
+     */
+    suspend fun signIn(parameters: NativeAuthSignInParameters): SignInResult
+
+    /**
      * Sign in a user with a given username; callback variant.
      *
      * @param username username of the account to sign in.
      * @param password (Optional) password of the account to sign in.
      * @param scopes (Optional) scopes to request during the sign in.
      * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignInCallback] to receive the result.
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
      * @throws [MsalException] if an account is already signed in.
      */
     @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:, callback:)' instead.")
     fun signIn(username: String, password: CharArray? = null, scopes: List<String>? = null, callback: NativeAuthPublicClientApplication.SignInCallback)
+
+    /**
+     * Sign in a user for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for signIn operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignInCallback] to receive the result.
+     * @throws [MsalException] if an account is already signed in.
+     */
+    fun signIn(parameters: NativeAuthSignInParameters, callback: NativeAuthPublicClientApplication.SignInCallback)
 
     /**
      * Sign up the account starting from a username; Kotlin coroutines variant.
@@ -101,6 +121,15 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      */
     @Deprecated("This method is now deprecated. Use the method 'signUp(parameters:)' instead.")
     suspend fun signUp(username: String, password: CharArray? = null, attributes: UserAttributes? = null): SignUpResult
+
+    /**
+     * Sign up the account for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for signUp operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    suspend fun signUp(parameters: NativeAuthSignUpParameters): SignUpResult
 
     /**
      * Sign up the account starting from a username; callback variant.
@@ -116,6 +145,15 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
     fun signUp(username: String, password: CharArray? = null, attributes: UserAttributes? = null, callback: NativeAuthPublicClientApplication.SignUpCallback)
 
     /**
+     * Sign up the account for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for signUp operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignUpCallback] to receive the result.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    fun signUp(parameters: NativeAuthSignUpParameters, callback: NativeAuthPublicClientApplication.SignUpCallback)
+
+    /**
      * Reset password for the account starting from a username; Kotlin coroutines variant.
      *
      * @param username username of the account to reset password.
@@ -126,13 +164,30 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
     suspend fun resetPassword(username: String): ResetPasswordStartResult
 
     /**
+     * Reset password for the account for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for resetPassword operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    suspend fun resetPassword(parameters: NativeAuthResetPasswordParameters): ResetPasswordStartResult
+
+    /**
      * Reset password for the account starting from a username; callback variant.
      *
      * @param username username of the account to reset password.
      * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.ResetPasswordCallback] to receive the result.
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
     @Deprecated("This method is now deprecated. Use the method 'resetPassword(parameters:, callback:)' instead.")
     fun resetPassword(username: String, callback: NativeAuthPublicClientApplication.ResetPasswordCallback)
+
+    /**
+     * Reset password for the account for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for resetPassword operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.ResetPasswordCallback] to receive the result.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    fun resetPassword(parameters: NativeAuthResetPasswordParameters, callback: NativeAuthPublicClientApplication.ResetPasswordCallback)
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
@@ -74,6 +74,7 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
      * @throws [MsalException] if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
     suspend fun signIn(username: String, password: CharArray? = null,  scopes: List<String>? = null): SignInResult
 
     /**
@@ -86,6 +87,7 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
      * @throws [MsalException] if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:, callback:)' instead.")
     fun signIn(username: String, password: CharArray? = null, scopes: List<String>? = null, callback: NativeAuthPublicClientApplication.SignInCallback)
 
     /**
@@ -97,6 +99,7 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signUp(parameters:)' instead.")
     suspend fun signUp(username: String, password: CharArray? = null, attributes: UserAttributes? = null): SignUpResult
 
     /**
@@ -109,6 +112,7 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signUp(parameters:, callback:)' instead.")
     fun signUp(username: String, password: CharArray? = null, attributes: UserAttributes? = null, callback: NativeAuthPublicClientApplication.SignUpCallback)
 
     /**
@@ -118,6 +122,7 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'resetPassword(parameters:)' instead.")
     suspend fun resetPassword(username: String): ResetPasswordStartResult
 
     /**
@@ -128,5 +133,6 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'resetPassword(parameters:, callback:)' instead.")
     fun resetPassword(username: String, callback: NativeAuthPublicClientApplication.ResetPasswordCallback)
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -60,6 +60,9 @@ import com.microsoft.identity.common.nativeauth.internal.commands.ResetPasswordS
 import com.microsoft.identity.common.nativeauth.internal.commands.SignInStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.SignUpStartCommand
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
+import com.microsoft.identity.nativeauth.parameters.NativeAuthResetPasswordParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignUpParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccountError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
@@ -292,6 +295,7 @@ class NativeAuthPublicClientApplication(
      * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignInCallback] to receive the result.
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:, callback:)' instead.")
     override fun signIn(
         username: String,
         password: CharArray?,
@@ -305,7 +309,31 @@ class NativeAuthPublicClientApplication(
         )
         pcaScope.launch {
             try {
-                val result = signIn(username, password, scopes)
+                val result = internalSignIn(username, password, scopes)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in signIn", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Sign in a user for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for signIn operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignInCallback] to receive the result.
+     * @throws [MsalException] if an account is already signed in.
+     */
+    override fun signIn(parameters: NativeAuthSignInParameters, callback: SignInCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signIn(parameters: NativeAuthSignInParameters, callback: SignInCallback)"
+        )
+        pcaScope.launch {
+            try {
+                val result = internalSignIn(parameters.username, parameters.password, parameters.scopes)
                 callback.onResult(result)
             } catch (e: MsalException) {
                 Logger.error(TAG, "Exception thrown in signIn", e)
@@ -323,6 +351,7 @@ class NativeAuthPublicClientApplication(
      * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
      * @throws MsalClientException if an account is already signed in.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
     override suspend fun signIn(
         username: String,
         password: CharArray?,
@@ -333,6 +362,251 @@ class NativeAuthPublicClientApplication(
             correlationId = null,
             methodName = "${TAG}.signIn(username: String, password: CharArray?, scopes: List<String>?)"
         )
+        return internalSignIn(username, password, scopes)
+    }
+
+    /**
+     * Sign in a user for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for signIn operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignInResult] see detailed possible return state under the object.
+     * @throws [MsalException] if an account is already signed in.
+     */
+    override suspend fun signIn(parameters: NativeAuthSignInParameters): SignInResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signIn(parameters: NativeAuthSignInParameters)"
+        )
+        return internalSignIn(parameters.username, parameters.password, parameters.scopes)
+    }
+
+
+    interface SignUpCallback : Callback<SignUpResult>
+
+    /**
+     * Sign up the account using username and password; callback variant.
+     *
+     * @param username username of the account to sign up.
+     * @param password (Optional) password of the account to sign up.
+     * @param attributes (Optional) user attributes to be used during account creation
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignUpCallback] to receive the result.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
+     */
+    @Deprecated("This method is now deprecated. Use the method 'signUp(parameters:, callback:)' instead.")
+    override fun signUp(
+        username: String,
+        password: CharArray?,
+        attributes: UserAttributes?,
+        callback: SignUpCallback
+    ) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signUp(username: String, password: CharArray?, attributes: UserAttributes?, callback: SignUpCallback)"
+        )
+        pcaScope.launch {
+            try {
+                val result = internalSignUp(password, username, attributes)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in signUp", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Sign up the account for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for signUp operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignUpCallback] to receive the result.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    override fun signUp(parameters: NativeAuthSignUpParameters, callback: SignUpCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signUp(parameters: NativeAuthSignUpParameters, callback: SignUpCallback)"
+        )
+        pcaScope.launch {
+            try {
+                val result = internalSignUp(parameters.password, parameters.username, parameters.attributes)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in signUp", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Sign up the account using username and password. Kotlin coroutines variant.
+     *
+     * @param username username of the account to sign up.
+     * @param password (Optional) password of the account to sign up.
+     * @param attributes (Optional) user attributes to be used during account creation
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
+     */
+    @Deprecated("This method is now deprecated. Use the method 'signUp(parameters:)' instead.")
+    override suspend fun signUp(
+        username: String,
+        password: CharArray?,
+        attributes: UserAttributes?
+    ): SignUpResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signUp(username: String, password: CharArray?, attributes: UserAttributes?)"
+        )
+        return internalSignUp(password, username, attributes)
+    }
+
+
+
+    /**
+     * Sign up the account for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for signUp operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    override suspend fun signUp(parameters: NativeAuthSignUpParameters): SignUpResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.signUp(parameters: NativeAuthSignUpParameters)"
+        )
+        return internalSignUp(parameters.password, parameters.username, parameters.attributes)
+    }
+
+    interface ResetPasswordCallback : Callback<ResetPasswordStartResult>
+
+    /**
+     * Reset password for the account starting from a username; callback variant.
+     *
+     * @param username username of the account to reset password.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.ResetPasswordCallback] to receive the result.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
+     */
+    @Deprecated("This method is now deprecated. Use the method 'resetPassword(parameters:, callback:)' instead.")
+    override fun resetPassword(username: String, callback: ResetPasswordCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.resetPassword(username: String, callback: ResetPasswordCallback)"
+        )
+        pcaScope.launch {
+            try {
+                val result = internalResetPassword(username)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in resetPassword", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Reset password for the account for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for resetPassword operation.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.ResetPasswordCallback] to receive the result.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    override fun resetPassword(
+        parameters: NativeAuthResetPasswordParameters,
+        callback: ResetPasswordCallback
+    ) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.resetPassword(parameters: NativeAuthResetPasswordParameters, callback: ResetPasswordCallback)"
+        )
+        pcaScope.launch {
+            try {
+                val result = internalResetPassword(parameters.username)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in resetPassword", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Reset password for the account starting from a username; Kotlin coroutines variant.
+     *
+     * @param username username of the account to reset password.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
+     */
+    @Deprecated("This method is now deprecated. Use the method 'resetPassword(parameters:)' instead.")
+    override suspend fun resetPassword(username: String): ResetPasswordStartResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.resetPassword(username: String)"
+        )
+        return internalResetPassword(username)
+    }
+
+    /**
+     * Reset password for the account for a provided parameters; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for resetPassword operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
+     * @throws MsalClientException if an account is already signed in.
+     */
+    override suspend fun resetPassword(parameters: NativeAuthResetPasswordParameters): ResetPasswordStartResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.resetPassword(parameters: NativeAuthResetPasswordParameters)"
+        )
+        return internalResetPassword(parameters.username)
+    }
+
+    private fun verifyNoUserIsSignedIn() {
+        val doesAccountExist = checkForPersistedAccount().get()
+        if (doesAccountExist) {
+            Logger.error(
+                TAG,
+                "An account is already signed in.",
+                null
+            )
+            throw MsalClientException(
+                MsalClientException.INVALID_PARAMETER,
+                "An account is already signed in."
+            )
+        }
+    }
+
+    private fun checkForPersistedAccount(): ResultFuture<Boolean> {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.checkForPersistedAccount"
+        )
+        val future = ResultFuture<Boolean>()
+        getCurrentAccount(object : NativeAuthPublicClientApplication.GetCurrentAccountCallback {
+            override fun onResult(result: GetAccountResult) {
+                future.setResult(result is GetAccountResult.AccountFound)
+            }
+
+            override fun onError(exception: BaseException) {
+                Logger.error(TAG, "Exception thrown in checkForPersistedAccount", exception)
+                future.setException(exception)
+            }
+        })
+
+        return future
+    }
+
+    private suspend fun internalSignIn(
+        username: String,
+        password: CharArray?,
+        scopes: List<String>?
+    ): SignInResult {
         return withContext(Dispatchers.IO) {
             try {
                 verifyNoUserIsSignedIn()
@@ -393,6 +667,7 @@ class NativeAuthPublicClientApplication(
                                 )
                             }
                         }
+
                         is SignInCommandResult.CodeRequired -> {
                             Logger.warn(
                                 TAG,
@@ -411,6 +686,7 @@ class NativeAuthPublicClientApplication(
                                 channel = result.challengeChannel
                             )
                         }
+
                         is INativeAuthCommandResult.InvalidUsername -> {
                             SignInError(
                                 errorType = ErrorTypes.INVALID_USERNAME,
@@ -420,6 +696,7 @@ class NativeAuthPublicClientApplication(
                                 errorCodes = result.errorCodes
                             )
                         }
+
                         is SignInCommandResult.PasswordRequired -> {
                             if (hasPassword) {
                                 Logger.warnWithObject(
@@ -443,6 +720,7 @@ class NativeAuthPublicClientApplication(
                                 )
                             }
                         }
+
                         is SignInCommandResult.UserNotFound -> {
                             SignInError(
                                 errorType = ErrorTypes.USER_NOT_FOUND,
@@ -452,6 +730,7 @@ class NativeAuthPublicClientApplication(
                                 errorCodes = result.errorCodes
                             )
                         }
+
                         is SignInCommandResult.InvalidCredentials -> {
                             if (hasPassword) {
                                 SignInError(
@@ -475,6 +754,7 @@ class NativeAuthPublicClientApplication(
                                 )
                             }
                         }
+
                         is SignInCommandResult.MFARequired -> {
                             SignInResult.MFARequired(
                                 nextState = AwaitingMFAState(
@@ -485,6 +765,7 @@ class NativeAuthPublicClientApplication(
                                 )
                             )
                         }
+
                         is INativeAuthCommandResult.Redirect -> {
                             SignInError(
                                 errorType = ErrorTypes.BROWSER_REQUIRED,
@@ -493,6 +774,7 @@ class NativeAuthPublicClientApplication(
                                 correlationId = result.correlationId
                             )
                         }
+
                         is INativeAuthCommandResult.APIError -> {
                             SignInError(
                                 errorMessage = result.errorDescription,
@@ -517,59 +799,12 @@ class NativeAuthPublicClientApplication(
         }
     }
 
-
-    interface SignUpCallback : Callback<SignUpResult>
-
-    /**
-     * Sign up the account using username and password; callback variant.
-     *
-     * @param username username of the account to sign up.
-     * @param password (Optional) password of the account to sign up.
-     * @param attributes (Optional) user attributes to be used during account creation
-     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.SignUpCallback] to receive the result.
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
-     */
-    override fun signUp(
-        username: String,
+    private suspend fun internalSignUp(
         password: CharArray?,
-        attributes: UserAttributes?,
-        callback: SignUpCallback
-    ) {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.signUp(username: String, password: CharArray?, attributes: UserAttributes?, callback: SignUpCallback)"
-        )
-        pcaScope.launch {
-            try {
-                val result = signUp(username, password, attributes)
-                callback.onResult(result)
-            } catch (e: MsalException) {
-                Logger.error(TAG, "Exception thrown in signUp", e)
-                callback.onError(e)
-            }
-        }
-    }
-
-    /**
-     * Sign up the account using username and password. Kotlin coroutines variant.
-     *
-     * @param username username of the account to sign up.
-     * @param password (Optional) password of the account to sign up.
-     * @param attributes (Optional) user attributes to be used during account creation
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.SignUpResult] see detailed possible return state under the object.
-     */
-    override suspend fun signUp(
         username: String,
-        password: CharArray?,
         attributes: UserAttributes?
     ): SignUpResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.signUp(username: String, password: CharArray?, attributes: UserAttributes?)"
-        )
-        var hasPassword = password?.isNotEmpty() == true
+        val hasPassword = password?.isNotEmpty() == true
 
         return withContext(Dispatchers.IO) {
             try {
@@ -761,201 +996,128 @@ class NativeAuthPublicClientApplication(
         }
     }
 
-    interface ResetPasswordCallback : Callback<ResetPasswordStartResult>
+    private suspend fun internalResetPassword(username: String): ResetPasswordStartResult {
+        try {
+            return withContext(Dispatchers.IO) {
+                val doesAccountExist = checkForPersistedAccount().get()
+                if (doesAccountExist) {
+                    throw MsalClientException(
+                        MsalClientException.INVALID_PARAMETER,
+                        "An account is already signed in."
+                    )
+                }
 
-    /**
-     * Reset password for the account starting from a username; callback variant.
-     *
-     * @param username username of the account to reset password.
-     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.ResetPasswordCallback] to receive the result.
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
-     */
-    override fun resetPassword(username: String, callback: ResetPasswordCallback) {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.resetPassword(username: String, callback: ResetPasswordCallback)"
-        )
-        pcaScope.launch {
-            try {
-                val result = resetPassword(username = username)
-                callback.onResult(result)
-            } catch (e: MsalException) {
-                Logger.error(TAG, "Exception thrown in resetPassword", e)
-                callback.onError(e)
+                if (username.isBlank()) {
+                    return@withContext ResetPasswordError(
+                        errorType = ErrorTypes.INVALID_USERNAME,
+                        errorMessage = "Empty or blank username",
+                        correlationId = "UNSET"
+                    )
+                }
+
+                val parameters = CommandParametersAdapter.createResetPasswordStartCommandParameters(
+                    nativeAuthConfig,
+                    nativeAuthConfig.oAuth2TokenCache,
+                    username
+                )
+
+                val command = ResetPasswordStartCommand(
+                    parameters,
+                    NativeAuthMsalController(),
+                    PublicApiId.NATIVE_AUTH_RESET_PASSWORD_START
+                )
+
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).get()
+
+                return@withContext when (val result =
+                    rawCommandResult.checkAndWrapCommandResultType<ResetPasswordStartCommandResult>()) {
+                    is ResetPasswordCommandResult.CodeRequired -> {
+                        ResetPasswordStartResult.CodeRequired(
+                            nextState = ResetPasswordCodeRequiredState(
+                                continuationToken = result.continuationToken,
+                                username = username,
+                                correlationId = result.correlationId,
+                                config = nativeAuthConfig
+                            ),
+                            codeLength = result.codeLength,
+                            sentTo = result.challengeTargetLabel,
+                            channel = result.challengeChannel
+                        )
+                    }
+
+                    is ResetPasswordCommandResult.UserNotFound -> {
+                        ResetPasswordError(
+                            errorType = ErrorTypes.USER_NOT_FOUND,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId
+                        )
+                    }
+
+                    is INativeAuthCommandResult.InvalidUsername -> {
+                        ResetPasswordError(
+                            errorType = ErrorTypes.INVALID_USERNAME,
+                            errorMessage = result.errorDescription,
+                            error = result.error,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+
+                    is INativeAuthCommandResult.APIError -> {
+                        ResetPasswordError(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            exception = result.exception
+                        )
+                    }
+
+                    is INativeAuthCommandResult.Redirect -> {
+                        ResetPasswordError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId
+                        )
+                    }
+
+                    is ResetPasswordCommandResult.PasswordNotSet -> {
+                        Logger.warnWithObject(
+                            TAG,
+                            result.correlationId,
+                            "Reset password received unexpected result: ",
+                            result
+                        )
+                        ResetPasswordError(
+                            error = ErrorTypes.INVALID_STATE,
+                            errorMessage = "Unexpected state",
+                            correlationId = result.correlationId,
+                        )
+                    }
+
+                    is ResetPasswordCommandResult.EmailNotVerified -> {
+                        Logger.warnWithObject(
+                            TAG,
+                            result.correlationId,
+                            "Reset password received unexpected result: ",
+                            result
+                        )
+                        ResetPasswordError(
+                            error = ErrorTypes.INVALID_STATE,
+                            errorMessage = "Unexpected state",
+                            correlationId = result.correlationId,
+                        )
+                    }
+                }
             }
-        }
-    }
-
-    /**
-     * Reset password for the account starting from a username; Kotlin coroutines variant.
-     *
-     * @param username username of the account to reset password.
-     * @return [com.microsoft.identity.nativeauth.statemachine.results.ResetPasswordStartResult] see detailed possible return state under the object.
-     */
-    override suspend fun resetPassword(username: String): ResetPasswordStartResult {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.resetPassword(username: String)"
-        )
-       try {
-           return withContext(Dispatchers.IO) {
-               val doesAccountExist = checkForPersistedAccount().get()
-               if (doesAccountExist) {
-                   throw MsalClientException(
-                       MsalClientException.INVALID_PARAMETER,
-                       "An account is already signed in."
-                   )
-               }
-
-               if (username.isBlank()) {
-                   return@withContext ResetPasswordError(
-                       errorType = ErrorTypes.INVALID_USERNAME,
-                       errorMessage = "Empty or blank username",
-                       correlationId = "UNSET"
-                   )
-               }
-
-               val parameters = CommandParametersAdapter.createResetPasswordStartCommandParameters(
-                   nativeAuthConfig,
-                   nativeAuthConfig.oAuth2TokenCache,
-                   username
-               )
-
-               val command = ResetPasswordStartCommand(
-                   parameters,
-                   NativeAuthMsalController(),
-                   PublicApiId.NATIVE_AUTH_RESET_PASSWORD_START
-               )
-
-               val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).get()
-
-               return@withContext when (val result =
-                   rawCommandResult.checkAndWrapCommandResultType<ResetPasswordStartCommandResult>()) {
-                   is ResetPasswordCommandResult.CodeRequired -> {
-                       ResetPasswordStartResult.CodeRequired(
-                           nextState = ResetPasswordCodeRequiredState(
-                               continuationToken = result.continuationToken,
-                               username = username,
-                               correlationId = result.correlationId,
-                               config = nativeAuthConfig
-                           ),
-                           codeLength = result.codeLength,
-                           sentTo = result.challengeTargetLabel,
-                           channel = result.challengeChannel
-                       )
-                   }
-
-                   is ResetPasswordCommandResult.UserNotFound -> {
-                       ResetPasswordError(
-                           errorType = ErrorTypes.USER_NOT_FOUND,
-                           error = result.error,
-                           errorMessage = result.errorDescription,
-                           correlationId = result.correlationId
-                       )
-                   }
-
-                   is INativeAuthCommandResult.InvalidUsername -> {
-                       ResetPasswordError(
-                           errorType = ErrorTypes.INVALID_USERNAME,
-                           errorMessage = result.errorDescription,
-                           error = result.error,
-                           correlationId = result.correlationId,
-                           errorCodes = result.errorCodes
-                       )
-                   }
-
-                   is INativeAuthCommandResult.APIError -> {
-                       ResetPasswordError(
-                           error = result.error,
-                           errorMessage = result.errorDescription,
-                           correlationId = result.correlationId,
-                           exception = result.exception
-                       )
-                   }
-
-                   is INativeAuthCommandResult.Redirect -> {
-                       ResetPasswordError(
-                           errorType = ErrorTypes.BROWSER_REQUIRED,
-                           error = result.error,
-                           errorMessage = result.errorDescription,
-                           correlationId = result.correlationId
-                       )
-                   }
-
-                   is ResetPasswordCommandResult.PasswordNotSet -> {
-                       Logger.warnWithObject(
-                           TAG,
-                           result.correlationId,
-                           "Reset password received unexpected result: ",
-                           result
-                       )
-                       ResetPasswordError(
-                           error = ErrorTypes.INVALID_STATE,
-                           errorMessage = "Unexpected state",
-                           correlationId = result.correlationId,
-                       )
-                   }
-
-                   is ResetPasswordCommandResult.EmailNotVerified -> {
-                       Logger.warnWithObject(
-                           TAG,
-                           result.correlationId,
-                           "Reset password received unexpected result: ",
-                           result
-                       )
-                       ResetPasswordError(
-                           error = ErrorTypes.INVALID_STATE,
-                           errorMessage = "Unexpected state",
-                           correlationId = result.correlationId,
-                       )
-                   }
-               }
-           }
-       } catch (e: Exception) {
-           return ResetPasswordError(
-               errorType = ErrorTypes.CLIENT_EXCEPTION,
-               errorMessage = "MSAL client exception occurred in resetPassword.",
-               exception = e,
-               correlationId = "UNSET"
-           )
-       }
-    }
-    
-    private fun verifyNoUserIsSignedIn() {
-        val doesAccountExist = checkForPersistedAccount().get()
-        if (doesAccountExist) {
-            Logger.error(
-                TAG,
-                "An account is already signed in.",
-                null
-            )
-            throw MsalClientException(
-                MsalClientException.INVALID_PARAMETER,
-                "An account is already signed in."
+        } catch (e: Exception) {
+            return ResetPasswordError(
+                errorType = ErrorTypes.CLIENT_EXCEPTION,
+                errorMessage = "MSAL client exception occurred in resetPassword.",
+                exception = e,
+                correlationId = "UNSET"
             )
         }
-    }
-
-    private fun checkForPersistedAccount(): ResultFuture<Boolean> {
-        LogSession.logMethodCall(
-            tag = TAG,
-            correlationId = null,
-            methodName = "${TAG}.checkForPersistedAccount"
-        )
-        val future = ResultFuture<Boolean>()
-        getCurrentAccount(object : NativeAuthPublicClientApplication.GetCurrentAccountCallback {
-            override fun onResult(result: GetAccountResult) {
-                future.setResult(result is GetAccountResult.AccountFound)
-            }
-
-            override fun onError(exception: BaseException) {
-                Logger.error(TAG, "Exception thrown in checkForPersistedAccount", exception)
-                future.setException(exception)
-            }
-        })
-
-        return future
     }
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthGetAccessTokenParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthGetAccessTokenParameters.kt
@@ -24,19 +24,14 @@
 package com.microsoft.identity.nativeauth.parameters
 
 /**
- * Encapsulates the parameters passed to the signIn methods of NativeAuthPublicClientApplication
+ * Encapsulates the parameters passed to the getAccessToken methods of AccountState
  */
-class NativeAuthSignInParameters(
-    /**
-     * username of the account to sign in
-     */
-    username: String
-) {
+class NativeAuthGetAccessTokenParameters {
 
     /**
-     * password of the account to sign in.
+     * Set to true to ignore any existing access token in the cache and force MSAL to get a new access token from the service.
      */
-    var password: CharArray? = null
+    var forceRefresh: Boolean = false
 
     /**
      * Permissions you want included in the access token received.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthResetPasswordParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthResetPasswordParameters.kt
@@ -30,5 +30,5 @@ class NativeAuthResetPasswordParameters(
     /**
      * username of the account to reset password.
      */
-    username: String
-) {}
+    val username: String
+)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthResetPasswordParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthResetPasswordParameters.kt
@@ -24,23 +24,11 @@
 package com.microsoft.identity.nativeauth.parameters
 
 /**
- * Encapsulates the parameters passed to the signIn methods of NativeAuthPublicClientApplication
+ * Encapsulates the parameters passed to the resetPassword methods of NativeAuthPublicClientApplication
  */
-class NativeAuthSignInParameters(
+class NativeAuthResetPasswordParameters(
     /**
-     * username of the account to sign in
+     * username of the account to reset password.
      */
     username: String
-) {
-
-    /**
-     * password of the account to sign in.
-     */
-    var password: CharArray? = null
-
-    /**
-     * Permissions you want included in the access token received.
-     * Not all scopes are guaranteed to be included in the access token returned.
-     */
-    var scopes: List<String>? = null
-}
+) {}

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInContinuationParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInContinuationParameters.kt
@@ -24,19 +24,9 @@
 package com.microsoft.identity.nativeauth.parameters
 
 /**
- * Encapsulates the parameters passed to the signIn methods of NativeAuthPublicClientApplication
+ * Encapsulates the parameters passed to the signIn methods after signUp or resetPassword
  */
-class NativeAuthSignInParameters(
-    /**
-     * username of the account to sign in
-     */
-    username: String
-) {
-
-    /**
-     * password of the account to sign in.
-     */
-    var password: CharArray? = null
+class NativeAuthSignInContinuationParameters {
 
     /**
      * Permissions you want included in the access token received.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
@@ -1,0 +1,40 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.nativeauth.parameters
+
+/**
+ * Encapsulates the parameters passed to the signIn methods of NativeAuthPublicClientApplication
+ */
+class NativeAuthSignInParameters(username: String) {
+
+    /**
+     * password (Optional) password of the account to sign in.
+     */
+    var password: CharArray? = null
+
+    /**
+     * scopes (Optional) scopes to request during the sign in.
+     */
+    var scopes: List<String>? = null
+}

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
@@ -28,7 +28,7 @@ package com.microsoft.identity.nativeauth.parameters
  */
 class NativeAuthSignInParameters(
     /**
-     * username of the account to sign in
+     * username of the account to sign in.
      */
     val username: String
 ) {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInParameters.kt
@@ -30,7 +30,7 @@ class NativeAuthSignInParameters(
     /**
      * username of the account to sign in
      */
-    username: String
+    val username: String
 ) {
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
@@ -30,7 +30,7 @@ import com.microsoft.identity.nativeauth.UserAttributes
  */
 class NativeAuthSignUpParameters(
     /**
-     * username of the account to sign up
+     * username of the account to sign up.
      */
     val username: String
 ) {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
@@ -32,7 +32,7 @@ class NativeAuthSignUpParameters(
     /**
      * username of the account to sign up
      */
-    username: String
+    val username: String
 ) {
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignUpParameters.kt
@@ -23,24 +23,25 @@
 
 package com.microsoft.identity.nativeauth.parameters
 
+import com.microsoft.identity.nativeauth.UserAttributes
+
 /**
- * Encapsulates the parameters passed to the signIn methods of NativeAuthPublicClientApplication
+ * Encapsulates the parameters passed to the signUp methods of NativeAuthPublicClientApplication
  */
-class NativeAuthSignInParameters(
+class NativeAuthSignUpParameters(
     /**
-     * username of the account to sign in
+     * username of the account to sign up
      */
     username: String
 ) {
 
     /**
-     * password of the account to sign in.
+     * password of the account to sign up.
      */
     var password: CharArray? = null
 
     /**
-     * Permissions you want included in the access token received.
-     * Not all scopes are guaranteed to be included in the access token returned.
+     * user attributes to be used during account creation.
      */
-    var scopes: List<String>? = null
+    var attributes: UserAttributes? = null
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
@@ -52,6 +52,7 @@ import com.microsoft.identity.common.java.result.LocalAuthenticationResult
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
+import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenErrorTypes
@@ -269,6 +270,28 @@ class AccountState private constructor(
     }
 
     /**
+     * Retrieves the access token for the currently signed in account from the cache for the provided parameters.
+     * If the access token has expired, it will be refreshed using the refresh token that's stored in the cache.
+     * If no access token matching the requested scopes is found in cache then a new access token is fetched.
+     * Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for getAccessToken operation.
+     * @return [com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult] The result of the getAccessToken action
+     */
+    suspend fun getAccessToken(parameters: NativeAuthGetAccessTokenParameters): GetAccessTokenResult {
+        val scopes = parameters.scopes ?: AuthenticationConstants.DEFAULT_SCOPES.toList()
+        if (scopes.isEmpty()) {
+            return GetAccessTokenError(
+                errorType = GetAccessTokenErrorTypes.INVALID_SCOPES,
+                errorMessage = "Empty or invalid scopes",
+                correlationId = correlationId
+            )
+        }
+
+        return getAccessTokenInternal(parameters.forceRefresh, scopes)
+    }
+
+    /**
      * Retrieves the access token for the currently signed in account from the cache such that
      * the scope of retrieved access token is a superset of requested scopes. If the access token
      * has expired, it will be refreshed using the refresh token that's stored in the cache. If no
@@ -287,6 +310,32 @@ class AccountState private constructor(
         NativeAuthPublicClientApplication.pcaScope.launch {
             try {
                 val result = getAccessToken(forceRefresh, scopes)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in getAccessToken", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Retrieves the access token for the currently signed in account from the cache for the provided parameters.
+     * If the access token has expired, it will be refreshed using the refresh token that's stored in the cache.
+     * If no access token matching the requested scopes is found in cache then a new access token is fetched.
+     * callback variant.
+     *
+     * @param parameters parameters used for getAccessToken operation.
+     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.AccountState.GetAccessTokenCallback] to receive the result on.
+     */
+    fun getAccessToken(parameters: NativeAuthGetAccessTokenParameters, callback: GetAccessTokenCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = null,
+            methodName = "${TAG}.getAccessToken(parameters: NativeAuthGetAccessTokenParameters, callback: GetAccessTokenCallback)"
+        )
+        NativeAuthPublicClientApplication.pcaScope.launch {
+            try {
+                val result = getAccessToken(parameters)
                 callback.onResult(result)
             } catch (e: MsalException) {
                 Logger.error(TAG, "Exception thrown in getAccessToken", e)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
@@ -216,6 +216,7 @@ class AccountState private constructor(
      *
      * @return [com.microsoft.identity.client.IAuthenticationResult] If successful.
      */
+    @Deprecated("This method is now deprecated. Use the method 'getAccessToken(parameters:, callback:)' instead.")
     fun getAccessToken(forceRefresh: Boolean = false, callback: GetAccessTokenCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -240,6 +241,7 @@ class AccountState private constructor(
      *
      * @return [com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult] The result of the getAccessToken action
      */
+    @Deprecated("This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
     suspend fun getAccessToken(forceRefresh: Boolean = false): GetAccessTokenResult {
         return getAccessTokenInternal(forceRefresh, AuthenticationConstants.DEFAULT_SCOPES.toList());
     }
@@ -253,6 +255,7 @@ class AccountState private constructor(
      *
      * @return [com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult] The result of the getAccessToken action
      */
+    @Deprecated("This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
     suspend fun getAccessToken(forceRefresh: Boolean = false, scopes: List<String>): GetAccessTokenResult {
         if (scopes.isEmpty()) {
             return GetAccessTokenError(
@@ -274,6 +277,7 @@ class AccountState private constructor(
      *
      * @return [com.microsoft.identity.client.IAuthenticationResult] If successful.
      */
+    @Deprecated("This method is now deprecated. Use the method 'getAccessToken(parameters:, callback:)' instead.")
     fun getAccessToken(forceRefresh: Boolean = false, scopes: List<String>, callback: GetAccessTokenCallback) {
         LogSession.logMethodCall(
             tag = TAG,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -562,6 +562,7 @@ class SignInContinuationState(
      * @param parameters parameters used for sign-in-continuation operation.
      * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState.SignInContinuationCallback] to receive the result on.
      */
+    @JvmName("signInWithParameters")
     fun signIn(parameters: NativeAuthSignInContinuationParameters, callback: SignInContinuationCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -604,6 +605,7 @@ class SignInContinuationState(
      * @param parameters parameters used for sign-in-continuation operation.
      * @return The results of the sign-in-after-sign-up action.
      */
+    @JvmName("signInWithParameters")
     suspend fun signIn(parameters: NativeAuthSignInContinuationParameters): SignInResult {
         LogSession.logMethodCall(
             tag = TAG,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -47,6 +47,7 @@ import com.microsoft.identity.common.nativeauth.internal.commands.SignInWithCont
 import com.microsoft.identity.common.nativeauth.internal.controllers.NativeAuthMsalController
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInContinuationParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.ResendCodeError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInContinuationError
@@ -542,10 +543,35 @@ class SignInContinuationState(
             correlationId = correlationId,
             methodName = "${TAG}.signIn(scopes: List<String>, callback: SignInContinuationCallback)"
         )
+        val params = NativeAuthSignInContinuationParameters()
+        params.scopes = scopes
+        NativeAuthPublicClientApplication.pcaScope.launch {
+            try {
+                val result = internalSignIn(params)
+                callback.onResult(result)
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in signIn", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Submits the sign-in-continuation verification code to the server for a provided parameters; callback variant.
+     *
+     * @param parameters parameters used for sign-in-continuation operation.
+     * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState.SignInContinuationCallback] to receive the result on.
+     */
+    fun signIn(parameters: NativeAuthSignInContinuationParameters, callback: SignInContinuationCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.signIn(parameters: NativeAuthSignInContinuationParameters, callback: SignInContinuationCallback)"
+        )
 
         NativeAuthPublicClientApplication.pcaScope.launch {
             try {
-                val result = signIn(scopes)
+                val result = internalSignIn(parameters)
                 callback.onResult(result)
             } catch (e: MsalException) {
                 Logger.error(TAG, "Exception thrown in signIn", e)
@@ -567,7 +593,27 @@ class SignInContinuationState(
             correlationId = correlationId,
             methodName = "${TAG}.signIn(scopes: List<String>)"
         )
+        val params = NativeAuthSignInContinuationParameters()
+        params.scopes = scopes
+        return internalSignIn(params)
+    }
 
+    /**
+     * Submits the sign-in-continuation verification code to the server; Kotlin coroutines variant.
+     *
+     * @param parameters parameters used for sign-in-continuation operation.
+     * @return The results of the sign-in-after-sign-up action.
+     */
+    suspend fun signIn(parameters: NativeAuthSignInContinuationParameters): SignInResult {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.signIn(parameters: NativeAuthSignInContinuationParameters)"
+        )
+        return internalSignIn(parameters)
+    }
+
+    private suspend fun internalSignIn(parameters: NativeAuthSignInContinuationParameters): SignInResult {
         return withContext(Dispatchers.IO) {
             try {
                 LogSession.logMethodCall(
@@ -596,7 +642,7 @@ class SignInContinuationState(
                         continuationToken,
                         username,
                         correlationId,
-                        scopes
+                        parameters.scopes
                     )
 
                 val command = SignInWithContinuationTokenCommand(

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -535,6 +535,7 @@ class SignInContinuationState(
      * @param callback [com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState.SignInContinuationCallback] to receive the result on.
      * @return The results of the sign-in-continuation action.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:, callback:)' instead.")
     fun signIn(scopes: List<String>? = null, callback: SignInContinuationCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -559,6 +560,7 @@ class SignInContinuationState(
      * @param scopes (Optional) The scopes to request.
      * @return The results of the sign-in-after-sign-up action.
      */
+    @Deprecated("This method is now deprecated. Use the method 'signIn(parameters:)' instead.")
     suspend fun signIn(scopes: List<String>? = null): SignInResult {
         LogSession.logMethodCall(
             tag = TAG,

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationJavaTest.java
@@ -34,6 +34,11 @@ import com.microsoft.identity.client.e2e.tests.PublicClientApplicationAbstractTe
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.client.exception.MsalException;
 import com.microsoft.identity.common.java.AuthenticationConstants;
+import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters;
+import com.microsoft.identity.nativeauth.parameters.NativeAuthResetPasswordParameters;
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInContinuationParameters;
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters;
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignUpParameters;
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError;
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError;
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordSubmitPasswordError;
@@ -235,6 +240,116 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
             }
         };
         application.signIn(username, null, null, signInCallback);
+        // 1a. Server returns invalid user error
+        assertTrue(signInResult.get(30, TimeUnit.SECONDS) instanceof SignInResult.CodeRequired);
+        SignInCodeRequiredState nextState = spy((((SignInResult.CodeRequired) signInResult.get(30, TimeUnit.SECONDS)).getNextState()));
+
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        mockCorrelationId(nextState, correlationId);
+
+        // 2. Submit (invalid) code
+        // 2a. Setup server response
+        configureMockApi(
+                MockApiEndpoint.SignInToken,
+                correlationId,
+                MockApiResponseType.INVALID_OOB_VALUE
+        );
+        // 2b. Call SDK interface
+        final ResultFuture<SignInSubmitCodeResult> submitCodeResult = new ResultFuture<>();
+        SignInCodeRequiredState.SubmitCodeCallback submitCodeCallback = new SignInCodeRequiredState.SubmitCodeCallback() {
+            @Override
+            public void onResult(SignInSubmitCodeResult result) {
+                submitCodeResult.setResult(result);
+            }
+
+            @Override
+            public void onError(@NonNull BaseException exception) {
+                submitCodeResult.setException(exception);
+            }
+        };
+        nextState.submitCode(code, submitCodeCallback);
+        // 2a. Server returns invalid code, stays in CodeRequired state
+        SignInSubmitCodeResult result = submitCodeResult.get(30, TimeUnit.SECONDS);
+        assertTrue(result instanceof SubmitCodeError);
+
+        SubmitCodeError error = spy((SubmitCodeError)result);
+        assertTrue(error.isInvalidCode());
+
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        mockCorrelationId(error, correlationId);
+
+        // 3. Submit (valid) code
+        // 3a. Setup server response
+        configureMockApi(
+                MockApiEndpoint.SignInToken,
+                correlationId,
+                MockApiResponseType.TOKEN_SUCCESS
+        );
+
+        // 3b. Call SDK interface
+        final ResultFuture<SignInSubmitCodeResult> submitCodeResult2 = new ResultFuture<>();
+        SignInCodeRequiredState.SubmitCodeCallback submitCodeCallback2 = new SignInCodeRequiredState.SubmitCodeCallback() {
+            @Override
+            public void onResult(SignInSubmitCodeResult result) {
+                submitCodeResult2.setResult(result);
+            }
+
+            @Override
+            public void onError(@NonNull BaseException exception) {
+                submitCodeResult2.setException(exception);
+            }
+        };
+        nextState.submitCode(code, submitCodeCallback2);
+        // 3a. Server accepts code, returns tokens
+        assertTrue(submitCodeResult2.get(30, TimeUnit.SECONDS) instanceof SignInResult.Complete);
+    }
+
+    /**
+     * Test sign in scenario 7 using signIn with parameters class:
+     * 1a -> sign in with (valid) username
+     * 1b <- server requires code challenge
+     * 2a -> submit (invalid) code
+     * 2b <- server returns invalid code error, code challenge is still required
+     * 3a -> submit valid code
+     * 3b <- sign in succeeds
+     */
+    @Test
+    public void testSignInScenario7UsingParametersClassMethod() throws ExecutionException, InterruptedException, TimeoutException {
+        // 1. Sign in initiate with username
+        // 1a. Setup server response
+        String correlationId = UUID.randomUUID().toString();
+        configureMockApi(
+                MockApiEndpoint.SignInInitiate,
+                correlationId,
+                MockApiResponseType.INITIATE_SUCCESS
+        );
+
+        // 2a. Sign in challenge
+        // 2b. Setup server response with oob required
+        configureMockApi(
+                MockApiEndpoint.SignInChallenge,
+                correlationId,
+                MockApiResponseType.CHALLENGE_TYPE_OOB
+        );
+
+        // 1b. Call SDK interface
+        final ResultFuture<SignInResult> signInResult = new ResultFuture<>();
+        NativeAuthPublicClientApplication.SignInCallback signInCallback = new NativeAuthPublicClientApplication.SignInCallback() {
+            @Override
+            public void onResult(SignInResult result) {
+                signInResult.setResult(result);
+            }
+
+            @Override
+            public void onError(@NonNull BaseException exception) {
+                signInResult.setException(exception);
+            }
+        };
+        NativeAuthSignInParameters params = new NativeAuthSignInParameters(username);
+
+        application.signIn(params, signInCallback);
         // 1a. Server returns invalid user error
         assertTrue(signInResult.get(30, TimeUnit.SECONDS) instanceof SignInResult.CodeRequired);
         SignInCodeRequiredState nextState = spy((((SignInResult.CodeRequired) signInResult.get(30, TimeUnit.SECONDS)).getNextState()));
@@ -859,6 +974,73 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
     }
 
     /**
+     * Test sign in, get access token using the parameters class methods. Compare to token from getAccount()
+     */
+    @Test
+    public void testGetAccessTokenWithSignInScopesUsingParametersClass() throws ExecutionException, InterruptedException, TimeoutException {
+        String correlationId = UUID.randomUUID().toString();
+        configureMockApi(
+                MockApiEndpoint.SignInInitiate,
+                correlationId,
+                MockApiResponseType.INITIATE_SUCCESS
+        );
+
+        configureMockApi(
+                MockApiEndpoint.SignInChallenge,
+                correlationId,
+                MockApiResponseType.CHALLENGE_TYPE_PASSWORD
+        );
+
+        configureMockApi(
+                MockApiEndpoint.SignInToken,
+                correlationId,
+                MockApiResponseType.TOKEN_SUCCESS
+        );
+
+        SignInTestCallback signInTestCallback = new SignInTestCallback();
+
+        NativeAuthSignInParameters params = new NativeAuthSignInParameters(username);
+        params.setPassword(password);
+
+        application.signIn(params, signInTestCallback);
+        SignInResult signInWithPasswordResult = signInTestCallback.get();
+        assertTrue(signInWithPasswordResult instanceof SignInResult.Complete);
+
+        // Get access token from sign in result
+        GetAccessTokenTestCallback getAccessTokenCallback = new GetAccessTokenTestCallback();
+
+        NativeAuthGetAccessTokenParameters getAccessTokenParameters = new NativeAuthGetAccessTokenParameters();
+        getAccessTokenParameters.setForceRefresh(false);
+
+        ((SignInResult.Complete) signInWithPasswordResult).getResultValue().getAccessToken(getAccessTokenParameters, getAccessTokenCallback);
+        GetAccessTokenResult getAccessTokenResult = getAccessTokenCallback.get();
+        assertTrue(getAccessTokenResult instanceof GetAccessTokenResult.Complete);
+
+        String accessToken = ((GetAccessTokenResult.Complete) getAccessTokenResult).getResultValue().getAccessToken();
+        assertNotNull(accessToken);
+
+        // For comparison, get access token from getAccount()
+        GetAccountTestCallback getAccountTestCallback = new GetAccountTestCallback();
+        application.getCurrentAccount(getAccountTestCallback);
+
+        GetAccountResult getAccountResult = getAccountTestCallback.get();
+        assertTrue(getAccountResult instanceof GetAccountResult.AccountFound);
+
+        NativeAuthGetAccessTokenParameters getAccessTokenWithScopesParameters = new NativeAuthGetAccessTokenParameters();
+        getAccessTokenWithScopesParameters.setForceRefresh(false);
+        getAccessTokenWithScopesParameters.setScopes(new ArrayList<>(AuthenticationConstants.DEFAULT_SCOPES));
+
+        ((GetAccountResult.AccountFound) getAccountResult).getResultValue().getAccessToken(getAccessTokenWithScopesParameters, getAccessTokenCallback);
+        GetAccessTokenResult getAccessTokenResultTwo = getAccessTokenCallback.get();
+        assertTrue(getAccessTokenResultTwo instanceof GetAccessTokenResult.Complete);
+
+        String accessTokenTwo = ((GetAccessTokenResult.Complete) getAccessTokenResult).getResultValue().getAccessToken();
+        assertNotNull(accessTokenTwo);
+
+        assertEquals(accessToken, accessTokenTwo);
+    }
+
+    /**
      * Test sign in, get access token. Compare to token from getAccount()
      */
     @Test
@@ -1199,6 +1381,48 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
             }
         };
         signInWithSLTState.signIn(null, callback);
+        assertTrue(resultFuture.get(30, TimeUnit.SECONDS) instanceof SignInResult.Complete);
+    }
+
+    /**
+     * Test sign in with SLT scenario 1 using parameters class method:
+     * 1a -> sign in with (valid) SLT
+     * 1b <- server returns token
+     */
+    @Test
+    public void testSignInWithSLTUsingParamtersClassMethod() throws ExecutionException, InterruptedException, TimeoutException {
+        System.out.println("testSignInWithSLT");
+
+        // Setup - sign up the user, so that we don't have to construct the SLT state manually
+        // as this doesn't allow for the NativeAuthPublicClientApplicationConfiguration to be set
+        // up, meaning it would need to be mocked (which we don't want in these tests).
+        SignInContinuationState signInWithSLTState = signUpUser();
+
+        // 1a. sign in with (valid) SLT
+        String correlationId = UUID.randomUUID().toString();
+        configureMockApi(
+                MockApiEndpoint.SignInToken,
+                correlationId,
+                MockApiResponseType.TOKEN_SUCCESS
+        );
+
+        // 1b. server returns token
+        final ResultFuture<SignInResult> resultFuture = new ResultFuture<>();
+        SignInContinuationState.SignInContinuationCallback callback = new SignInContinuationState.SignInContinuationCallback() {
+            @Override
+            public void onResult(SignInResult result) {
+                resultFuture.setResult(result);
+            }
+
+            @Override
+            public void onError(@NonNull BaseException exception) {
+                resultFuture.setException(exception);
+            }
+        };
+
+        NativeAuthSignInContinuationParameters params = new NativeAuthSignInContinuationParameters();
+
+        signInWithSLTState.signInWithParameters(params, callback);
         assertTrue(resultFuture.get(30, TimeUnit.SECONDS) instanceof SignInResult.Complete);
     }
 
@@ -1720,6 +1944,34 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
     }
 
     /**
+     * Test SSPR scenario 3.2.5 using parameters class method:
+     * 1 -> USER click resetPassword
+     * 1 <- user not found, SERVER returns error
+     */
+    @Test
+    public void testSSPRScenario3_2_5UsingParametersClassMethod() throws ExecutionException, InterruptedException, TimeoutException {
+        String correlationId = UUID.randomUUID().toString();
+        // 1. Click reset password
+        // 1_mock_api. Setup server response - endpoint: resetpassword/start - Server returns Error: user not found
+        configureMockApi(
+                MockApiEndpoint.SSPRStart,
+                correlationId,
+                MockApiResponseType.USER_NOT_FOUND
+        );
+
+        ResetPasswordStartTestCallback resetPasswordCallback = new ResetPasswordStartTestCallback();
+
+        NativeAuthResetPasswordParameters params = new NativeAuthResetPasswordParameters(username);
+
+        // 1a. Call SDK interface - resetPassword(ResetPasswordStart)
+        application.resetPassword(params, resetPasswordCallback);
+        // 1b. Transform /start(error) to Result(UserNotFound)
+        ResetPasswordStartResult resetPasswordResult = resetPasswordCallback.get();
+        assertTrue(resetPasswordResult instanceof ResetPasswordError);
+        assertTrue(((ResetPasswordError) resetPasswordResult).isUserNotFound());
+    }
+
+    /**
      * Test SSPR scenario 3.2.6:
      * 1 -> USER click resetPassword
      * 1 <- challenge type do no support, SERVER requires error: redirect
@@ -2021,6 +2273,85 @@ public class NativeAuthPublicClientApplicationJavaTest extends PublicClientAppli
         // 1b. Call SDK interface
         SignUpTestCallback signUpTestCallback = new SignUpTestCallback();
         application.signUp(username, password, null, signUpTestCallback);
+
+        SignUpResult signUpResult = signUpTestCallback.get();
+
+        assertTrue(signUpResult instanceof SignUpResult.CodeRequired);
+
+        // 2a. Setup resend code challenge
+        configureMockApi(
+                MockApiEndpoint.SignUpChallenge,
+                correlationId,
+                MockApiResponseType.CHALLENGE_TYPE_OOB
+        );
+
+        SignUpCodeRequiredState codeRequiredState = spy(((SignUpResult.CodeRequired) signUpResult).getNextState());
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        mockCorrelationId(codeRequiredState, correlationId);
+
+        // 2b. Call resendCode
+        SignUpResendCodeRequiredTestCallback resendCodeCallback = new SignUpResendCodeRequiredTestCallback();
+        codeRequiredState.resendCode(resendCodeCallback);
+
+        SignUpResendCodeResult resendCodeResult = resendCodeCallback.get();
+
+        assertTrue(resendCodeResult instanceof SignUpResendCodeResult.Success);
+
+        // 3. submit (valid) code
+        // 3a. setup server response
+        configureMockApi(
+                MockApiEndpoint.SignUpContinue,
+                correlationId,
+                MockApiResponseType.SIGNUP_CONTINUE_SUCCESS
+        );
+
+        SignUpCodeRequiredState submitCodeState = spy(((SignUpResendCodeResult.Success) resendCodeResult).getNextState());
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        mockCorrelationId(submitCodeState, correlationId);
+
+        final SignUpCodeRequiredTestCallback codeRequiredCallback = new SignUpCodeRequiredTestCallback();
+        submitCodeState.submitCode(code, codeRequiredCallback);
+
+        // 3b. Server accepts code, returns tokens
+        assertTrue(codeRequiredCallback.get() instanceof SignUpResult.Complete);
+    }
+
+    /**
+     * Test Sign Up scenario 2 using parameters class method:
+     * 1a -> signUp
+     * 1b <- server requires code verification
+     * 2a -> user prompts resend code, challenge endpoint is called
+     * 2b <- codeRequired is returned
+     * 3a -> submitCode is called with valid code
+     * 3b <- sign up succeeds
+     */
+    @Test
+    public void testSignUpScenario2UsingParametersClassMethod() throws ExecutionException, InterruptedException, TimeoutException {
+        // 1. sign up with password
+        // 1a. Setup server response
+        String correlationId = UUID.randomUUID().toString();
+
+        configureMockApi(
+                MockApiEndpoint.SignUpStart,
+                correlationId,
+                MockApiResponseType.SIGNUP_START_SUCCESS
+        );
+
+        configureMockApi(
+                MockApiEndpoint.SignUpChallenge,
+                correlationId,
+                MockApiResponseType.CHALLENGE_TYPE_OOB
+        );
+
+        // 1b. Call SDK interface
+        SignUpTestCallback signUpTestCallback = new SignUpTestCallback();
+
+        NativeAuthSignUpParameters params = new NativeAuthSignUpParameters(username);
+        params.setPassword(password);
+
+        application.signUp(params, signUpTestCallback);
 
         SignUpResult signUpResult = signUpTestCallback.get();
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplicationKotlinTest.kt
@@ -43,6 +43,11 @@ import com.microsoft.identity.common.nativeauth.MockApiEndpoint
 import com.microsoft.identity.common.nativeauth.MockApiResponseType
 import com.microsoft.identity.common.nativeauth.MockApiUtils.Companion.configureMockApi
 import com.microsoft.identity.internal.testutils.TestUtils
+import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthResetPasswordParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInContinuationParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignUpParameters
 import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenError
 import com.microsoft.identity.nativeauth.statemachine.errors.GetAccessTokenErrorTypes
@@ -234,6 +239,71 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
     }
 
     /**
+     * Test sign in scenario 7 using signIn with parameters class:
+     * 1a -> sign in with (valid) username
+     * 1b <- server requires code challenge
+     * 2a -> submit (invalid) code
+     * 2b <- server returns invalid code error, code challenge is still required
+     * 3a -> submit valid code
+     * 3b <- sign in succeeds
+     */
+    @Test
+    fun testSignInScenario7UsingParametersClassMethod() = runTest {
+        // 1. Sign in with username
+        // 1a. Setup server response
+        var correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInInitiate,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.INITIATE_SUCCESS
+        )
+
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.CHALLENGE_TYPE_OOB
+        )
+
+        val params = NativeAuthSignInParameters(username = username)
+
+        // 1b. Call SDK interface
+        val codeRequiredResult = application.signIn(params)
+        // 1a. Server returns invalid user error
+        assertTrue(codeRequiredResult is SignInResult.CodeRequired)
+        val nextState = spy((codeRequiredResult as SignInResult.CodeRequired).nextState)
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        nextState.mockCorrelationId(correlationId)
+
+        // 2. Submit (invalid) code
+        // 2a. Setup server response
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInToken,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.INVALID_OOB_VALUE
+        )
+        // 2b. Call SDK interface
+        val invalidCodeResult = nextState.submitCode(code)
+        // 2a. Server returns invalid code, stays in CodeRequired state
+        assertTrue(invalidCodeResult is SubmitCodeError)
+        assertTrue((invalidCodeResult as SubmitCodeError).isInvalidCode())
+
+        // 3. Submit (valid) code
+        // 3a. Setup server response
+        correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInToken,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.TOKEN_SUCCESS
+        )
+
+        // 3b. Call SDK interface
+        val successResult = nextState.submitCode(code)
+        // 3a. Server accepts code, returns tokens
+        assertTrue(successResult is SignInResult.Complete)
+    }
+
+    /**
      * Test sign in blocked (when account is already signed in)
      */
     @Test
@@ -287,6 +357,33 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
 
         // 1b. server returns token
         val result = signInWithContinuationTokenState.signIn(scopes = null)
+        assertTrue(result is SignInResult.Complete)
+    }
+
+    /**
+     * Test sign in with continuation token scenario 1 using signIn with parameters class:
+     * 1a -> sign in with (valid) continuation token
+     * 1b <- server returns token
+     */
+    @Test
+    fun testSignInWithContinuationTokenUsingParametersClassMethod() = runTest {
+        // Setup - sign up the user, so that we don't have to construct the ContinuationToken state manually
+        // as this doesn't allow for the NativeAuthPublicClientApplicationConfiguration to be set
+        // up, meaning it would need to be mocked (which we don't want in these tests).
+        val signInWithContinuationTokenState = signUpUser()
+
+        // 1a. sign in with (valid) continuation token
+        val correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInToken,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.TOKEN_SUCCESS
+        )
+
+        val params = NativeAuthSignInContinuationParameters()
+
+        // 1b. server returns token
+        val result = signInWithContinuationTokenState.signIn(params)
         assertTrue(result is SignInResult.Complete)
     }
 
@@ -502,6 +599,70 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         assertEquals(accessToken, accessTokenThree)
     }
 
+    /**
+     * Test sign in, get access token with scopes using the parameters class methods. Compare to token from getAccount() and getAccessToken()
+     */
+    @Test
+    fun testGetAccessTokenWithSignInScopesUsingParametersClass() = runTest {
+        val correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            MockApiEndpoint.SignInInitiate,
+            correlationId,
+            MockApiResponseType.INITIATE_SUCCESS
+        )
+
+        configureMockApi(
+            MockApiEndpoint.SignInChallenge,
+            correlationId,
+            MockApiResponseType.CHALLENGE_TYPE_PASSWORD
+        )
+
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignInToken,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.TOKEN_SUCCESS
+        )
+
+        val signInParams = NativeAuthSignInParameters(username)
+        signInParams.password = password
+
+        val signInResult = application.signIn(signInParams)
+        assertTrue(signInResult is SignInResult.Complete)
+
+        val getAccessTokenNoScopesParams = NativeAuthGetAccessTokenParameters()
+
+        val accessTokenState = (signInResult as SignInResult.Complete).resultValue.getAccessToken(getAccessTokenNoScopesParams)
+        assertTrue(accessTokenState is GetAccessTokenResult.Complete)
+
+        val accessToken = (accessTokenState as GetAccessTokenResult.Complete).resultValue.accessToken
+        assertNotNull(accessToken)
+
+        val getAccountResult = application.getCurrentAccount()
+        assertTrue(getAccountResult is GetAccountResult.AccountFound)
+
+        val accessTokenResultTwo = (getAccountResult as GetAccountResult.AccountFound).resultValue.getAccessToken(getAccessTokenNoScopesParams)
+        assertTrue(accessTokenResultTwo is GetAccessTokenResult.Complete)
+
+        val accessTokenTwo = (accessTokenResultTwo as GetAccessTokenResult.Complete).resultValue.accessToken
+        assertNotNull(accessTokenTwo)
+
+        assertEquals(accessToken, accessTokenTwo)
+
+        val scopes = Arrays.asList(AuthenticationConstants.OAuth2Scopes.OPEN_ID_SCOPE)
+
+        val getAccessTokenWithScopesParams = NativeAuthGetAccessTokenParameters()
+        getAccessTokenWithScopesParams.forceRefresh = false
+        getAccessTokenWithScopesParams.scopes = scopes
+
+        val accessTokenResultThree = (getAccountResult as GetAccountResult.AccountFound).resultValue.getAccessToken(getAccessTokenWithScopesParams)
+        assertTrue(accessTokenResultThree is GetAccessTokenResult.Complete)
+
+        val accessTokenThree = (accessTokenResultThree as GetAccessTokenResult.Complete).resultValue.accessToken
+        assertNotNull(accessTokenThree)
+
+        assertEquals(accessTokenTwo, accessTokenThree)
+        assertEquals(accessToken, accessTokenThree)
+    }
 
     /**
      * Test sign in, get access token with empty scopes. Compare to token from getAccount() and getAccessToken()
@@ -651,7 +812,7 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         val signOutResult = accountState.signOut()
         assertTrue(signOutResult is SignOutResult.Complete)
 
-        var accessTokenState = accountState.getAccessToken(false, emptyList())
+        val accessTokenState = accountState.getAccessToken(false, emptyList())
 
         assertTrue(accessTokenState is GetAccessTokenError)
         assertTrue((accessTokenState as GetAccessTokenError).isInvalidScopes())
@@ -1013,6 +1174,31 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
         )
         // 1a. Call SDK interface - resetPassword(ResetPasswordStart)
         val resetPasswordResult = application.resetPassword(username = username)
+        // 1b. Transform /start(error) to Result(UserNotFound)
+        assertTrue(resetPasswordResult is ResetPasswordError)
+        assertTrue((resetPasswordResult as ResetPasswordError).isUserNotFound())
+    }
+
+    /**
+     * Test SSPR scenario 3.2.5 using parameters class method:
+     * 1 -> USER click resetPassword
+     * 1 <- user not found, SERVER returns error
+     */
+    @Test
+    fun testSSPRScenario3_2_5UsingParametersClassMethod() = runTest {
+        var nextState: Any?
+        // 1. Click reset password
+        // 1_mock_api. Setup server response - endpoint: resetpassword/start - Server returns Error: user not found
+        val correlationId = UUID.randomUUID().toString()
+        configureMockApi(
+            endpointType = MockApiEndpoint.SSPRStart,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.USER_NOT_FOUND
+        )
+
+        val params = NativeAuthResetPasswordParameters(username)
+        // 1a. Call SDK interface - resetPassword(ResetPasswordStart)
+        val resetPasswordResult = application.resetPassword(params)
         // 1b. Transform /start(error) to Result(UserNotFound)
         assertTrue(resetPasswordResult is ResetPasswordError)
         assertTrue((resetPasswordResult as ResetPasswordError).isUserNotFound())
@@ -1492,6 +1678,76 @@ class NativeAuthPublicClientApplicationKotlinTest(private val allowPII: Boolean)
 
         // 1b. Call SDK interface
         val result = application.signUp(username, password)
+
+        assertTrue(result is SignUpResult.CodeRequired)
+
+        // 2a. Setup resend code challenge
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignUpChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.CHALLENGE_TYPE_OOB
+        )
+
+        val codeRequiredState = spy((result as SignUpResult.CodeRequired).nextState)
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        codeRequiredState.mockCorrelationId(correlationId)
+
+        // 2b. Call resendCode
+        val resendCodeResult = codeRequiredState.resendCode()
+        assertTrue(resendCodeResult is SignUpResendCodeResult.Success)
+
+        // 3. submit (valid) code
+        // 3a. setup server response
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignUpContinue,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SIGNUP_CONTINUE_SUCCESS
+        )
+
+        val submitCodeState = spy((resendCodeResult as SignUpResendCodeResult.Success).nextState)
+        // correlation ID field in will be null, because the mock API doesn't return this. So, we mock
+        // it's value in order to make it consistent with the subsequent call to mock API.
+        submitCodeState.mockCorrelationId(correlationId)
+
+        val successResult = submitCodeState.submitCode(code)
+
+        // 3b. Server accepts code, returns tokens
+        assertTrue(successResult is SignUpResult.Complete)
+    }
+
+    /**
+     * Test Sign Up scenario 2 using parameters class method:
+     * 1a -> signUp
+     * 1b <- server requires code verification
+     * 2a -> user prompts resend code, challenge endpoint is called
+     * 2b <- codeRequired is returned
+     * 3a -> submitCode is called with valid code
+     * 3b <- sign up succeeds
+     */
+    @Test
+    fun testSignUpScenario2UsingParametersClassMethod() = runTest {
+        // 1. sign up with password
+        // 1a. Setup server response
+        val correlationId = UUID.randomUUID().toString()
+
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignUpStart,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.SIGNUP_START_SUCCESS
+        )
+
+        configureMockApi(
+            endpointType = MockApiEndpoint.SignUpChallenge,
+            correlationId = correlationId,
+            responseType = MockApiResponseType.CHALLENGE_TYPE_OOB
+        )
+
+        val params = NativeAuthSignUpParameters(username)
+        params.password = password
+
+        // 1b. Call SDK interface
+        val result = application.signUp(params)
 
         assertTrue(result is SignUpResult.CodeRequired)
 


### PR DESCRIPTION
Fixes [AB#3117217](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3117217)

Add parameters class methods to native auth interface. Deprecate parameter list methods.
The signIn with continuation token method has a custom name for Java to avoid ambiguity. Without this custom name the introduction of the new method could introduce a breaking change in case the external developer used null as scopes value.

#### Additional info
The ideal test strategy for these new methods would be wrapping the `CommandDispatcher` in a class and inject it a spy class during tests to check that the new parameters class is used properly. This refactor would require quite some time, so this work will be done in a separate PBI.