### PR TITLE
Updating testDeviceCodeFlowTokenExpiredToken unit test, Fixes AB#3468472

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/DeviceCodeFlowApiTest.java
@@ -197,8 +197,7 @@ public class DeviceCodeFlowApiTest extends PublicClientApplicationAbstractTest {
 
         // Previously authenticated code
         tokenRequest.setDeviceCode(
-                "BAQABIQEAAADnfolhJpSnRYB1SVj-Hgd8CWNtqmssVukUXfdCHy1XJMxy2O7R0WZgTVcQVF4A3fjnWPQ1JPXf-"
-                        + "SIl-NLuC9gGzGRgsLyUyknjbUReNC7vcHx8jigGiO2CkKi_Mc_YRU0E0lGH3EQZiJNwHxUc_YkTGG5DKl9sww36TdMPz-v7Bzy6cHzR6r3yQWULGNtidaogAA");
+                "EAQABIQEAAABlMNzVhAPUTrARzfQjWPtKRXZvU3RzQXJ0aWZhY3RzAQAAAAAAPYh9V3CvjvOB825bqyY61Bde3S6FzapbES5Yr5kuUdO4amvrqBW9JTaXBUIH9PMoK7yFKza-nSqRHL0yoxYNHhkg0f1_juE50MlJSvdXBWJEsHHZk2y2T5804dMx1QZX0739imnhE0Y9Lm1Wd5iFbaTQZrcD9oKgxxKRL8GavO4gAA");
 
         final TokenResult tokenResult = strategy.requestToken(tokenRequest);
         Assert.assertNull(tokenResult.getTokenResponse());


### PR DESCRIPTION
This test has been failing again with invalid_grant; this is because the expired device code value we used is now "expired" (server side not recognizing it as a previous code anymore). So we need to update this value.

Also updating common submodule while I'm at it.

[AB#3468472](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3468472)