### PR TITLE
Add null checks for guest account ids, Fixes AB#3330213

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Add null checks for guest account ids (#2361)
 
 Version 7.0.1
 ----------

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -60,7 +60,9 @@ public class AccountAdapter {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
 
-                if (!acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (acctHomeAccountId != null
+                        && acctLocalAccountId != null
+                        && !acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }

--- a/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AccountAdapter.java
@@ -54,15 +54,23 @@ public class AccountAdapter {
 
         @Override
         public List<ICacheRecord> filter(@NonNull List<ICacheRecord> records) {
+            final String methodTag = TAG + ":GuestAccountFilter";
             final List<ICacheRecord> result = new ArrayList<>();
 
             for (final ICacheRecord cacheRecord : records) {
                 final String acctHomeAccountId = cacheRecord.getAccount().getHomeAccountId();
                 final String acctLocalAccountId = cacheRecord.getAccount().getLocalAccountId();
+                boolean isValid = true;
 
-                if (acctHomeAccountId != null
-                        && acctLocalAccountId != null
-                        && !acctHomeAccountId.contains(acctLocalAccountId)) {
+                if (acctHomeAccountId == null) {
+                    Logger.warn(methodTag, "Home account ID is null for entry.");
+                    isValid = false;
+                }
+                if (acctLocalAccountId == null) {
+                    Logger.warn(methodTag, "Local account ID is null for entry.");
+                    isValid = false;
+                }
+                if (isValid && !acctHomeAccountId.contains(acctLocalAccountId)) {
                     result.add(cacheRecord);
                 }
             }


### PR DESCRIPTION
### Summary
[AB#3330213](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3330213)

We got a report from a partner team that they were seeing very low amounts (like 5 instances) of an NPE related to AccountAdapter. Looking at past related issues, this seems like some account entry data got malformed for particular accounts/devices, perhaps due to very old broker versions. The patch in this PR is to add null checks for both the home and local id from the guest account, and if either are null, then it won't be added to the guest account array.