### PR TITLE
Refactor ShadowAndroidSdkStorageEncryptionManager to use ISecretKeyProvider for key management, Fixes AB#3297746

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAndroidSdkStorageEncryptionManager.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAndroidSdkStorageEncryptionManager.java
@@ -23,8 +23,8 @@
 package com.microsoft.identity.client.e2e.shadows;
 
 import com.microsoft.identity.common.crypto.AndroidAuthSdkStorageEncryptionManager;
-import com.microsoft.identity.common.java.crypto.key.PredefinedKeyLoader;
-import com.microsoft.identity.common.java.crypto.key.AES256KeyLoader;
+import com.microsoft.identity.common.java.crypto.key.PredefinedKeyProvider;
+import com.microsoft.identity.common.java.crypto.key.ISecretKeyProvider;
 
 import org.robolectric.annotation.Implements;
 
@@ -35,14 +35,14 @@ import java.util.List;
 public class ShadowAndroidSdkStorageEncryptionManager {
 
     final byte[] encryptionKey = new byte[]{22, 78, -69, -66, 84, -65, 119, -9, -34, -80, 60, 67, -12, -117, 86, -47, -84, -24, -18, 121, 70, 32, -110, 51, -93, -10, -93, -110, 124, -68, -42, -119};
-    final AES256KeyLoader mUserDefinedKey = new PredefinedKeyLoader("MOCK_ALIAS", encryptionKey);
+    final ISecretKeyProvider mUserDefinedKey = new PredefinedKeyProvider("MOCK_ALIAS", encryptionKey);
 
-    public  AES256KeyLoader getKeyLoaderForEncryption() {
+    public ISecretKeyProvider getKeyProviderForEncryption() {
         return mUserDefinedKey;
     }
 
-    public List<AES256KeyLoader> getKeyLoaderForDecryption(byte[] cipherText) {
-        return new ArrayList<AES256KeyLoader>() {{
+    public List<ISecretKeyProvider> getKeyProviderForDecryption(byte[] cipherText) {
+        return new ArrayList<ISecretKeyProvider>() {{
             add(mUserDefinedKey);
         }};
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAndroidSdkStorageEncryptionManager.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/shadows/ShadowAndroidSdkStorageEncryptionManager.java
@@ -28,7 +28,7 @@ import com.microsoft.identity.common.java.crypto.key.ISecretKeyProvider;
 
 import org.robolectric.annotation.Implements;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Implements(AndroidAuthSdkStorageEncryptionManager.class)
@@ -42,8 +42,6 @@ public class ShadowAndroidSdkStorageEncryptionManager {
     }
 
     public List<ISecretKeyProvider> getKeyProviderForDecryption(byte[] cipherText) {
-        return new ArrayList<ISecretKeyProvider>() {{
-            add(mUserDefinedKey);
-        }};
+        return Collections.singletonList(mUserDefinedKey);
     }
 }


### PR DESCRIPTION
Update necessary from: 
https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2666

[AB#3297746](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3297746)