### PR TITLE
Add domainHint support to acquireTokenParameters, Fixes AB#3385486

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AcquireTokenParameters.java
@@ -41,6 +41,7 @@ public class AcquireTokenParameters extends TokenParameters {
     private Activity mActivity;
     private Fragment mFragment;
     private String mLoginHint;
+    private String mDomainHint;
     private Prompt mPrompt;
     private List<String> mExtraScopesToConsent;
     private List<Map.Entry<String, String>> mExtraQueryStringParameters;
@@ -53,6 +54,7 @@ public class AcquireTokenParameters extends TokenParameters {
         mActivity = builder.mActivity;
         mFragment = builder.mFragment;
         mLoginHint = builder.mLoginHint;
+        mDomainHint = builder.mDomainHint;
         mPreferredAuthMethod = builder.mPreferredAuthMethod;
         mPrompt = builder.mPrompt;
         mExtraScopesToConsent = builder.mExtraScopesToConsent;
@@ -90,6 +92,24 @@ public class AcquireTokenParameters extends TokenParameters {
      */
     void setLoginHint(String loginHint) {
         this.mLoginHint = loginHint;
+    }
+
+    /**
+     * Optional. Gets the domain hint sent along with the authorization request.
+     *
+     * @return
+     */
+    public String getDomainHint() {
+        return mDomainHint;
+    }
+
+    /**
+     * Sets the domain hint sent along with the authorization request.
+     *
+     * @param domainHint
+     */
+    void setDomainHint(String domainHint) {
+        this.mDomainHint = domainHint;
     }
 
     /**
@@ -152,7 +172,7 @@ public class AcquireTokenParameters extends TokenParameters {
         private Activity mActivity;
         private Fragment mFragment;
         private String mLoginHint;
-
+        private String mDomainHint;
         private PreferredAuthMethod mPreferredAuthMethod;
         private Prompt mPrompt;
         private List<String> mExtraScopesToConsent;
@@ -171,6 +191,11 @@ public class AcquireTokenParameters extends TokenParameters {
 
         public AcquireTokenParameters.Builder withLoginHint(String loginHint) {
             mLoginHint = loginHint;
+            return self();
+        }
+
+        public AcquireTokenParameters.Builder withDomainHint(String domainHint) {
+            mDomainHint = domainHint;
             return self();
         }
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -192,6 +192,7 @@ public class CommandParametersAdapter {
                         parameters.getExtraQueryStringParameters(),
                         configuration))
                 .loginHint(getLoginHint(parameters))
+                .domainHint(getDomainHint(parameters))
                 .account(parameters.getAccountRecord())
                 .authenticationScheme(authenticationScheme)
                 .authorizationAgent(getAuthorizationAgent(configuration))
@@ -1282,6 +1283,10 @@ public class CommandParametersAdapter {
         } else {
             return parameters.getLoginHint();
         }
+    }
+
+    private static String getDomainHint(@NonNull final AcquireTokenParameters parameters) {
+        return parameters.getDomainHint();
     }
 
     private static AuthorizationAgent getAuthorizationAgent(@NonNull final PublicClientApplicationConfiguration configuration) {


### PR DESCRIPTION
[AB#3385486](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3385486)

This PR adds the domainHint parameters into acquireTokenParameters and has a dependency on https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2792

DomainHint is added the SDK to streamline developer experience for Social IdP/Custom OIDC scenarios with MSAL SDK. Today developer can use extraQueryParameters as a alternative which required developer to type in "domain_hint".