### PR TITLE
Print library variant being built in assemble task, Fixes AB#3412918

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -138,6 +138,14 @@ android {
         }
     }
 
+    libraryVariants.all { variant ->
+        tasks.named("assemble${variant.name.capitalize()}").configure {
+            doFirst {
+                println("Assembling variant: ${variant.name} for ${project.name}")
+            }
+        }
+    }
+
     testOptions {
         unitTests.all {
             if (!project.hasProperty('labtest')) {


### PR DESCRIPTION
Print library variant being built in assemble task. This should help as a sanity check during pipeline runs

[AB#3412918](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3412918)