### PR TITLE
ignore 3 federated tests

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561147.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561147.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -47,6 +48,7 @@ import java.util.Arrays;
 // [Joined][MSAL] Broker Auth - Federated User
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1561147
 @RetryOnFailure(retryCount = 2)
+@Ignore("Federated Account in LAB is not working at the moment")
 public class TestCase1561147 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561147_Joined_FederatedUser() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase833553.java
@@ -42,6 +42,7 @@ import com.microsoft.identity.labapi.utilities.constants.GuestHomedIn;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -49,6 +50,7 @@ import java.util.Arrays;
 // [MSAL] Broker Auth for Non-Joined Account (Federated User)
 // https://identitydivision.visualstudio.com/DevEx/_workitems/edit/833553
 @RetryOnFailure()
+@Ignore("Federated Account in LAB is not working at the moment")
 public class TestCase833553 extends AbstractMsalBrokerTest {
     @Test
     public void test_833553_NonJoined_Federated() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938368.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/msalonly/usgov/TestCase938368.java
@@ -46,6 +46,7 @@ import com.microsoft.identity.labapi.utilities.constants.AzureEnvironment;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 import com.microsoft.identity.labapi.utilities.constants.UserType;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -57,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 // Adding a retry on failure, sometimes arlington login page fails to load
 @RetryOnFailure(retryCount = 2)
 @RunOnAPI29Minus("Speed Bump Page")
+@Ignore("Federated Account in LAB is not working at the moment")
 public class TestCase938368 extends AbstractMsalUiTest {
 
     @Test


### PR DESCRIPTION
ignore 3 federated tests

These tests use a lab api which currently does not have VMs allocated for federated auth. Ignoring these tests as they are currently failing as false flags.