### PR TITLE
Native auth: Add support for claims request in getAccessToken and signIn after signUp/SSPR, Fixes AB#3188133

### DIFF
--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 vNext
 ----------
 - [MAJOR] Update minSDK to 21
+- [MINOR] Native auth: Add claimsRequest also to getAccessToken and signIn after signUp/SSPR flows (#2278)
 
 Version 5.10.0
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -532,6 +532,7 @@ public class CommandParametersAdapter {
      * @param username email address of the user
      * @param password password of the user
      * @param scopes scopes requested during sign in flow
+     * @param claimsRequest claims request object. Nullable object
      * @return Command parameter object
      * @throws ClientException
      */
@@ -587,6 +588,7 @@ public class CommandParametersAdapter {
      * @param username email address of the user
      * @param correlationId correlation ID to use in the API request, taken from the previous API response in the flow
      * @param scopes scopes requested during sign in flow
+     * @param claimsRequest claims request object. Nullable object
      * @return Command parameter object
      * @throws ClientException
      */
@@ -596,13 +598,15 @@ public class CommandParametersAdapter {
             @Nullable final String continuationToken,
             @Nullable final String username,
             @NonNull final String correlationId,
-            final List<String> scopes) throws ClientException {
+            final List<String> scopes,
+            @Nullable final ClaimsRequest claimsRequest) throws ClientException {
         final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
                 AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
                 null
         );
-
         final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+
+        final String claimsRequestJson = ClaimsRequest.getJsonStringFromClaimsRequest(claimsRequest);
 
         final SignInWithContinuationTokenCommandParameters commandParameters = SignInWithContinuationTokenCommandParameters.builder()
                 .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
@@ -621,6 +625,7 @@ public class CommandParametersAdapter {
                 .username(username)
                 .challengeType(configuration.getChallengeTypes())
                 .authenticationScheme(authenticationScheme)
+                .claimsRequestJson(claimsRequestJson)
                 .scopes(scopes)
                 .correlationId(correlationId)
                 .build();

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthGetAccessTokenParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthGetAccessTokenParameters.kt
@@ -23,6 +23,8 @@
 
 package com.microsoft.identity.nativeauth.parameters
 
+import com.microsoft.identity.client.claims.ClaimsRequest
+
 /**
  * Encapsulates the parameters passed to the getAccessToken methods of AccountState
  */
@@ -38,4 +40,9 @@ class NativeAuthGetAccessTokenParameters {
      * Not all scopes are guaranteed to be included in the access token returned.
      */
     var scopes: List<String>? = null
+
+    /**
+     *  The claims parameter that needs to be sent to the service.
+     */
+    var claimsRequest: ClaimsRequest? = null
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInContinuationParameters.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/parameters/NativeAuthSignInContinuationParameters.kt
@@ -23,6 +23,8 @@
 
 package com.microsoft.identity.nativeauth.parameters
 
+import com.microsoft.identity.client.claims.ClaimsRequest
+
 /**
  * Encapsulates the parameters passed to the signIn methods after signUp or resetPassword
  */
@@ -33,4 +35,9 @@ class NativeAuthSignInContinuationParameters {
      * Not all scopes are guaranteed to be included in the access token returned.
      */
     var scopes: List<String>? = null
+
+    /**
+     *  The claims parameter that needs to be sent to the service.
+     */
+    var claimsRequest: ClaimsRequest? = null
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/AccountState.kt
@@ -31,6 +31,7 @@ import com.microsoft.identity.client.AuthenticationResultAdapter
 import com.microsoft.identity.client.IAccount
 import com.microsoft.identity.client.IAuthenticationResult
 import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.client.claims.ClaimsRequest
 import com.microsoft.identity.client.exception.MsalClientException
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.client.internal.CommandParametersAdapter
@@ -244,7 +245,7 @@ class AccountState private constructor(
      */
     @Deprecated("This method is now deprecated. Use the method 'getAccessToken(parameters:)' instead.")
     suspend fun getAccessToken(forceRefresh: Boolean = false): GetAccessTokenResult {
-        return getAccessTokenInternal(forceRefresh, AuthenticationConstants.DEFAULT_SCOPES.toList());
+        return getAccessTokenInternal(forceRefresh, AuthenticationConstants.DEFAULT_SCOPES.toList(), null);
     }
 
     /**
@@ -266,7 +267,7 @@ class AccountState private constructor(
             )
         }
 
-        return getAccessTokenInternal(forceRefresh, scopes)
+        return getAccessTokenInternal(forceRefresh, scopes, null)
     }
 
     /**
@@ -288,7 +289,7 @@ class AccountState private constructor(
             )
         }
 
-        return getAccessTokenInternal(parameters.forceRefresh, scopes)
+        return getAccessTokenInternal(parameters.forceRefresh, scopes, parameters.claimsRequest)
     }
 
     /**
@@ -344,7 +345,7 @@ class AccountState private constructor(
         }
     }
 
-    private suspend fun getAccessTokenInternal(forceRefresh: Boolean, scopes: List<String>): GetAccessTokenResult {
+    private suspend fun getAccessTokenInternal(forceRefresh: Boolean, scopes: List<String>, claimsRequest: ClaimsRequest?): GetAccessTokenResult {
         LogSession.logMethodCall(
             tag = TAG,
             correlationId = null,
@@ -370,6 +371,7 @@ class AccountState private constructor(
                     .withCorrelationId(UUID.fromString(privateCorrelationId))
                     .forceRefresh(forceRefresh)
                     .withScopes(scopes)
+                    .withClaims(claimsRequest)
                     .build()
 
                 val accountRecord = PublicClientApplication.selectAccountRecordForTokenRequest(

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -652,7 +652,8 @@ class SignInContinuationState(
                         continuationToken,
                         username,
                         correlationId,
-                        parameters.scopes
+                        parameters.scopes,
+                        parameters.claimsRequest
                     )
 
                 val command = SignInWithContinuationTokenCommand(

--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -44,6 +44,7 @@ import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters;
 import com.microsoft.identity.common.java.providers.oauth2.OAuth2TokenCache;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.ui.PreferredAuthMethod;
@@ -452,6 +453,38 @@ public class CommandParametersTest {
         Assert.assertEquals(commandParameters.scopes, scopes);
         Assert.assertEquals(commandParameters.challengeType, challengeTypes);
         Assert.assertEquals(commandParameters.getCorrelationId(), correlationId);
+    }
+
+    @Test
+    public void createSignInWithContinuationCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+        List<String> challengeTypes = new ArrayList<>(Collections.singletonList("OOB"));
+        String continuationToken = "continuationToken";
+        String username = "username";
+        String correlationId = UUID.randomUUID().toString();
+        List<String> scopes = new ArrayList<>(Collections.singletonList("User.Read"));
+        ClaimsRequest claimsRequest = ClaimsRequest.getClaimsRequestFromJsonString("{\"access_token\":{\"acrs\":{\"essential\":true,\"value\":\"c4\"}}}");
+        NativeAuthPublicClientApplicationConfiguration configuration = new NativeAuthPublicClientApplicationConfiguration();
+        configuration.setChallengeTypes(challengeTypes);
+        configuration.setClientId("clientId");
+        configuration.setAppContext(mContext);
+        configuration.setPowerOptCheckEnabled(false);
+
+        final SignInWithContinuationTokenCommandParameters commandParameters = CommandParametersAdapter.createSignInWithContinuationTokenCommandParameters(
+                configuration,
+                null,
+                continuationToken,
+                username,
+                correlationId,
+                scopes,
+                claimsRequest
+        );
+        Assert.assertEquals(commandParameters.claimsRequestJson, ClaimsRequest.getJsonStringFromClaimsRequest(claimsRequest));
+        Assert.assertEquals(commandParameters.continuationToken, continuationToken);
+        Assert.assertEquals(commandParameters.scopes, scopes);
+        Assert.assertEquals(commandParameters.challengeType, challengeTypes);
+        Assert.assertEquals(commandParameters.getCorrelationId(), correlationId);
+        Assert.assertEquals(commandParameters.username, username);
+
     }
 
     private ClaimsRequest getAccessTokenClaimsRequest(@NonNull String claimName, @NonNull String claimValue) {


### PR DESCRIPTION
Adding support on native authentication for claims request for getAccessToken and signIn after signUp/SSPR flows.

MSAL common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2622

[AB#3188133](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3188133)