### PR TITLE
Ignore some UI tests that use ResetApi, EnablePolicyApi, Fixes AB#3424041

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -138,6 +138,14 @@ android {
         }
     }
 
+    libraryVariants.all { variant ->
+        tasks.named("assemble${variant.name.capitalize()}").configure {
+            doFirst {
+                println("Assembling variant: ${variant.name} for ${project.name}")
+            }
+        }
+    }
+
     testOptions {
         unitTests.all {
             if (!project.hasProperty('labtest')) {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/joined/TestCase1561151.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -51,6 +52,7 @@ import java.util.concurrent.TimeUnit;
 @RetryOnFailure
 @LongUIAutomationTest("Password reset test")
 @RunOnAPI29Minus
+@Ignore("Ignore until lab issue is resolved for Reset API")
 public class TestCase1561151 extends AbstractMsalBrokerTest {
     @Test
     public void test_1561151_Joined_PasswordChange() throws Throwable {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase850457.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -50,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 @RetryOnFailure
 @LongUIAutomationTest("Password reset test")
 @RunOnAPI29Minus
+@Ignore("Ignore until lab issue is resolved for Reset API")
 public class TestCase850457 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase1561152.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -52,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 @RetryOnFailure
 @LongUIAutomationTest("Password reset test")
 @RunOnAPI29Minus
+@Ignore("Ignore until lab issue is resolved for Reset API")
 public class TestCase1561152 extends AbstractMsalBrokerTest {
 
     @Test

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase2139526.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/nonjoined/TestCase2139526.java
@@ -40,6 +40,7 @@ import com.microsoft.identity.labapi.utilities.client.LabQuery;
 import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -49,6 +50,7 @@ import java.util.concurrent.TimeUnit;
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/2139526
 @RetryOnFailure
 @LongUIAutomationTest
+@Ignore("Ignore until lab issue is resolved for Enable Policy API")
 public class TestCase2139526 extends AbstractMsalBrokerTest {
 
     @Test


### PR DESCRIPTION
There are some functions that still don't work from lab api. This PR ignores 4 tests that use these apis.

Common PR to fix lab api calls: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2809

[AB#3424041](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3424041)