### PR TITLE
Port Some UI Tests from ADAL to MSAL, Fixes AB#3139992

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
@@ -108,7 +108,7 @@ public class TestCase2110359 extends AbstractMsalBrokerTest{
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
 
         final UiObject optionsObject = device.findObject(new UiSelector()
-                .textContains("Sign-in options").className("android.widget.Button"));
+                .text("Sign-in options").className("android.widget.Button"));
 
         try {
             optionsObject.click();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase2110359.java
@@ -108,7 +108,7 @@ public class TestCase2110359 extends AbstractMsalBrokerTest{
                 UiDevice.getInstance(InstrumentationRegistry.getInstrumentation());
 
         final UiObject optionsObject = device.findObject(new UiSelector()
-                .text("Sign-in options").className("android.widget.Button"));
+                .textContains("Sign-in options").className("android.widget.Button"));
 
         try {
             optionsObject.click();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
@@ -1,0 +1,151 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NON INFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.crosscloud;
+
+import android.text.TextUtils;
+
+import androidx.annotation.NonNull;
+
+import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
+import com.microsoft.identity.client.ui.automation.TestContext;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
+import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
+import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.GuestHomeAzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+// [Joined] Guest Support: Interactive and Silent Auth with MSAL Test app (Authenticator or Company Portal)
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1400731/
+@RetryOnFailure(retryCount = 2)
+@RunWith(Parameterized.class)
+@RunOnAPI29Minus("Keep me signed in")
+public class TestCase1400731 extends AbstractGuestAccountMsalBrokerUiTest {
+
+    private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
+
+    public TestCase1400731(final String name, final @NonNull GuestHomeAzureEnvironment guestHomeAzureEnvironment) {
+        mGuestHomeAzureEnvironment = guestHomeAzureEnvironment;
+    }
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection guestHomeAzureEnvironment() {
+        return Arrays.asList(new Object[][]{
+                {"AZURE_US_GOV", GuestHomeAzureEnvironment.AZURE_US_GOVERNMENT},
+                {"AZURE_CHINA_CLOUD", GuestHomeAzureEnvironment.AZURE_CHINA_CLOUD},
+        });
+    }
+
+    /**
+     * Tests Acquiring token for Cross cloud Guest account with broker.
+     */
+    @Test
+    public void test_1420494() throws Throwable {
+        final String userName = mGuestUser.getHomeUpn();
+        final String password = mLabClient.getPasswordForGuestUser(mGuestUser);
+
+        //perform device registration
+        mBroker.performDeviceRegistration(userName, password);
+
+        // Handler for Interactive auth call
+        final OnInteractionRequired interactionHandler = () -> {
+            final PromptHandlerParameters promptHandlerParameters =
+                    PromptHandlerParameters.builder()
+                            .prompt(PromptParameter.SELECT_ACCOUNT)
+                            .loginHint(userName)
+                            .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
+                            .broker(mBroker)
+                            .build();
+            final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
+            promptHandler.handlePrompt(userName, password);
+        };
+
+        final MsalAuthTestParams acquireTokenAuthParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(userName)
+                .scopes(Arrays.asList(getScopes()))
+                .promptParameter(Prompt.SELECT_ACCOUNT)
+                .authority(getAuthority())
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalSdk msalSdk = new MsalSdk();
+        // Acquire token interactively
+        final MsalAuthResult acquireTokenResult = msalSdk.acquireTokenInteractive(acquireTokenAuthParams, interactionHandler, TokenRequestTimeout.SHORT);
+
+        Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenResult.getAccessToken()));
+
+        // change the time on the device (without resetting to automatic time zone)
+        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
+
+        // Acquire token silently
+        MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);
+        Assert.assertFalse("AccessToken is empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
+
+        Assert.assertNotEquals("Silent request does not return a new access token", acquireTokenSilentResult.getAccessToken(), acquireTokenResult.getAccessToken());
+
+        final JSONObject profileObject = getProfileObjectFromMSGraph(acquireTokenSilentResult.getAccessToken());
+        Assert.assertEquals(userName, profileObject.get("mail"));
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.GUEST)
+                .guestHomeAzureEnvironment(mGuestHomeAzureEnvironment)
+                .guestHomedIn(GuestHomedIn.HOST_AZURE_AD)
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return "https://login.microsoftonline.com/" + mGuestUser.getGuestLabTenants().get(0);
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
@@ -27,125 +27,133 @@ import android.text.TextUtils;
 import androidx.annotation.NonNull;
 
 import com.microsoft.identity.client.Prompt;
+import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
-import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractGuestAccountMsalBrokerUiTest;
-import com.microsoft.identity.client.ui.automation.TestContext;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.RunOnAPI29Minus;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
-import com.microsoft.identity.client.ui.automation.constants.GlobalConstants;
-import com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired;
-import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
-import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.labapi.utilities.client.LabGuestAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
-import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
-import com.microsoft.identity.labapi.utilities.constants.GuestHomeAzureEnvironment;
-import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
+import com.microsoft.identity.labapi.utilities.constants.LabConstants;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.TimeUnit;
 
 // [Joined] Guest Support: Interactive and Silent Auth with MSAL Test app (Authenticator or Company Portal)
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1400731/
 @RetryOnFailure(retryCount = 2)
-@RunWith(Parameterized.class)
-@RunOnAPI29Minus("Keep me signed in")
-public class TestCase1400731 extends AbstractGuestAccountMsalBrokerUiTest {
+public class TestCase1400731 extends AbstractMsalBrokerTest {
 
-    private final GuestHomeAzureEnvironment mGuestHomeAzureEnvironment;
-
-    public TestCase1400731(final String name, final @NonNull GuestHomeAzureEnvironment guestHomeAzureEnvironment) {
-        mGuestHomeAzureEnvironment = guestHomeAzureEnvironment;
-    }
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection guestHomeAzureEnvironment() {
-        return Arrays.asList(new Object[][]{
-                {"AZURE_US_GOV", GuestHomeAzureEnvironment.AZURE_US_GOVERNMENT},
-                {"AZURE_CHINA_CLOUD", GuestHomeAzureEnvironment.AZURE_CHINA_CLOUD},
-        });
-    }
-
-    /**
-     * Tests Acquiring token for Cross cloud Guest account with broker.
-     */
     @Test
-    public void test_1420494() throws Throwable {
-        final String userName = mGuestUser.getHomeUpn();
-        final String password = mLabClient.getPasswordForGuestUser(mGuestUser);
+    public void test_1400731() throws Throwable {
+        // load a guest user account from the Lab
+        final LabGuestAccount labGuest = mLabClient.loadGuestAccountFromLab(getLabQuery());
+
+        final String username = "gcidlab@msidlab4.onmicrosoft.com";
+        final String password = mLabClient.getPasswordForGuestUser(labGuest);
 
         //perform device registration
-        mBroker.performDeviceRegistration(userName, password);
+        mBroker.performDeviceRegistration(username, password);
 
-        // Handler for Interactive auth call
-        final OnInteractionRequired interactionHandler = () -> {
-            final PromptHandlerParameters promptHandlerParameters =
-                    PromptHandlerParameters.builder()
-                            .prompt(PromptParameter.SELECT_ACCOUNT)
-                            .loginHint(userName)
-                            .staySignedInPageExpected(GlobalConstants.IS_STAY_SIGN_IN_PAGE_EXPECTED)
-                            .broker(mBroker)
-                            .build();
-            final AadPromptHandler promptHandler = new AadPromptHandler(promptHandlerParameters);
-            promptHandler.handlePrompt(userName, password);
-        };
+        final MsalSdk msalSdk = new MsalSdk();
 
-        final MsalAuthTestParams acquireTokenAuthParams = MsalAuthTestParams.builder()
+        final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(userName)
-                .scopes(Arrays.asList(getScopes()))
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
                 .promptParameter(Prompt.SELECT_ACCOUNT)
-                .authority(getAuthority())
+                .authority(LabConstants.MSID_LAB3)
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
-        final MsalSdk msalSdk = new MsalSdk();
-        // Acquire token interactively
-        final MsalAuthResult acquireTokenResult = msalSdk.acquireTokenInteractive(acquireTokenAuthParams, interactionHandler, TokenRequestTimeout.SHORT);
+        // start interactive acquire token request in MSAL (should succeed)
+        final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                // Should be silent
+            }
+        }, TokenRequestTimeout.MEDIUM);
 
-        Assert.assertFalse("Verify accessToken is not empty", TextUtils.isEmpty(acquireTokenResult.getAccessToken()));
+        Assert.assertFalse(TextUtils.isEmpty(authResult.getAccessToken()));
 
-        // change the time on the device (without resetting to automatic time zone)
-        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
+        final MsalAuthTestParams authTestParams2 = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(mScopes))
+                .promptParameter(Prompt.SELECT_ACCOUNT)
+                .authority(LabConstants.MSID_LAB4)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
 
-        // Acquire token silently
-        MsalAuthResult acquireTokenSilentResult = msalSdk.acquireTokenSilent(acquireTokenAuthParams, TokenRequestTimeout.SHORT);
-        Assert.assertFalse("AccessToken is empty", TextUtils.isEmpty(acquireTokenSilentResult.getAccessToken()));
+        // start interactive acquire token request in MSAL for msidlab4 (should succeed and be silent)
+        final MsalAuthResult authResult2 = msalSdk.acquireTokenInteractive(authTestParams2, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                // Should be silent
+            }
+        }, TokenRequestTimeout.MEDIUM);
 
-        Assert.assertNotEquals("Silent request does not return a new access token", acquireTokenSilentResult.getAccessToken(), acquireTokenResult.getAccessToken());
+        authResult2.assertSuccess();
 
-        final JSONObject profileObject = getProfileObjectFromMSGraph(acquireTokenSilentResult.getAccessToken());
-        Assert.assertEquals(userName, profileObject.get("mail"));
+        // advance clock by more than an hour to expire AT in cache
+        getSettingsScreen().forwardDeviceTimeForOneDay();
+
+        final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .authority(LabConstants.MSID_LAB3)
+                .forceRefresh(true)
+                .scopes(Arrays.asList(mScopes))
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        // get a token silently for msidlab3
+        final MsalAuthResult silentAuthResult = msalSdk.acquireTokenSilent(silentParams, TokenRequestTimeout.SILENT);
+        silentAuthResult.assertSuccess();
+
+        final MsalAuthTestParams silentParams2 = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .authority(LabConstants.MSID_LAB4)
+                .forceRefresh(true)
+                .scopes(Arrays.asList(mScopes))
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        // get a token silently for msidlab4
+        final MsalAuthResult silentAuthResult2 = msalSdk.acquireTokenSilent(silentParams2, TokenRequestTimeout.SILENT);
+        silentAuthResult2.assertSuccess();
     }
 
     @Override
     public LabQuery getLabQuery() {
         return LabQuery.builder()
                 .userType(UserType.GUEST)
-                .guestHomeAzureEnvironment(mGuestHomeAzureEnvironment)
-                .guestHomedIn(GuestHomedIn.HOST_AZURE_AD)
-                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
                 .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
     }
 
     @Override
     public String[] getScopes() {
         return new String[]{"User.read"};
     }
-
     @Override
     public String getAuthority() {
-        return "https://login.microsoftonline.com/" + mGuestUser.getGuestLabTenants().get(0);
+        return "https://login.microsoftonline.us/common";
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
     }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -62,6 +62,8 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833544() throws LabApiException {
+        getSettingsScreen().toggleNotificationsThroughSettings(mBroker.getPackageName());
+
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -62,6 +62,7 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833544() throws LabApiException {
+        // Recent build of authenticator seems to produce a notification popup on device, this blocks some ui we rely on to validate account presence. Disabling notifications will work.
         getSettingsScreen().toggleNotificationsThroughSettings(mBroker.getPackageName());
 
         final String username = mLabAccount.getUsername();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -1,0 +1,232 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.foci;
+
+import androidx.test.uiautomator.UiObject;
+
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.app.AzureSampleApp;
+import com.microsoft.identity.client.ui.automation.app.OutlookApp;
+import com.microsoft.identity.client.ui.automation.app.WordApp;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+import com.microsoft.identity.client.ui.automation.logging.Logger;
+import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
+import com.microsoft.identity.client.ui.automation.interaction.FirstPartyAppPromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.common.java.util.ThreadUtils;
+import com.microsoft.identity.labapi.utilities.client.ILabAccount;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.FederationProvider;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+import com.microsoft.identity.labapi.utilities.exception.LabApiException;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+// [Non-joined][FoCl] FoCl (Multi-users) with Outlook and Word
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833544
+@SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
+@RetryOnFailure
+@LongUIAutomationTest
+public class TestCase833544 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_833544() throws LabApiException {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        final OutlookApp outlook = new OutlookApp(new LocalApkInstaller());
+
+        outlook.install();
+        outlook.launch();
+        outlook.handleFirstRun();
+
+        final FirstPartyAppPromptHandlerParameters promptHandlerParameters = FirstPartyAppPromptHandlerParameters.builder()
+                .prompt(PromptParameter.SELECT_ACCOUNT)
+                .loginHint(username)
+                .broker(mBroker)
+                .registerPageExpected(false)
+                .enrollPageExpected(false)
+                .consentPageExpected(false)
+                .speedBumpExpected(false)
+                .sessionExpected(false)
+                .expectingLoginPageAccountPicker(false)
+                .expectingBrokerAccountChooserActivity(false)
+                .build();
+
+        // add first account to Outlook
+        outlook.addFirstAccount(username, password, promptHandlerParameters);
+        outlook.onAccountAdded();
+        outlook.confirmAccount(username);
+
+        final WordApp wordApp = new WordApp(new LocalApkInstaller());
+
+        // open word
+        wordApp.install();
+        wordApp.launch();
+        wordApp.handleFirstRun();
+
+        // Word auto signs the user into with the account that was in Outlook
+        // Sometimes, it might take a bit longer to see this UI page in word app
+        final UiObject fileFetchScreen = UiAutomatorUtils.obtainUiObjectWithText("Fetching your files", TimeUnit.SECONDS.toMillis(45));
+        Assert.assertTrue(fileFetchScreen.exists());
+
+        // Make sure the account exists in Word
+        wordApp.confirmAccount(username);
+
+        // Steps from 833519
+        // Make sure a Non-FOCI app (Azure sample in this case) can't see the account
+        AzureSampleApp azureSample = new AzureSampleApp();
+        azureSample.install();
+        azureSample.launch();
+
+        // sign in silently into Azure Sample App, should see account picker and not get signed in
+        azureSample.signInSilentlyWithSingleAccountFragment(mBrowser, mBroker, false);
+
+        // Confirm that the account picker did show up
+        final UiObject accountPicker = UiAutomatorUtils.obtainUiObjectWithResourceId(CommonUtils.getResourceId(mBroker.getPackageName(), "account_chooser_listView"));
+        Assert.assertTrue(accountPicker.exists());
+
+        // Confirm that no account is logged in to AzureSampleApp
+        azureSample.forceStop();
+        azureSample.launch();
+        azureSample.confirmSignedIn("None");
+
+        // fetch another account from lab - someone from a different tenant
+        final LabQuery queryForAdfsV3Account = LabQuery.builder()
+                .userType(UserType.FEDERATED)
+                .federationProvider(FederationProvider.ADFS_V3)
+                .build();
+
+        final ILabAccount labAccountAdfsV3 = mLabClient.getLabAccount(queryForAdfsV3Account);
+
+        final String usernameV3 = labAccountAdfsV3.getUsername();
+        final String passwordV3 = labAccountAdfsV3.getPassword();
+
+        // relaunch Outlook
+        outlook.forceStop();
+        outlook.launch();
+
+        final FirstPartyAppPromptHandlerParameters outlookPromptParameters =
+                FirstPartyAppPromptHandlerParameters.builder()
+                        .expectingNonZeroAccountsInTSL(true)
+                        .prompt(PromptParameter.SELECT_ACCOUNT)
+                        .broker(mBroker)
+                        .consentPageExpected(false)
+                        .enrollPageExpected(false)
+                        .registerPageExpected(false)
+                        .isFederated(true)
+                        .expectingBrokerAccountChooserActivity(true)
+                        .expectingLoginPageAccountPicker(false)
+                        .howWouldYouLikeToSignInExpected(true)
+                        .loginHint(usernameV3)
+                        .sessionExpected(false)
+                        .speedBumpExpected(false)
+                        .build();
+
+        // add another account in Outlook
+        outlook.addAnotherAccount(usernameV3, passwordV3, outlookPromptParameters);
+
+        // Relaunching word right after outlook sign in is pressed leads to issues, sometimes the user is not signed in
+        ThreadUtils.sleepSafely(5000, "Sleep failed", "Interrupted");
+
+        // relaunch Word app
+        wordApp.forceStop();
+        wordApp.launch();
+
+        // We used to check for a flag to expect what new, which occasionally appears in our testing based on word version
+        // Let's just ignore any AssertionErrors that get thrown here, we don't know what to expect before hand anyway
+        try {
+            // Word shows a Whats New Dialog when the app is launched NEXT TIME after adding first account
+            final UiObject whatsNewDialog = UiAutomatorUtils.obtainUiObjectWithResourceId(
+                    "com.microsoft.office.word:id/WhatsNewDialogTitleTextView"
+            );
+
+            Assert.assertTrue(whatsNewDialog.exists());
+
+            // Click the close btn to close this dialog
+            UiAutomatorUtils.handleButtonClick("android:id/button2");
+        } catch (AssertionError e){
+            Logger.i(TestCase833544.class.getSimpleName(), "What's New Page did not appear: " + e.getMessage());
+        }
+
+        final FirstPartyAppPromptHandlerParameters wordPromptParameters =
+                FirstPartyAppPromptHandlerParameters.builder()
+                        .expectingNonZeroAccountsInTSL(true)
+                        .prompt(PromptParameter.SELECT_ACCOUNT)
+                        .broker(mBroker)
+                        .consentPageExpected(false)
+                        .enrollPageExpected(false)
+                        .registerPageExpected(false)
+                        .isFederated(true)
+                        .expectingBrokerAccountChooserActivity(true)
+                        .expectingLoginPageAccountPicker(false)
+                        .loginHint(usernameV3)
+                        .sessionExpected(true)
+                        .speedBumpExpected(false)
+                        .build();
+
+        // add another account in Word
+        wordApp.addAnotherAccount(usernameV3, passwordV3, wordPromptParameters);
+
+        // make sure this other account is in Word
+        wordApp.confirmAccount(usernameV3);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase831126.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase831126.java
@@ -60,7 +60,6 @@ import java.util.Arrays;
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/831126
 @SupportedBrokers(brokers = {BrokerCompanyPortal.class})
 @RetryOnFailure
-//public class TestCase831126 extends AbstractFirstPartyBrokerTest {
 public class TestCase831126 extends AbstractMsalBrokerTest {
 
     @Test
@@ -100,23 +99,6 @@ public class TestCase831126 extends AbstractMsalBrokerTest {
 
         // enroll device in MDM via the Company Portal app
         ((IMdmAgent) mBroker).enrollDevice(username, password);
-
-        // SILENT REQUEST - start a acquireTokenSilent request in MSAL with the Account 2
-        final MsalSdk msalSdk = new MsalSdk();
-        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
-
-        final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
-                .activity(mActivity)
-                .loginHint(username)
-                .authority(account.getAuthority())
-                .forceRefresh(true)
-                .scopes(Arrays.asList(mScopes))
-                .msalConfigResourceId(getConfigFileResourceId())
-                .build();
-
-        // get a token silently
-        final MsalAuthResult silentAuthResult = msalSdk.acquireTokenSilent(silentParams, TokenRequestTimeout.SILENT);
-        silentAuthResult.assertSuccess();
 
         // re-launch outlook
         outlook.launch();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase831126.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase831126.java
@@ -1,0 +1,186 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.mdm;
+
+import static com.microsoft.identity.client.ui.automation.utils.CommonUtils.FIND_UI_ELEMENT_TIMEOUT;
+import static org.junit.Assert.fail;
+
+import androidx.test.uiautomator.UiObject;
+
+import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
+import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.app.OutlookApp;
+import com.microsoft.identity.client.ui.automation.app.WordApp;
+import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
+import com.microsoft.identity.client.ui.automation.broker.IMdmAgent;
+import com.microsoft.identity.client.ui.automation.installer.LocalApkInstaller;
+import com.microsoft.identity.client.ui.automation.interaction.FirstPartyAppPromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
+import com.microsoft.identity.client.ui.automation.utils.CommonUtils;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+// [Joined][MDM] Device Admin MDM: MDM Account with Microsoft Outlook and Word
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/831126
+@SupportedBrokers(brokers = {BrokerCompanyPortal.class})
+@RetryOnFailure
+//public class TestCase831126 extends AbstractFirstPartyBrokerTest {
+public class TestCase831126 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_831126() throws Throwable {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        final OutlookApp outlook = new OutlookApp(new LocalApkInstaller());
+
+        outlook.install();
+
+        // launch outlook and handle first run
+        outlook.launch();
+        outlook.handleFirstRun();
+
+        // This went back and forth about needing an additional password prompt in browser, might need to revisit this one
+        final FirstPartyAppPromptHandlerParameters promptHandlerParameters = FirstPartyAppPromptHandlerParameters.builder()
+                .broker(mBroker)
+                .prompt(PromptParameter.LOGIN)
+                .loginHint(username)
+                .consentPageExpected(false)
+                .expectingBrokerAccountChooserActivity(false)
+                .secondPasswordPageExpected(true)
+                .expectingLoginPageAccountPicker(false)
+                .enrollPageExpected(true)
+                .build();
+
+        // add first account in Outlook
+        outlook.addFirstAccount(username, password, promptHandlerParameters);
+
+        // verify go to playstore page to download CP
+        mBrowser.handleFirstRun();
+        final UiObject goToPlayStoreBtn = UiAutomatorUtils.obtainUiObjectWithText("Go to Google Play");
+        if (!goToPlayStoreBtn.waitForExists(FIND_UI_ELEMENT_TIMEOUT)) {
+            fail("Go to play store page did not show up");
+        }
+
+        // enroll device in MDM via the Company Portal app
+        ((IMdmAgent) mBroker).enrollDevice(username, password);
+
+        // SILENT REQUEST - start a acquireTokenSilent request in MSAL with the Account 2
+        final MsalSdk msalSdk = new MsalSdk();
+        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
+
+        final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .authority(account.getAuthority())
+                .forceRefresh(true)
+                .scopes(Arrays.asList(mScopes))
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        // get a token silently
+        final MsalAuthResult silentAuthResult = msalSdk.acquireTokenSilent(silentParams, TokenRequestTimeout.SILENT);
+        silentAuthResult.assertSuccess();
+
+        // re-launch outlook
+        outlook.launch();
+
+        final FirstPartyAppPromptHandlerParameters promptHandlerParamsPostEnroll = FirstPartyAppPromptHandlerParameters.builder()
+                .broker(mBroker)
+                .prompt(PromptParameter.SELECT_ACCOUNT)
+                .loginHint(username)
+                .sessionExpected(true)
+                .build();
+
+        outlook.addFirstAccount(username, password, promptHandlerParamsPostEnroll);
+        outlook.onAccountAdded();
+
+        // make sure our Account is in Outlook now
+        outlook.confirmAccount(username);
+
+        final WordApp wordApp = new WordApp(new LocalApkInstaller());
+        wordApp.install();
+        wordApp.launch();
+        wordApp.handleFirstRun();
+
+        // Word performs auto login using the account that was previously used in one of the other
+        // microsoft apps.
+        UiObject fileFetchScreen = UiAutomatorUtils.obtainUiObjectWithText("Fetching your files", CommonUtils.FIND_UI_ELEMENT_TIMEOUT_LONG);
+        Assert.assertTrue(fileFetchScreen.exists());
+
+        // confirm that the account appears in Word
+        wordApp.confirmAccount(username);
+        // advance clock by more than an hour to expire AT in cache
+        getSettingsScreen().forwardDeviceTimeForOneDay();
+
+        // again open outlook and confirm that there is no interactive prompt
+        outlook.launch();
+        outlook.confirmAccount(username);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .protectionPolicy(ProtectionPolicy.MDM_CA)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}
+

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase2139526.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase2139526.java
@@ -29,26 +29,30 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthResult;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.TestContext;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
+import com.microsoft.identity.client.ui.automation.annotations.LongUIAutomationTest;
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
-import com.microsoft.identity.labapi.utilities.constants.UserType;
 
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
-// [Non-joined][MSAL] Acquire Token + Acquire Token Silent (Prompt.SELECT_ACCOUNT)
-// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850455
-@RetryOnFailure(retryCount = 2)
-public class TestCase850455 extends AbstractMsalBrokerTest {
+// Acquire Token Silent After Policy Change Should Fail
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2139526
+@RetryOnFailure
+@LongUIAutomationTest
+public class TestCase2139526 extends AbstractMsalBrokerTest {
 
     @Test
-    public void test_850455() throws Throwable {
+    public void test_2139526() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
@@ -59,7 +63,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
                 .activity(mActivity)
                 .loginHint(username)
                 .scopes(Arrays.asList(getScopes()))
-                .resource("00000002-0000-0000-c000-000000000000")
+                .resource("00000003-0000-0ff1-ce00-000000000000")
                 .promptParameter(Prompt.SELECT_ACCOUNT)
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
@@ -84,6 +88,16 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
 
         authResult.assertSuccess();
 
+        // Change the policy to MAM_CA
+        mLabClient.enablePolicy(username, ProtectionPolicy.MAM_CA);
+
+        // It takes some time for the policy change to reflect
+        Thread.sleep(TimeUnit.MINUTES.toMillis(3));
+
+        // advance clock by more than an hour to expire AT in cache
+        TestContext.getTestContext().getTestDevice().getSettings().forwardDeviceTimeForOneDay();
+
+        // Try silent call with sharepoint as the resource, this should fail
         // Silent call
         final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
 
@@ -93,30 +107,29 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
                 .authority(account.getAuthority())
                 .forceRefresh(true)
                 .scopes(Arrays.asList(getScopes()))
-                .resource("00000002-0000-0000-c000-000000000000")
+                .resource("00000003-0000-0ff1-ce00-000000000000")
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
         final MsalAuthResult silentAuthResult = msalSdk.acquireTokenSilent(silentParams,TokenRequestTimeout.SILENT);
-        silentAuthResult.assertSuccess();
+        silentAuthResult.assertFailure();
     }
 
     @Override
     public LabQuery getLabQuery() {
-        return LabQuery.builder()
-                .userType(UserType.CLOUD)
-                .build();
+        return null;
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return null;
+        return TempUserType.BASIC;
     }
 
     @Override
     public String[] getScopes() {
         return new String[]{"User.read"};
     }
+
     @Override
     public String getAuthority() {
         return "https://login.microsoftonline.us/common";

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase3139972.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase3139972.java
@@ -44,7 +44,7 @@ import java.util.Arrays;
 
 // [Non-joined][MSAL] Acquire Token + Acquire Token Silent, no loginhint (Prompt.SELECT_ACCOUNT)
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3139972
-//@RetryOnFailure(retryCount = 2)
+@RetryOnFailure(retryCount = 2)
 public class TestCase3139972 extends AbstractMsalBrokerTest {
 
     @Test
@@ -89,10 +89,11 @@ public class TestCase3139972 extends AbstractMsalBrokerTest {
 
         final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(null)
+                .loginHint(username)
                 .authority(account.getAuthority())
                 .forceRefresh(true)
-                .resource(mScopes[0])
+                .scopes(Arrays.asList(getScopes()))
+                .resource("00000002-0000-0000-c000-000000000000")
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase3139972.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase3139972.java
@@ -42,13 +42,13 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [Non-joined][MSAL] Acquire Token + Acquire Token Silent (Prompt.SELECT_ACCOUNT)
-// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850455
-@RetryOnFailure(retryCount = 2)
-public class TestCase850455 extends AbstractMsalBrokerTest {
+// [Non-joined][MSAL] Acquire Token + Acquire Token Silent, no loginhint (Prompt.SELECT_ACCOUNT)
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3139972
+//@RetryOnFailure(retryCount = 2)
+public class TestCase3139972 extends AbstractMsalBrokerTest {
 
     @Test
-    public void test_850455() throws Throwable {
+    public void test_3139972() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
@@ -57,7 +57,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
         // Interactive call
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(username)
+                .loginHint(null)
                 .scopes(Arrays.asList(getScopes()))
                 .resource("00000002-0000-0000-c000-000000000000")
                 .promptParameter(Prompt.SELECT_ACCOUNT)
@@ -69,7 +69,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
             public void handleUserInteraction() {
                 final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
                         .prompt(PromptParameter.SELECT_ACCOUNT)
-                        .loginHint(username)
+                        .loginHint(null)
                         .sessionExpected(false)
                         .consentPageExpected(false)
                         .speedBumpExpected(false)
@@ -89,11 +89,10 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
 
         final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(username)
+                .loginHint(null)
                 .authority(account.getAuthority())
                 .forceRefresh(true)
-                .scopes(Arrays.asList(getScopes()))
-                .resource("00000002-0000-0000-c000-000000000000")
+                .resource(mScopes[0])
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();
 
@@ -117,6 +116,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
     public String[] getScopes() {
         return new String[]{"User.read"};
     }
+
     @Override
     public String getAuthority() {
         return "https://login.microsoftonline.us/common";

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833546.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833546.java
@@ -30,7 +30,6 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
@@ -42,13 +41,11 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [Non-joined][MSAL] Acquire Token + Acquire Token Silent (Prompt.SELECT_ACCOUNT)
-// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850455
-@RetryOnFailure(retryCount = 2)
-public class TestCase850455 extends AbstractMsalBrokerTest {
-
+// [ADAL] Broker Auth for Non-Joined Account - Multiple Resources
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833546
+public class TestCase833546 extends AbstractMsalBrokerTest {
     @Test
-    public void test_850455() throws Throwable {
+    public void test_833546() throws Throwable {
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 
@@ -59,7 +56,7 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
                 .activity(mActivity)
                 .loginHint(username)
                 .scopes(Arrays.asList(getScopes()))
-                .resource("00000002-0000-0000-c000-000000000000")
+                .resource("00000003-0000-0ff1-ce00-000000000000")
                 .promptParameter(Prompt.SELECT_ACCOUNT)
                 .msalConfigResourceId(getConfigFileResourceId())
                 .build();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833546.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833546.java
@@ -41,7 +41,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [ADAL] Broker Auth for Non-Joined Account - Multiple Resources
+// [MSAL] Broker Auth for Non-Joined Account - Multiple Resources
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833546
 public class TestCase833546 extends AbstractMsalBrokerTest {
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
@@ -30,9 +30,10 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
-import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandler;
+import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
 import com.microsoft.identity.labapi.utilities.client.LabGuestAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
@@ -45,11 +46,12 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [ADAL] Broker Auth for Non-Joined Account (Federated User)
+// [MSAL] Broker Auth for Non-Joined Account (Federated User)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833553
+@RetryOnFailure()
 public class TestCase833553 extends AbstractMsalBrokerTest {
     @Test
-    public void test_833546() throws Throwable {
+    public void test_833553() throws Throwable {
         final String username = mLabAccount.getUsername();
 
         // query to load another user from the same tenant
@@ -64,14 +66,14 @@ public class TestCase833553 extends AbstractMsalBrokerTest {
         final LabGuestAccount userB = mLabClient.loadGuestAccountFromLab(queryForUserB);
 
         final String usernameB = userB.getHomeUpn();
-        final String passwordB = mLabClient.getPasswordForGuestUser(userB);
+        final String password = mLabClient.getPasswordForGuestUser(userB);
 
         final MsalSdk msalSdk = new MsalSdk();
 
         // Interactive call
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(null)
+                .loginHint(username)
                 .scopes(Arrays.asList(getScopes()))
                 .resource("00000002-0000-0000-c000-000000000000")
                 .promptParameter(Prompt.SELECT_ACCOUNT)
@@ -81,22 +83,54 @@ public class TestCase833553 extends AbstractMsalBrokerTest {
         final MsalAuthResult authResult = msalSdk.acquireTokenInteractive(authTestParams, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
             @Override
             public void handleUserInteraction() {
-                final PromptHandlerParameters promptHandlerParameters = PromptHandlerParameters.builder()
+                final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
                         .prompt(PromptParameter.SELECT_ACCOUNT)
                         .loginHint(username)
                         .sessionExpected(false)
                         .consentPageExpected(false)
+                        .isFederated(true)
                         .speedBumpExpected(false)
                         .broker(mBroker)
                         .expectingBrokerAccountChooserActivity(false)
                         .build();
 
-                new AadPromptHandler(promptHandlerParameters)
-                        .handlePrompt(usernameB, passwordB);
+                new MicrosoftStsPromptHandler(promptHandlerParameters)
+                        .handlePrompt(username, password);
             }
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
+
+        // Interactive call for user b
+        final MsalAuthTestParams authTestParams2 = MsalAuthTestParams.builder()
+                .activity(mActivity)
+                .loginHint(username)
+                .scopes(Arrays.asList(getScopes()))
+                .resource("00000002-0000-0000-c000-000000000000")
+                .promptParameter(Prompt.LOGIN)
+                .msalConfigResourceId(getConfigFileResourceId())
+                .build();
+
+        final MsalAuthResult authResult2 = msalSdk.acquireTokenInteractive(authTestParams2, new com.microsoft.identity.client.ui.automation.interaction.OnInteractionRequired() {
+            @Override
+            public void handleUserInteraction() {
+                final MicrosoftStsPromptHandlerParameters promptHandlerParameters = MicrosoftStsPromptHandlerParameters.builder()
+                        .prompt(PromptParameter.LOGIN)
+                        .loginHint(null)
+                        .sessionExpected(false)
+                        .consentPageExpected(false)
+                        .isFederated(true)
+                        .speedBumpExpected(false)
+                        .broker(mBroker)
+                        .expectingBrokerAccountChooserActivity(false)
+                        .build();
+
+                new MicrosoftStsPromptHandler(promptHandlerParameters)
+                        .handlePrompt(usernameB, password);
+            }
+        }, TokenRequestTimeout.MEDIUM);
+
+        authResult2.assertSuccess();
 
         // Silent call
         final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),usernameB);

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
@@ -30,11 +30,14 @@ import com.microsoft.identity.client.msal.automationapp.sdk.MsalAuthTestParams;
 import com.microsoft.identity.client.msal.automationapp.sdk.MsalSdk;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.TokenRequestTimeout;
-import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
 import com.microsoft.identity.client.ui.automation.interaction.PromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.interaction.PromptParameter;
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.AadPromptHandler;
+import com.microsoft.identity.labapi.utilities.client.LabGuestAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.FederationProvider;
+import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
@@ -42,22 +45,33 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-// [Non-joined][MSAL] Acquire Token + Acquire Token Silent (Prompt.SELECT_ACCOUNT)
-// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/850455
-@RetryOnFailure(retryCount = 2)
-public class TestCase850455 extends AbstractMsalBrokerTest {
-
+// [ADAL] Broker Auth for Non-Joined Account (Federated User)
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833553
+public class TestCase833553 extends AbstractMsalBrokerTest {
     @Test
-    public void test_850455() throws Throwable {
+    public void test_833546() throws Throwable {
         final String username = mLabAccount.getUsername();
-        final String password = mLabAccount.getPassword();
+
+        // query to load another user from the same tenant
+        final LabQuery queryForUserB = LabQuery.builder()
+                .userType(UserType.GUEST)
+                .guestHomedIn(GuestHomedIn.ON_PREM)
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .federationProvider(FederationProvider.ADFS_V4)
+                .build();
+
+        // load this other user
+        final LabGuestAccount userB = mLabClient.loadGuestAccountFromLab(queryForUserB);
+
+        final String usernameB = userB.getHomeUpn();
+        final String passwordB = mLabClient.getPasswordForGuestUser(userB);
 
         final MsalSdk msalSdk = new MsalSdk();
 
         // Interactive call
         final MsalAuthTestParams authTestParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(username)
+                .loginHint(null)
                 .scopes(Arrays.asList(getScopes()))
                 .resource("00000002-0000-0000-c000-000000000000")
                 .promptParameter(Prompt.SELECT_ACCOUNT)
@@ -78,18 +92,18 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
                         .build();
 
                 new AadPromptHandler(promptHandlerParameters)
-                        .handlePrompt(username, password);
+                        .handlePrompt(usernameB, passwordB);
             }
         }, TokenRequestTimeout.MEDIUM);
 
         authResult.assertSuccess();
 
         // Silent call
-        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),username);
+        final IAccount account = msalSdk.getAccount(mActivity,getConfigFileResourceId(),usernameB);
 
         final MsalAuthTestParams silentParams = MsalAuthTestParams.builder()
                 .activity(mActivity)
-                .loginHint(username)
+                .loginHint(usernameB)
                 .authority(account.getAuthority())
                 .forceRefresh(true)
                 .scopes(Arrays.asList(getScopes()))
@@ -104,7 +118,9 @@ public class TestCase850455 extends AbstractMsalBrokerTest {
     @Override
     public LabQuery getLabQuery() {
         return LabQuery.builder()
-                .userType(UserType.CLOUD)
+                .userType(UserType.FEDERATED)
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .federationProvider(FederationProvider.ADFS_V4)
                 .build();
     }
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase831655.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase831655.java
@@ -1,0 +1,80 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.wpj;
+
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.broker.BrokerCompanyPortal;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Test;
+
+// Verify WPJ Cert installation on a Non samsung device with Authenticator
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/831655
+
+// Technically this works on Samsung device too (at least Galaxy S6)
+// So this should also cover TestCase831570
+// https://identitydivision.visualstudio.com/Engineering/_workitems/edit/831570
+@SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerCompanyPortal.class})
+public class TestCase831655 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_831655() {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        // add work account via Settings screen
+        getSettingsScreen().addWorkAccount(mBroker, username, password);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
@@ -45,6 +45,7 @@ public class TestCase833547 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833547() {
+        // Recent build of authenticator seems to produce a notification popup on device, this blocks some ui we rely on to validate account presence. Disabling notifications will work.
         getSettingsScreen().toggleNotificationsThroughSettings(mBroker.getPackageName());
 
         final String username = mLabAccount.getUsername();

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
@@ -1,0 +1,88 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.wpj;
+
+import androidx.test.uiautomator.UiObject;
+
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+import com.microsoft.identity.labapi.utilities.constants.UserType;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+// Broker Add Account via Account Manager
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833547
+@SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
+@RetryOnFailure
+public class TestCase833547 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_833547() {
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        getSettingsScreen().addWorkAccount(mBroker, username, password);
+
+        // Assert Authenticator Account screen has account
+        mBroker.launch(); // open Authenticator App
+        mBroker.handleFirstRun();
+
+        final UiObject account1 = UiAutomatorUtils.obtainUiObjectWithText(username);
+        Assert.assertTrue(account1.exists()); // make sure account 1 is there
+    }
+
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833547.java
@@ -45,6 +45,8 @@ public class TestCase833547 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_833547() {
+        getSettingsScreen().toggleNotificationsThroughSettings(mBroker.getPackageName());
+
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833561.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833561.java
@@ -39,7 +39,7 @@ import org.junit.Test;
 // [WPJ] Install WPJ Certificate for Browser Access
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833561
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
-@RetryOnFailure(retryCount = 2)
+//@RetryOnFailure(retryCount = 2)
 public class TestCase833561 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833561.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/wpj/TestCase833561.java
@@ -1,0 +1,88 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.msal.automationapp.testpass.broker.wpj;
+
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
+import com.microsoft.identity.client.msal.automationapp.R;
+import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
+import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure;
+import com.microsoft.identity.client.ui.automation.annotations.SupportedBrokers;
+import com.microsoft.identity.client.ui.automation.broker.BrokerHost;
+import com.microsoft.identity.client.ui.automation.broker.BrokerMicrosoftAuthenticator;
+import com.microsoft.identity.labapi.utilities.client.LabQuery;
+import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
+import com.microsoft.identity.labapi.utilities.constants.TempUserType;
+
+import org.junit.Assume;
+import org.junit.Test;
+
+// [WPJ] Install WPJ Certificate for Browser Access
+// https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833561
+@SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class, BrokerHost.class})
+@RetryOnFailure(retryCount = 2)
+public class TestCase833561 extends AbstractMsalBrokerTest {
+
+    @Test
+    public void test_833561() {
+        // Check flight, this is checking what was passed to automation app, not the broker apks
+        Assume.assumeFalse( "EnableKeyStoreKeyFactory flight is activated, Test will be skipped",
+                BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableKeyStoreKeyFactory:true"));
+
+        // Fetch credentials
+        final String username = mLabAccount.getUsername();
+        final String password = mLabAccount.getPassword();
+
+        // perform device registration in broker
+        mBroker.performDeviceRegistration(username, password);
+
+        // enable browser access via broker
+        mBroker.enableBrowserAccess(username);
+    }
+
+    @Override
+    public LabQuery getLabQuery() {
+        return LabQuery.builder()
+                .azureEnvironment(AzureEnvironment.AZURE_CLOUD)
+                .build();
+    }
+
+    @Override
+    public TempUserType getTempUserType() {
+        return null;
+    }
+
+    @Override
+    public String[] getScopes() {
+        return new String[]{"User.read"};
+    }
+
+    @Override
+    public String getAuthority() {
+        return mApplication.getConfiguration().getDefaultAuthority().getAuthorityURL().toString();
+    }
+
+    @Override
+    public int getConfigFileResourceId() {
+        return R.raw.msal_config_default;
+    }
+}


### PR DESCRIPTION
Trying copilot to generate PR summary

This pull request includes several new test cases and updates to existing ones in the `msalautomationapp` project. The most important changes involve adding new test cases for various scenarios involving Microsoft Outlook and Word applications, as well as updating subproject commits.

### New Test Cases:

* [`msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java`](diffhunk://#diff-3ab764a654b96cd6b7ad36d2bd11a881cbbcd4737054fea8a5fd7b135e33eae7R1-R151): Added a new test case for acquiring tokens for cross-cloud guest accounts with brokers. This includes both interactive and silent authentication.
* [`msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java`](diffhunk://#diff-bace7c969485237a7d80a4952f9cd3353804aea5d67a36a0ec92c406a62f0fecR1-R232): Added a new test case for multi-user scenarios with Outlook and Word applications, ensuring non-FOCI apps cannot access FOCI accounts.
* [`msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mdm/TestCase831126.java`](diffhunk://#diff-c538bfcbc28cda9036dd5d979e72773d390b69f727877c99f1e17c0b201a64ddR1-R186): Added a new test case for MDM-enrolled devices, focusing on Microsoft Outlook and Word applications. This includes device enrollment and token acquisition scenarios.

### Subproject Updates:

* [`common`](diffhunk://#diff-92a5dc04bd6f9fb8f29f8066fed8a5c1e81bc59ad48a11283b63736867e4f2a8L1-R1): Updated subproject commit to the latest version.

[AB#3139992](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3139992)