### PR TITLE
lab 3 ui test case fix, Fixes AB#3181878

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 
 // [Joined] Guest Support: Interactive and Silent Auth with MSAL Test app (Authenticator or Company Portal)
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1400731/
-@RetryOnFailure(retryCount = 2)
+//@RetryOnFailure(retryCount = 2)
 public class TestCase1400731 extends AbstractMsalBrokerTest {
 
     @Test
@@ -55,11 +55,11 @@ public class TestCase1400731 extends AbstractMsalBrokerTest {
         // load a guest user account from the Lab
         final LabGuestAccount labGuest = mLabClient.loadGuestAccountFromLab(getLabQuery());
 
-        final String username = labGuest.getHomeUpn();
+        final String username = "gcidlab@msidlab4.onmicrosoft.com";
         final String password = mLabClient.getPasswordForGuestUser(labGuest);
 
         //perform device registration
-        mBroker.performDeviceRegistration(username, password, true);
+        mBroker.performDeviceRegistration(username, password);
 
         final MsalSdk msalSdk = new MsalSdk();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
@@ -47,7 +47,7 @@ import java.util.Arrays;
 
 // [Joined] Guest Support: Interactive and Silent Auth with MSAL Test app (Authenticator or Company Portal)
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1400731/
-//@RetryOnFailure(retryCount = 2)
+@RetryOnFailure(retryCount = 2)
 public class TestCase1400731 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/crosscloud/TestCase1400731.java
@@ -55,11 +55,11 @@ public class TestCase1400731 extends AbstractMsalBrokerTest {
         // load a guest user account from the Lab
         final LabGuestAccount labGuest = mLabClient.loadGuestAccountFromLab(getLabQuery());
 
-        final String username = "gcidlab@msidlab4.onmicrosoft.com";
+        final String username = labGuest.getHomeUpn();
         final String password = mLabClient.getPasswordForGuestUser(labGuest);
 
         //perform device registration
-        mBroker.performDeviceRegistration(username, password);
+        mBroker.performDeviceRegistration(username, password, true);
 
         final MsalSdk msalSdk = new MsalSdk();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -125,15 +125,15 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
         azureSample.confirmSignedIn("None");
 
         // fetch another account from lab - someone from a different tenant
-        final LabQuery guestAccountQuery = LabQuery.builder()
+        final LabQuery govAccountQuery = LabQuery.builder()
                 .userType(UserType.CLOUD)
                 .azureEnvironment(AzureEnvironment.AZURE_US_GOVERNMENT)
                 .build();
 
-        final ILabAccount guestAccount = mLabClient.getLabAccount(guestAccountQuery);
+        final ILabAccount govAccount = mLabClient.getLabAccount(govAccountQuery);
 
-        final String usernameGuest = guestAccount.getUsername();
-        final String passwordGuest = guestAccount.getPassword();
+        final String usernameGov = govAccount.getUsername();
+        final String passwordGov = govAccount.getPassword();
 
         // relaunch Outlook
         outlook.forceStop();
@@ -151,13 +151,13 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
                         .expectingBrokerAccountChooserActivity(true)
                         .expectingLoginPageAccountPicker(false)
                         .howWouldYouLikeToSignInExpected(true)
-                        .loginHint(usernameGuest)
+                        .loginHint(usernameGov)
                         .sessionExpected(false)
                         .speedBumpExpected(false)
                         .build();
 
         // add another account in Outlook
-        outlook.addAnotherAccount(usernameGuest, passwordGuest, outlookPromptParameters);
+        outlook.addAnotherAccount(usernameGov, passwordGov, outlookPromptParameters);
 
         // Relaunching word right after outlook sign in is pressed leads to issues, sometimes the user is not signed in
         ThreadUtils.sleepSafely(5000, "Sleep failed", "Interrupted");
@@ -193,16 +193,16 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
                         .isFederated(true)
                         .expectingBrokerAccountChooserActivity(true)
                         .expectingLoginPageAccountPicker(false)
-                        .loginHint(usernameGuest)
+                        .loginHint(usernameGov)
                         .sessionExpected(true)
                         .speedBumpExpected(false)
                         .build();
 
         // add another account in Word
-        wordApp.addAnotherAccount(usernameGuest, passwordGuest, wordPromptParameters);
+        wordApp.addAnotherAccount(usernameGov, passwordGov, wordPromptParameters);
 
         // make sure this other account is in Word
-        wordApp.confirmAccount(usernameGuest);
+        wordApp.confirmAccount(usernameGov);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -43,7 +43,6 @@ import com.microsoft.identity.common.java.util.ThreadUtils;
 import com.microsoft.identity.labapi.utilities.client.ILabAccount;
 import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
-import com.microsoft.identity.labapi.utilities.constants.FederationProvider;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 import com.microsoft.identity.labapi.utilities.exception.LabApiException;
@@ -126,15 +125,15 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
         azureSample.confirmSignedIn("None");
 
         // fetch another account from lab - someone from a different tenant
-        final LabQuery queryForAdfsV3Account = LabQuery.builder()
-                .userType(UserType.FEDERATED)
-                .federationProvider(FederationProvider.ADFS_V3)
+        final LabQuery guestAccountQuery = LabQuery.builder()
+                .userType(UserType.CLOUD)
+                .azureEnvironment(AzureEnvironment.AZURE_US_GOVERNMENT)
                 .build();
 
-        final ILabAccount labAccountAdfsV3 = mLabClient.getLabAccount(queryForAdfsV3Account);
+        final ILabAccount guestAccount = mLabClient.getLabAccount(guestAccountQuery);
 
-        final String usernameV3 = labAccountAdfsV3.getUsername();
-        final String passwordV3 = labAccountAdfsV3.getPassword();
+        final String usernameGuest = guestAccount.getUsername();
+        final String passwordGuest = guestAccount.getPassword();
 
         // relaunch Outlook
         outlook.forceStop();
@@ -148,17 +147,17 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
                         .consentPageExpected(false)
                         .enrollPageExpected(false)
                         .registerPageExpected(false)
-                        .isFederated(true)
+                        .isFederated(false)
                         .expectingBrokerAccountChooserActivity(true)
                         .expectingLoginPageAccountPicker(false)
                         .howWouldYouLikeToSignInExpected(true)
-                        .loginHint(usernameV3)
+                        .loginHint(usernameGuest)
                         .sessionExpected(false)
                         .speedBumpExpected(false)
                         .build();
 
         // add another account in Outlook
-        outlook.addAnotherAccount(usernameV3, passwordV3, outlookPromptParameters);
+        outlook.addAnotherAccount(usernameGuest, passwordGuest, outlookPromptParameters);
 
         // Relaunching word right after outlook sign in is pressed leads to issues, sometimes the user is not signed in
         ThreadUtils.sleepSafely(5000, "Sleep failed", "Interrupted");
@@ -194,16 +193,16 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
                         .isFederated(true)
                         .expectingBrokerAccountChooserActivity(true)
                         .expectingLoginPageAccountPicker(false)
-                        .loginHint(usernameV3)
+                        .loginHint(usernameGuest)
                         .sessionExpected(true)
                         .speedBumpExpected(false)
                         .build();
 
         // add another account in Word
-        wordApp.addAnotherAccount(usernameV3, passwordV3, wordPromptParameters);
+        wordApp.addAnotherAccount(usernameGuest, passwordGuest, wordPromptParameters);
 
         // make sure this other account is in Word
-        wordApp.confirmAccount(usernameV3);
+        wordApp.confirmAccount(usernameGuest);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-joined][FoCl] FoCl (Multi-users) with Outlook and Word
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833544
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
-@RetryOnFailure
+//@RetryOnFailure
 @LongUIAutomationTest
 public class TestCase833544 extends AbstractMsalBrokerTest {
 
@@ -190,7 +190,7 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
                         .consentPageExpected(false)
                         .enrollPageExpected(false)
                         .registerPageExpected(false)
-                        .isFederated(true)
+                        .isFederated(false)
                         .expectingBrokerAccountChooserActivity(true)
                         .expectingLoginPageAccountPicker(false)
                         .loginHint(usernameGov)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -55,7 +55,7 @@ import java.util.concurrent.TimeUnit;
 // [Non-joined][FoCl] FoCl (Multi-users) with Outlook and Word
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833544
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
-//@RetryOnFailure
+@RetryOnFailure
 @LongUIAutomationTest
 public class TestCase833544 extends AbstractMsalBrokerTest {
 


### PR DESCRIPTION
We have one test case that checks foci for 2 accounts from different tenants. We previously used a lab 3 account for the second user, many lab 3 accounts have been decommissioned so we are instead using a different account.

[AB#3181878](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3181878)