### PR TITLE
Re-enable Phone Sign Up Option Test

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/msa/TestCase3040042.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/msa/TestCase3040042.kt
@@ -39,7 +39,6 @@ import org.junit.Test
 // [Brokered] When Broker Installed, OneDrive and Office should show phone sign up option, Outlook should not
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3040042
 @RetryOnFailure
-@Ignore("Flow is currently not working, Outlook is showing phone sign up option")
 class TestCase3040042 : AbstractMsalBrokerTest(){
 
     @Test


### PR DESCRIPTION
Enabling Phone signup option test again, as the changes are not deployed to WW.

Tested Locally using the URL redirects. The test can run on 08/10/2025 weekly run