### PR TITLE
Update test case to handle multiple dialog messages, Fixes AB#3505565

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
@@ -41,6 +41,9 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+
 // Invoke each API from non-allowed apps. the request should be blocked.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/1600567
 @SupportedBrokers(brokers = {BrokerMicrosoftAuthenticator.class})
@@ -49,7 +52,7 @@ public class TestCase1600567 extends AbstractMsalBrokerTest {
     @Test
     public void test_1600567_nonAllowedBrokerApp() throws Throwable {
         // Skip test if preconditions are not met
-        Assume.assumeTrue( "Only run this test if there are no local flights",
+        Assume.assumeTrue("Only run this test if there are no local flights",
                 BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.isEmpty()
         );
         final BrokerHost brokerHost = new BrokerHost();
@@ -124,8 +127,19 @@ public class TestCase1600567 extends AbstractMsalBrokerTest {
      */
     private void confirmCallingAppNotVerified(@NonNull final BrokerHost brokerHost) {
         String dialogMessage = brokerHost.dismissDialog();
-        Assert.assertTrue(dialogMessage.contains("is not in the list of allowed callers"));
+        final List<String> validDialogMessages = Arrays.asList(
+                "Calling app could not be verified", // This is the client message for older versions of Broker.
+                "is not in the list of allowed callers", // This is the broker auth message for latest version of Broker.
+                "Only apps hosting the broker can invoke this API" // This is the client message for the latest version of Broker.
+        );
+        boolean matchesValidMessage = false;
+        for (final String validMessage : validDialogMessages) {
+            if (dialogMessage != null && dialogMessage.contains(validMessage)) {
+                matchesValidMessage = true;
+                break;
+            }
+        }
+        Assert.assertTrue("Unexpected dialog message: " + dialogMessage, matchesValidMessage);
     }
 
 }
-


### PR DESCRIPTION
https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2472
Fix for test: test_1600567_nonAllowedBrokerApp
[AB#3505565](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3505565)
