### PR TITLE
Melissaahn/release/5.10.2

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,9 +3,9 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 vNext
 ----------
 
-Version 5.10.1
+Version 5.10.2
 ----------
-- [PATCH] Update common @20.1.0
+- [PATCH] Update common @20.1.1
 
 Version 5.10.0
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,12 +188,12 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def commonVersion = "20.1.0"
+def commonVersion = "20.1.1-RC1"
 if (project.hasProperty("distCommonVersion")) {
     commonVersion = project.distCommonVersion
 }
 // Used for testfixtures
-def common4jVersion = "20.1.0"
+def common4jVersion = "20.1.1-RC1"
 if (project.hasProperty("distCommon4jVersion")) {
     distCommon4jVersion = project.distCommon4jVersion
 }

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -193,7 +193,7 @@ if (project.hasProperty("distCommonVersion")) {
     commonVersion = project.distCommonVersion
 }
 // Used for testfixtures
-def common4jVersion = "20.1.1-RC3"
+def common4jVersion = "20.1.1"
 if (project.hasProperty("distCommon4jVersion")) {
     distCommon4jVersion = project.distCommon4jVersion
 }

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,7 +188,7 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def commonVersion = "20.1.1-RC3"
+def commonVersion = "20.1.1"
 if (project.hasProperty("distCommonVersion")) {
     commonVersion = project.distCommonVersion
 }

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -188,12 +188,12 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def commonVersion = "20.1.1-RC1"
+def commonVersion = "20.1.1-RC3"
 if (project.hasProperty("distCommonVersion")) {
     commonVersion = project.distCommonVersion
 }
 // Used for testfixtures
-def common4jVersion = "20.1.1-RC1"
+def common4jVersion = "20.1.1-RC3"
 if (project.hasProperty("distCommon4jVersion")) {
     distCommon4jVersion = project.distCommon4jVersion
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=5.10.2-RC3
+versionName=5.10.2
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=5.10.1
+versionName=5.10.2-RC1
 versionCode=0

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=5.10.2-RC1
+versionName=5.10.2-RC3
 versionCode=0


### PR DESCRIPTION
Note: the files had existing versions of "20.1.0" and "5.10.1" because release/5.10.2 was created from release/5.10.1, which is a scrapped version due to some issues which occurred during the release process.

See here that release/5.10.2 has no differences from dev other than the version numbers: https://github.com/AzureAD/microsoft-authentication-library-for-android/compare/dev...release/5.10.2