### PR TITLE
code cleanup - skip eSTS telemetry Fixes AB#3493850

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/mocked/AcquireTokenMockedTelemetryTest.java
@@ -35,7 +35,6 @@ import com.microsoft.identity.client.e2e.tests.AcquireTokenAbstractTest;
 import com.microsoft.identity.client.e2e.utils.AcquireTokenTestHelper;
 import com.microsoft.identity.common.internal.controllers.CommandDispatcherHelper;
 import com.microsoft.identity.common.java.eststelemetry.PublicApiId;
-import com.microsoft.identity.common.java.eststelemetry.EstsTelemetry;
 import com.microsoft.identity.common.java.eststelemetry.SchemaConstants;
 import com.microsoft.identity.common.java.exception.ClientException;
 import com.microsoft.identity.common.java.net.HttpClient;
@@ -127,7 +126,6 @@ public class AcquireTokenMockedTelemetryTest extends AcquireTokenAbstractTest {
     public void setup() {
         sTelemetryHeaders = null;
         sCorrelationIdList.clear();
-        EstsTelemetry.getInstance().clear();
         super.setup();
     }
 


### PR DESCRIPTION
Fixes [AB#3493850](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3493850) The eSTS telemetry emission has been gated behind a flight since September 2025. This PR removes the associated code paths as part of the cleanup. https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/2742