### PR TITLE
Handle redirect across all endpoints and return the redirect reason to the developers, Fixes AB#3288191

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/Error.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/Error.kt
@@ -175,7 +175,7 @@ class ResendCodeError(
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): SignInResendCodeResult, SignUpResendCodeResult, ResetPasswordResendCodeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, SignInResendCodeResult, SignUpResendCodeResult, ResetPasswordResendCodeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 
 class GetAccountError(
     override val errorType: String? = null,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/GetAccessTokenError.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/GetAccessTokenError.kt
@@ -48,7 +48,7 @@ class GetAccessTokenError(
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): GetAccessTokenResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
+): BrowserRequiredError, GetAccessTokenResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
     fun isNoAccountFound() : Boolean = this.errorType == GetAccessTokenErrorTypes.NO_ACCOUNT_FOUND
 
     fun isInvalidScopes(): Boolean = this.errorType == GetAccessTokenErrorTypes.INVALID_SCOPES

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/JITErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/JITErrors.kt
@@ -10,7 +10,7 @@ class RegisterStrongAuthChallengeError(
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): RegisterStrongAuthChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, RegisterStrongAuthChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 {
     fun isInvalidInput(): Boolean = this.errorType == ErrorTypes.INVALID_INPUT
 }
@@ -22,7 +22,7 @@ class RegisterStrongAuthSubmitChallengeError(
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): RegisterStrongAuthSubmitChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, RegisterStrongAuthSubmitChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 {
     fun isInvalidChallenge(): Boolean = this.errorType == ErrorTypes.INVALID_CHALLENGE
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
@@ -66,7 +66,7 @@ class MFASubmitChallengeError(
     override val errorCodes: List<Int>? = null,
     val subError: String? = null,
     override var exception: Exception? = null
-): MFASubmitChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, MFASubmitChallengeResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
 {
     fun isInvalidChallenge(): Boolean = this.errorType == ErrorTypes.INVALID_CHALLENGE
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/ResetPasswordErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/ResetPasswordErrors.kt
@@ -84,7 +84,7 @@ class ResetPasswordSubmitPasswordError(
     override val errorCodes: List<Int>? = null,
     val subError: String? = null,
     override var exception: Exception? = null
-): ResetPasswordSubmitPasswordResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
+): BrowserRequiredError, ResetPasswordSubmitPasswordResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
 
     fun isInvalidPassword() : Boolean = this.errorType == ErrorTypes.INVALID_PASSWORD
 

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrors.kt
@@ -77,9 +77,10 @@ class SignInSubmitPasswordError(
  * @param exception an internal unexpected exception that happened.
  */
 open class SignInContinuationError(
+    override val errorType: String? = null,
     override val error: String? = null,
     override val errorMessage: String?,
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): BrowserRequiredError, SignInResult, Error(errorType = null, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, SignInResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrors.kt
@@ -61,7 +61,7 @@ class SignInSubmitPasswordError(
     override val correlationId: String,
     override  val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): SignInSubmitPasswordResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
+): BrowserRequiredError, SignInSubmitPasswordResult, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception) {
     fun isInvalidCredentials(): Boolean = this.errorType == SignInErrorTypes.INVALID_CREDENTIALS
 }
 
@@ -82,4 +82,4 @@ open class SignInContinuationError(
     override val correlationId: String,
     override val errorCodes: List<Int>? = null,
     override var exception: Exception? = null
-): SignInResult, Error(errorType = null, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+): BrowserRequiredError, SignInResult, Error(errorType = null, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/JITStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/JITStates.kt
@@ -122,6 +122,15 @@ abstract class BaseJITSubmitChallengeState(
                         )
                     )
                 }
+                is INativeAuthCommandResult.Redirect -> {
+                    RegisterStrongAuthChallengeError(
+                        errorType = ErrorTypes.BROWSER_REQUIRED,
+                        error = result.error,
+                        errorMessage = result.errorDescription,
+                        correlationId = result.correlationId,
+                        errorCodes = result.errorCodes
+                    )
+                }
             }
         }
     }
@@ -308,6 +317,15 @@ class RegisterStrongAuthVerificationRequiredState(
                 is JITCommandResult.IncorrectChallenge -> {
                     RegisterStrongAuthSubmitChallengeError(
                         errorType = ErrorTypes.INVALID_CHALLENGE,
+                        error = result.error,
+                        errorMessage = result.errorDescription,
+                        correlationId = result.correlationId,
+                        errorCodes = result.errorCodes
+                    )
+                }
+                is INativeAuthCommandResult.Redirect -> {
+                    RegisterStrongAuthSubmitChallengeError(
+                        errorType = ErrorTypes.BROWSER_REQUIRED,
                         error = result.error,
                         errorMessage = result.errorDescription,
                         correlationId = result.correlationId,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/JITStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/JITStates.kt
@@ -126,7 +126,7 @@ abstract class BaseJITSubmitChallengeState(
                     RegisterStrongAuthChallengeError(
                         errorType = ErrorTypes.BROWSER_REQUIRED,
                         error = result.error,
-                        errorMessage = result.errorDescription,
+                        errorMessage = result.redirectReason,
                         correlationId = result.correlationId,
                         errorCodes = result.errorCodes
                     )
@@ -327,7 +327,7 @@ class RegisterStrongAuthVerificationRequiredState(
                     RegisterStrongAuthSubmitChallengeError(
                         errorType = ErrorTypes.BROWSER_REQUIRED,
                         error = result.error,
-                        errorMessage = result.errorDescription,
+                        errorMessage = result.redirectReason,
                         correlationId = result.correlationId,
                         errorCodes = result.errorCodes
                     )

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
@@ -176,7 +176,7 @@ class AwaitingMFAState(
                         MFARequestChallengeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -323,7 +323,7 @@ class MFARequiredState(
                         MFAGetAuthMethodsError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -464,7 +464,7 @@ class MFARequiredState(
                         MFARequestChallengeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -573,7 +573,7 @@ class MFARequiredState(
                         MFASubmitChallengeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId,
                             errorCodes = result.errorCodes
                         )

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
@@ -568,7 +568,15 @@ class MFARequiredState(
                             errorCodes = result.errorCodes,
                             subError = result.subError
                         )
-
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        MFASubmitChallengeError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
                     }
                     is INativeAuthCommandResult.APIError -> {
                         Logger.warnWithObject(

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -271,7 +271,16 @@ class ResetPasswordCodeRequiredState internal constructor(
                         )
                     }
 
-                    is INativeAuthCommandResult.Redirect,
+                    is INativeAuthCommandResult.Redirect -> {
+                        ResendCodeError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+
                     is INativeAuthCommandResult.APIError -> {
                         Logger.warnWithObject(
                             TAG,
@@ -446,6 +455,16 @@ class ResetPasswordPasswordRequiredState internal constructor(
                                 error = result.error,
                                 errorMessage = result.errorDescription,
                                 correlationId = result.correlationId
+                            )
+                        }
+
+                        is INativeAuthCommandResult.Redirect -> {
+                            ResetPasswordSubmitPasswordError(
+                                errorType = ErrorTypes.BROWSER_REQUIRED,
+                                error = result.error,
+                                errorMessage = result.errorDescription,
+                                correlationId = result.correlationId,
+                                errorCodes = result.errorCodes
                             )
                         }
 

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordStates.kt
@@ -167,7 +167,7 @@ class ResetPasswordCodeRequiredState internal constructor(
                         SubmitCodeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -275,7 +275,7 @@ class ResetPasswordCodeRequiredState internal constructor(
                         ResendCodeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId,
                             errorCodes = result.errorCodes
                         )
@@ -462,7 +462,7 @@ class ResetPasswordPasswordRequiredState internal constructor(
                             ResetPasswordSubmitPasswordError(
                                 errorType = ErrorTypes.BROWSER_REQUIRED,
                                 error = result.error,
-                                errorMessage = result.errorDescription,
+                                errorMessage = result.redirectReason,
                                 correlationId = result.correlationId,
                                 errorCodes = result.errorCodes
                             )

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -181,7 +181,7 @@ class SignInCodeRequiredState internal constructor(
                         SubmitCodeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -291,7 +291,7 @@ class SignInCodeRequiredState internal constructor(
                         ResendCodeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId,
                             errorCodes = result.errorCodes
                         )
@@ -481,7 +481,7 @@ class SignInPasswordRequiredState(
                             SignInSubmitPasswordError(
                                 errorType = ErrorTypes.BROWSER_REQUIRED,
                                 error = result.error,
-                                errorMessage = result.errorDescription,
+                                errorMessage = result.redirectReason,
                                 correlationId = result.correlationId,
                                 errorCodes = result.errorCodes
                             )
@@ -719,7 +719,15 @@ class SignInContinuationState(
                             authMethods = result.authMethods.toListOfAuthMethods()
                         )
                     }
-                    is INativeAuthCommandResult.Redirect,
+                    is INativeAuthCommandResult.Redirect -> {
+                        SignInContinuationError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.redirectReason,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
+                    }
                     is INativeAuthCommandResult.APIError -> {
                         Logger.warnWithObject(
                             TAG,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignInStates.kt
@@ -287,7 +287,17 @@ class SignInCodeRequiredState internal constructor(
                         )
                     }
 
-                    is INativeAuthCommandResult.Redirect, is INativeAuthCommandResult.APIError -> {
+                    is INativeAuthCommandResult.Redirect -> {
+                        ResendCodeError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+
+                    is INativeAuthCommandResult.APIError -> {
                         Logger.warnWithObject(
                             TAG,
                             result.correlationId,
@@ -466,7 +476,18 @@ class SignInPasswordRequiredState(
                                 )
                             )
                         }
-                        is INativeAuthCommandResult.Redirect, is INativeAuthCommandResult.APIError -> {
+
+                        is INativeAuthCommandResult.Redirect -> {
+                            SignInSubmitPasswordError(
+                                errorType = ErrorTypes.BROWSER_REQUIRED,
+                                error = result.error,
+                                errorMessage = result.errorDescription,
+                                correlationId = result.correlationId,
+                                errorCodes = result.errorCodes
+                            )
+                        }
+
+                        is INativeAuthCommandResult.APIError -> {
                             Logger.warnWithObject(
                                 TAG,
                                 result.correlationId,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/SignUpStates.kt
@@ -198,7 +198,7 @@ class SignUpCodeRequiredState internal constructor(
                         SubmitCodeError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }
@@ -313,8 +313,16 @@ class SignUpCodeRequiredState internal constructor(
                             channel = result.challengeChannel
                         )
                     }
-
-                    is INativeAuthCommandResult.Redirect, is INativeAuthCommandResult.APIError -> {
+                    is INativeAuthCommandResult.Redirect -> {
+                        ResendCodeError(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.redirectReason,
+                            correlationId = result.correlationId,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
                         Logger.warnWithObject(
                             TAG,
                             result.correlationId,
@@ -487,7 +495,7 @@ class SignUpPasswordRequiredState internal constructor(
                             SignUpSubmitPasswordError(
                                 errorType = ErrorTypes.BROWSER_REQUIRED,
                                 error = result.error,
-                                errorMessage = result.errorDescription,
+                                errorMessage = result.redirectReason,
                                 correlationId = result.correlationId
                             )
                         }
@@ -695,7 +703,7 @@ class SignUpAttributesRequiredState internal constructor(
                         SignUpSubmitAttributesError(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
-                            errorMessage = result.errorDescription,
+                            errorMessage = result.redirectReason,
                             correlationId = result.correlationId
                         )
                     }


### PR DESCRIPTION
Fixes [AB#3288191](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3288191)

Related common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2660

Pipeline failed: SignInStates.kt: (294, 51): Unresolved reference: redirectReason - common reference