### PR TITLE
Remove `MaxPermSize` option as it's incompatible with newer JDKs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.daemon=true
 
 # See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
 # we must make sure that the total size is <7G, as that's the RAM size of VM on the build pipeline.
-org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx2048m -XX:+HeapDumpOnOutOfMemoryError
 
 # For OneAuth default abiSelection
 abiSelection=x86_64


### PR DESCRIPTION
```
Unable to start the daemon process.
This problem might be caused by incorrect configuration of the daemon.
For example, an unrecognized jvm option is used.
Please refer to the User Manual chapter on the daemon at https://docs.gradle.org/7.5/userguide/gradle_daemon.html
Process command line: /Library/Java/JavaVirtualMachines/zulu-17.jdk/Contents/Home/bin/java -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.invoke=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED --add-opens java.prefs/java.util.prefs=ALL-UNNAMED --add-opens java.base/java.nio.charset=ALL-UNNAMED --add-opens java.base/java.net=ALL-UNNAMED --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED -Xmx2048m -Dfile.encoding=UTF-8 -Duser.country=CN -Duser.language=en -Duser.variant -cp /Users/goooler/.gradle/wrapper/dists/gradle-7.5-all/6qsw290k5lz422uaf8jf6m7co/gradle-7.5/lib/gradle-launcher-7.5.jar org.gradle.launcher.daemon.bootstrap.GradleDaemon 7.5
Please read the following process output to find out more:
-----------------------
Unrecognized VM option 'MaxPermSize=512m'
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.

-----------------------
Check the JVM arguments defined for the gradle process in:
 - gradle.properties in project root directory
 - gradle.properties in GRADLE_USER_HOME directory
```