### PR TITLE
Native auth: add new SDK error when auth method is blocked, Fixes AB#3313635

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/Error.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/Error.kt
@@ -87,6 +87,12 @@ internal class ErrorTypes {
         const val VERIFICATION_CONTACT_BLOCKED = "verification_contact_blocked"
 
         /*
+         * The AUTH_METHOD_BLOCKED value indicates that the server blocked the strong authentication method.
+         * Try contacting customer support to seek assistance.
+         */
+        const val AUTH_METHOD_BLOCKED = "auth_method_blocked"
+
+        /*
          * The INVALID_STATE value indicates a misconfigured or expired state, or an internal error
          * in state transitions. If this occurs, the flow should be restarted.
          */

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrors.kt
@@ -24,6 +24,9 @@ class MFARequestChallengeError(
     val subError: String? = null,
     override var exception: Exception? = null
 ): MFARequiredResult, BrowserRequiredError, Error(errorType = errorType, error = error, errorMessage= errorMessage, correlationId = correlationId, errorCodes = errorCodes, exception = exception)
+{
+    fun isAuthMethodBlocked(): Boolean = this.errorType == ErrorTypes.AUTH_METHOD_BLOCKED
+}
 
 /**
  * MFA submit challenge error. The user should use the utility methods of this class

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAStates.kt
@@ -94,7 +94,7 @@ class AwaitingMFAState(
     }
 
     /**
-     * Requests a challenge to be sent to the user's default authentication method; Kotlin coroutines variant.
+     * Requests a challenge to be sent to the authentication method; Kotlin coroutines variant.
      *
      * <strong><u>Warning: this API is experimental. It may be changed in the future without notice. Do not use in production applications.</u></strong>
      * @return The result of the request challenge action.
@@ -162,6 +162,14 @@ class AwaitingMFAState(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.redirectReason,
+                            correlationId = result.correlationId
+                        )
+                    }
+                    is MFACommandResult.BlockedAuthMethod -> {
+                        MFARequestChallengeError(
+                            errorType = ErrorTypes.AUTH_METHOD_BLOCKED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
                             correlationId = result.correlationId
                         )
                     }
@@ -245,7 +253,7 @@ class MFARequiredState(
     }
 
     /**
-     * Requests a challenge to be sent to the user's default authentication method; Kotlin coroutines variant.
+     * Requests a challenge to be sent to authentication method; Kotlin coroutines variant.
      *
      * <strong><u>Warning: this API is experimental. It may be changed in the future without notice. Do not use in production applications.</u></strong>
      * @param authMethod [com.microsoft.identity.nativeauth.AuthMethod] the authentication method used for the challenge operation.
@@ -315,6 +323,14 @@ class MFARequiredState(
                             errorType = ErrorTypes.BROWSER_REQUIRED,
                             error = result.error,
                             errorMessage = result.redirectReason,
+                            correlationId = result.correlationId
+                        )
+                    }
+                    is MFACommandResult.BlockedAuthMethod -> {
+                        MFARequestChallengeError(
+                            errorType = ErrorTypes.AUTH_METHOD_BLOCKED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
                             correlationId = result.correlationId
                         )
                     }


### PR DESCRIPTION
This PR adds a new SDK error with instructions when the auth method is blocked during MFA flow.

MSAL Common PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2772

Fixes [AB#3313635](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3313635)