### PR TITLE
[Android SDK] Change Native Auth E2E tests variables, Fixes AB#3320709

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -60,7 +60,7 @@ jobs:
   - task: Gradle@2
     displayName: Run Unit tests
     inputs:
-      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL)
+      tasks: msal:testLocalDebugUnitTest -Plabtest -PlabSecret=$(LabVaultAppCert) -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)
       javaHomeSelection: $(BuildParameters.javaHomeSelection)
       jdkVersion: 1.17
 - job: spotbugs

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -185,7 +185,8 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
                 }
             }
         } catch (e: IOException) {
-            e.printStackTrace()
+            android.util.Log.e("NativeAuthTest", "Failed to read config file: $filePath", e)
+            throw RuntimeException("Error reading config file: $filePath", e)
         }
         return sb.toString()
     }

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -103,15 +103,15 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
     }
 
     private fun getConfigsThroughBuildValue(): Map<String, NativeAuthTestConfig.Config>? {
-        // We are no longer fetching the config from the Key Vault, we are using a BuildConfig value
-        // val secretValue = KeyVaultFetchHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
         var buildConfigString = BuildValues.getNativeAuthConfigString()
         // If the buildConfigString is null or empty, we will try to read the config from the file path
-        if (buildConfigString == null || buildConfigString.isEmpty()) {
+        if (buildConfigString.isNullOrBlank()) {
             val buildConfigFilePath = BuildValues.getNativeAuthConfigFilePath()
             // If the build config file path is set, read the file and set buildConfigString to its content
             if (buildConfigFilePath != null && buildConfigFilePath.isNotEmpty()) {
                 buildConfigString = readConfigFile(buildConfigFilePath)
+            } else {
+                throw IllegalStateException("Native auth config file pipeline variable or local file path not found")
             }
         }
         val type = TypeToken.getParameterized(

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/NativeAuthPublicClientApplicationAbstractTest.kt
@@ -32,8 +32,8 @@ import com.microsoft.identity.client.e2e.shadows.ShadowAndroidSdkStorageEncrypti
 import com.microsoft.identity.client.e2e.tests.IPublicClientApplicationTest
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper
+import com.microsoft.identity.common.java.nativeauth.BuildValues
 import com.microsoft.identity.internal.testutils.TestUtils
-import com.microsoft.identity.internal.testutils.labutils.KeyVaultFetchHelper
 import com.microsoft.identity.internal.testutils.labutils.LabConstants
 import com.microsoft.identity.internal.testutils.labutils.LabUserHelper
 import com.microsoft.identity.internal.testutils.labutils.LabUserQuery
@@ -52,6 +52,10 @@ import org.mockito.Mockito
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.LooperMode
+import java.io.BufferedReader
+import java.io.FileInputStream
+import java.io.IOException
+import java.io.InputStreamReader
 
 // TODO: move to "PAUSED". A work in RoboTestUtils will be needed though.
 @LooperMode(LooperMode.Mode.LEGACY)
@@ -98,19 +102,29 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
         return credential.password
     }
 
-    private fun getConfigsThroughSecretValue(): Map<String, NativeAuthTestConfig.Config>? {
-        val secretValue = KeyVaultFetchHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
+    private fun getConfigsThroughBuildValue(): Map<String, NativeAuthTestConfig.Config>? {
+        // We are no longer fetching the config from the Key Vault, we are using a BuildConfig value
+        // val secretValue = KeyVaultFetchHelper.getSecretForBuildAutomation("msalandroidnativeauthautomationconfjsonfile")
+        var buildConfigString = BuildValues.getNativeAuthConfigString()
+        // If the buildConfigString is null or empty, we will try to read the config from the file path
+        if (buildConfigString == null || buildConfigString.isEmpty()) {
+            val buildConfigFilePath = BuildValues.getNativeAuthConfigFilePath()
+            // If the build config file path is set, read the file and set buildConfigString to its content
+            if (buildConfigFilePath != null && buildConfigFilePath.isNotEmpty()) {
+                buildConfigString = readConfigFile(buildConfigFilePath)
+            }
+        }
         val type = TypeToken.getParameterized(
             Map::class.java,
             String::class.java,
             NativeAuthTestConfig.Config::class.java
         ).type
 
-        return Gson().fromJson(secretValue, type)
+        return Gson().fromJson(buildConfigString, type)
     }
 
     fun getConfig(configType: ConfigType): NativeAuthTestConfig.Config {
-        val secretValue = getConfigsThroughSecretValue()
+        val secretValue = getConfigsThroughBuildValue()
         return secretValue?.get(configType.stringValue)
             ?: throw IllegalStateException("Config not $secretValue")
     }
@@ -156,5 +170,23 @@ abstract class NativeAuthPublicClientApplicationAbstractTest : IPublicClientAppl
                 }
             }
         }
+    }
+
+    private fun readConfigFile(filePath: String): String {
+        val sb = StringBuilder()
+        try {
+            FileInputStream(filePath).use { inputStream ->
+                BufferedReader(InputStreamReader(inputStream)).use { reader ->
+                    var line: String? = reader.readLine()
+                    while (line != null) {
+                        sb.append(line)
+                        line = reader.readLine()
+                    }
+                }
+            }
+        } catch (e: IOException) {
+            e.printStackTrace()
+        }
+        return sb.toString()
     }
 }


### PR DESCRIPTION
This PR introduces the following:
-Add NATIVE_AUTH_CONFIG_STRING to Pipeline variables and use it in scripts to run E2E tests instead of the KeyVault
-Add NATIVE_AUTH_CONFIG_FILE_PATH to be used locally from build settings and use it in scripts to run E2E tests
This PR is connected to the MSAL Android Common PR [[Android SDK] Change Native Auth E2E tests variables, Fixes AB#3320709](https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2708)