### PR TITLE
Update codeowner file. Native auth co-ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,10 @@
 
 # Shared Ownership
 #---------------------
-changelog.txt @AzureAD/androididentity @AzureAD/NativeAuthTeam
+changelog @AzureAD/androididentity @AzureAD/NativeAuthTeam
+msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java @AzureAD/androididentity @AzureAD/NativeAuthTeam
+common @AzureAD/androididentity @AzureAD/NativeAuthTeam
+msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java @AzureAD/androididentity @AzureAD/NativeAuthTeam
 
 # Area Owners
 #---------------------


### PR DESCRIPTION
Native auth and Android identity team should share ownership of:
 - changelog
 - CommandParametersAdapter
 - Test class of CommandParametersAdapter
 - common repo link