### PR TITLE
Move our Libraries to only use artifact feed for packages, no Maven Central, Fixes AB#3395409

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -41,8 +41,8 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - bash: |
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
     displayName: 'Set VSTS Fields in Environment'
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
@@ -89,8 +89,8 @@ jobs:
     submodules: recursive
     persistCredentials: True
   - bash: |
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
     displayName: 'Set VSTS Fields in Environment'
   - task: Gradle@3
     displayName: Lint Local debug

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -77,6 +77,10 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - template: azure-pipelines/templates/steps/spotbugs.yml@common
     parameters:
       project: msal

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -40,10 +40,6 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
-  - bash: |
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
-      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
-    displayName: 'Set VSTS Fields in Environment'
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
     displayName: Use Java 17

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -80,6 +80,8 @@ jobs:
   - template: azure-pipelines/templates/steps/spotbugs.yml@common
     parameters:
       project: msal
+      vstsUsernameVariable: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
+      vstsAccessTokenVariable: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
 - job: lint
   displayName: Lint
   cancelTimeoutInMinutes: 1

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -40,6 +40,10 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
     displayName: Use Java 17
@@ -84,11 +88,10 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
-  - task: CmdLine@1
-    displayName: Set Office MVN Access Token in Environment
-    inputs:
-      filename: echo
-      arguments: '##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)'
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - task: Gradle@3
     displayName: Lint Local debug
     inputs:

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -80,8 +80,6 @@ jobs:
   - template: azure-pipelines/templates/steps/spotbugs.yml@common
     parameters:
       project: msal
-      vstsUsernameVariable: ENV_VSTS_MVN_ANDROID_MSAL_USERNAME
-      vstsAccessTokenVariable: ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN
 - job: lint
   displayName: Lint
   cancelTimeoutInMinutes: 1

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -40,6 +40,10 @@ jobs:
     clean: true
     submodules: recursive
     persistCredentials: True
+  - bash: |
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_USERNAME]VSTS"
+      echo "##vso[task.setvariable variable=ENV_VSTS_MVN_CRED_ACCESSTOKEN]$(System.AccessToken)"
+    displayName: 'Set VSTS Fields in Environment'
   - template: azure-pipelines/templates/steps/automation-cert.yml@common
   - task: JavaToolInstaller@0
     displayName: Use Java 17

--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ buildscript {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
             credentials {
-                username project.vstsUsername
-                password project.vstsPassword
+                username project.ext.vstsUsername
+                password project.ext.vstsPassword
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 
 allprojects {
     repositories {
-//        google()
+        google()
         mavenLocal()
         maven {
             name "vsts-maven-adal-android"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Load credentials for VSTS Maven
 project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsPassword = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
@@ -33,7 +33,7 @@ allprojects {
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.vstsUsername
-                password project.vstsPassword
+                password project.vstsMavenAccessToken
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,15 @@ buildscript {
 
     repositories {
         google()
+        maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
+                password System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+            }
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,14 @@ buildscript {
 
     repositories {
         google()
-        mavenCentral()
+        maven {
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username project.vstsUsername
+                password project.vstsPassword
+            }
+        }
     }
 
     dependencies {
@@ -20,12 +27,6 @@ allprojects {
     repositories {
         google()
         mavenLocal()
-        mavenCentral()
-        // Adding here because Travis cannot access AndroidADAL feed.
-        maven {
-            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
-            name 'Duo-SDK-Feed'
-        }
         maven {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ buildscript {
 
     repositories {
         google()
-        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
 
     repositories {
+        mavenLocal()
         google()
     }
 
@@ -19,6 +20,11 @@ allprojects {
     repositories {
         google()
         mavenLocal()
+        // Adding here because Travis cannot access AndroidADAL feed.
+        maven {
+            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
+            name 'Duo-SDK-Feed'
+        }
         maven {
             name "vsts-maven-adal-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         google()
         maven {
             // msazure and aria are consumed via upstream sources of the NewAndroid feed.
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
@@ -29,7 +29,7 @@ allprojects {
         google()
         mavenLocal()
         maven {
-            name "vsts-maven-adal-android"
+            name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.vstsUsername

--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,21 @@
 // Load credentials for VSTS Maven
-project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+project.ext.vstsUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+project.ext.vstsMavenAccessToken = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 
 buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
 
     repositories {
+        // If you don't have access to the package feed uncomment these repositories
+        // mavenCentral()
         google()
         maven {
             // msazure and aria are consumed via upstream sources of the NewAndroid feed.
             name "vsts-maven-new-android"
             url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
-                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-                password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+                password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
             }
         }
     }
@@ -26,6 +28,8 @@ buildscript {
 
 allprojects {
     repositories {
+        // If you don't have access to the package feed uncomment these repositories
+        // mavenCentral()
         google()
         mavenLocal()
         maven {

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,16 @@ buildscript {
     apply from: rootProject.file("gradle/versions.gradle")
 
     repositories {
-        mavenLocal()
         google()
+        maven {
+            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            name "vsts-maven-adal-android"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            credentials {
+                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
+                password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+            }
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,9 @@ buildscript {
     repositories {
         google()
         maven {
-            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
+            // msazure and aria are consumed via upstream sources of the NewAndroid feed.
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
                 password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
@@ -26,16 +26,11 @@ buildscript {
 
 allprojects {
     repositories {
-        google()
+//        google()
         mavenLocal()
-        // Adding here because Travis cannot access AndroidADAL feed.
-        maven {
-            url 'https://pkgs.dev.azure.com/MicrosoftDeviceSDK/DuoSDK-Public/_packaging/Duo-SDK-Feed/maven/v1'
-            name 'Duo-SDK-Feed'
-        }
         maven {
             name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+            url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
             credentials {
                 username project.vstsUsername
                 password project.vstsPassword

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,6 @@ buildscript {
 
     repositories {
         google()
-        maven {
-            // msazure and aria are consumed via upstream sources of the AndroidADAL feed.
-            name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
-            credentials {
-                username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-                password System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROIDADACCOUNTS_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
-            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,14 +7,6 @@ buildscript {
 
     repositories {
         google()
-        maven {
-            name "vsts-maven-adal-android"
-            url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
-            credentials {
-                username project.ext.vstsUsername
-                password project.ext.vstsPassword
-            }
-        }
     }
 
     dependencies {

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MINOR] Remove MavenCentral repository from build.gradle files (#2413)
 
 Version 8.1.0
 ----------

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -360,7 +360,7 @@ afterEvaluate {
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
                     password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -360,7 +360,7 @@ afterEvaluate {
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
                     password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -362,8 +362,8 @@ afterEvaluate {
                 name "vsts-maven-adal-android"
                 url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
-                    username System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_USERNAME") : project.findProperty("vstsUsername")
-                    password System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_ANDROID_MSAL_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
+                    username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
+                    password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
                 }
             }
         }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,8 @@
 pluginManagement {
      // Note: Since our plugin references the android plugin we need to include google() here.
      repositories {
+         // If you don't have access to the package feed uncomment these repositories
+         //  mavenCentral()
          google()
          gradlePluginPortal()
      }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,8 +1,7 @@
 pluginManagement {
-     // Note: Since our plugin references the android plugin we need to include google() and mavenCentral() here.
+     // Note: Since our plugin references the android plugin we need to include google() here.
      repositories {
          google()
-         mavenCentral()
          gradlePluginPortal()
      }
  }


### PR DESCRIPTION
Received an s360 item asking our libraries to always pull packages from feeds, and not declare mavenCentral as a repository to source dependencies. The feed itself has maven as an upstream. We cannot use AndroidADAL feed as that one has some versions deleted (once a version is deleted from a feed, it cannot be restored, even if an upstream has it). Created a new feed to support this https://identitydivision.visualstudio.com/Engineering/_artifacts/feed/NewAndroid. We pull packages from this new feed, but we still publish our versions to AndroidADAL. The new feed has AndroidADAL as an upstream still, so our existing collection of artifacts is still accessible.

I also took this chance to consolidate the Maven VSTS Username and Access Token fields, which are fields used to authenticate and pull artifacts from the feed. Previously, each library had their own names for these fields with an identifier based on the library in question. These PRs make it so all libraries use the same names, `ENV_VSTS_MVN_CRED_USERNAME` and `ENV_VSTS_MVN_CRED_ACCESSTOKEN`.

Validation: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1568877&view=results

[AB#3395409](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3395409)

