### PR TITLE
Update package inspector to generate SHA-512 along with SHA-1

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplicationConfiguration.java
@@ -772,8 +772,7 @@ public class PublicClientApplicationConfiguration {
                 if (AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_RELEASE_SIGNATURE_SHA512.equalsIgnoreCase(sha512_signingCertThumbprint)
                         || AuthenticationConstants.Broker.AZURE_AUTHENTICATOR_APP_DEBUG_SIGNATURE_SHA512.equalsIgnoreCase(sha512_signingCertThumbprint)) {
 
-                    // MSAL still uses SHA-1 format in redirect url.
-                    final MessageDigest md_sha1 = MessageDigest.getInstance("SHA");
+                    final MessageDigest md_sha1 = MessageDigest.getInstance("SHA"); // CodeQL [SM05136] MSAL still uses SHA-1 format in redirect url.
                     md_sha1.update(signature.toByteArray());
                     final String sha1_signingCertThumbprint = Base64.encodeToString(md_sha1.digest(), Base64.NO_WRAP);
 

--- a/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
+++ b/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
@@ -139,18 +139,24 @@ public class MainActivity extends AppCompatActivity {
                             getPackageManagerFlag()
                     );
 
-                    String packageSigningSha = "";
+                    String signingCertificateHashes = "";
 
                     final Signature[] signatures = getSignatures(packageInfo);
                     if (null != signatures
                             && signatures.length > 0) {
                         final Signature signature = signatures[0];
-                        final MessageDigest digest = MessageDigest.getInstance("SHA");
-                        digest.update(signature.toByteArray());
-                        packageSigningSha = Base64.encodeToString(digest.digest(), Base64.NO_WRAP);
+                        final MessageDigest digestSha1 = MessageDigest.getInstance("SHA"); // CodeQL [SM05136] This is only for test purposes, not used in production.
+                        digestSha1.update(signature.toByteArray());
+                        final String packageSigningSha1 = Base64.encodeToString(digestSha1.digest(), Base64.NO_WRAP);
+
+                        final MessageDigest digestSha512 = MessageDigest.getInstance("SHA-512");
+                        digestSha512.update(signature.toByteArray());
+                        final String  packageSigningSha512 = Base64.encodeToString(digestSha512.digest(), Base64.NO_WRAP);
+
+                        signingCertificateHashes = "SHA-1: " + packageSigningSha1 + "\nSHA-512: " + packageSigningSha512;
                     }
 
-                    String msg = packageSigningSha;
+                    String msg = signingCertificateHashes;
 
                     if (isAnAuthenticatorApp(pkgName)) {
                         msg += "\n\n" + getAuthenticatorAppMetadata(pkgName);

--- a/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
+++ b/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
@@ -151,7 +151,7 @@ public class MainActivity extends AppCompatActivity {
 
                         final MessageDigest digestSha512 = MessageDigest.getInstance("SHA-512");
                         digestSha512.update(signature.toByteArray());
-                        final String  packageSigningSha512 = Base64.encodeToString(digestSha512.digest(), Base64.NO_WRAP);
+                        final String packageSigningSha512 = Base64.encodeToString(digestSha512.digest(), Base64.NO_WRAP);
 
                         signingCertificateHashes = "SHA-1: " + packageSigningSha1 + "\nSHA-512: " + packageSigningSha512;
                     }

--- a/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
+++ b/package-inspector/src/main/java/com/microsoft/inspector/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends AppCompatActivity {
                     if (null != signatures
                             && signatures.length > 0) {
                         final Signature signature = signatures[0];
-                        final MessageDigest digestSha1 = MessageDigest.getInstance("SHA"); // CodeQL [SM05136] This is only for test purposes, not used in production.
+                        final MessageDigest digestSha1 = MessageDigest.getInstance("SHA-1"); // CodeQL [SM05136] This is only for test purposes, not used in production.
                         digestSha1.update(signature.toByteArray());
                         final String packageSigningSha1 = Base64.encodeToString(digestSha1.digest(), Base64.NO_WRAP);
 


### PR DESCRIPTION
Additionally, I suppress a CodeQL regarding the use of SHA-1, why because we are still using sha1 in the redirect urls and we cannot force apps to update the signature.