### PR TITLE
Update BrokerSelection E2E Test, Fixes AB#3285353

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2572249.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2572249.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -71,6 +72,12 @@ public class TestCase2572249 extends AbstractMsalBrokerTest {
 
     @Test
     public void test_2572249_LTW_SSOAfterLTWUninstallIfAuthenticatorPresent() throws Throwable {
+        if (BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true")) {
+            // No longer applicable with V2 protocol.
+            return;
+        }
+
+
         final String username = mLabAccount.getUsername();
         final String password = mLabAccount.getPassword();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2572294.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2572294.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -105,7 +106,13 @@ public class TestCase2572294 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584409.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584409.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -105,7 +106,13 @@ public class TestCase2584409 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584410.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584410.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -108,7 +109,13 @@ public class TestCase2584410 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584411.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584411.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -67,6 +68,7 @@ public class TestCase2584411 extends AbstractMsalBrokerTest {
                 UserType.CLOUD
         );
     }
+
     @Test
     public void test_2584411_LTW_AuthenticatorHighestPriorityAuthCPLTW() throws Throwable {
         final String username = mLabAccount.getUsername();
@@ -107,7 +109,13 @@ public class TestCase2584411 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584412.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584412.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -107,7 +108,13 @@ public class TestCase2584412 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584414.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/ltw/TestCase2584414.java
@@ -24,6 +24,7 @@ package com.microsoft.identity.client.msal.automationapp.testpass.broker.ltw;
 
 import androidx.annotation.NonNull;
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig;
 import com.microsoft.identity.client.msal.automationapp.R;
 import com.microsoft.identity.client.msal.automationapp.testpass.broker.AbstractMsalBrokerTest;
 import com.microsoft.identity.client.ui.automation.annotations.LTWTests;
@@ -107,7 +108,13 @@ public class TestCase2584414 extends AbstractMsalBrokerTest {
 
         msalTestApp.handleBackButton();
         final String activeBroker = msalTestApp.getActiveBrokerPackageName();
-        Assert.assertEquals("Active broker pkg name : " + BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME, activeBroker);
+
+        // Check flight, if v2 is enabled, LTW should have the highest priority.
+        final String activeBrokerApp = BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.contains("EnableBrokerDiscoveryV2Protocol:true") ?
+                BrokerLTW.BROKER_LTW_APP_PACKAGE_NAME :
+                BrokerMicrosoftAuthenticator.AUTHENTICATOR_APP_PACKAGE_NAME;
+
+        Assert.assertEquals("Active broker pkg name : " + activeBrokerApp, activeBroker);
     }
     @Override
     public LabQuery getLabQuery() {


### PR DESCRIPTION
[AB#3285353](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3285353)

Main PR: https://github.com/AzureAD/ad-accounts-for-android/pull/3101

We'll make ipc requests to each broker apps to get the flight values.

If the broker selection v2 flight is enabled in all 3, then we expect the new result (LTW is the broker).