### PR TITLE
Fix UI test related to broker validation for ECS configuration, Fixes AB#3540776

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase1600567.java
@@ -58,7 +58,7 @@ public class TestCase1600567 extends AbstractMsalBrokerTest {
         final BrokerHost brokerHost = new BrokerHost();
         brokerHost.install();
         brokerHost.launch();
-
+        confirmCallingAppNotVerified(brokerHost);
         brokerHost.brokerApiFragment.launch();
         // verify getAccounts call gives calling app not verified
         UiAutomatorUtils.handleButtonClick("com.microsoft.identity.testuserapp:id/button_get_accounts");

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
@@ -22,6 +22,7 @@
 //  THE SOFTWARE.
 package com.microsoft.identity.client.msal.automationapp.testpass.broker.mam
 
+import com.microsoft.identity.client.msal.automationapp.BuildConfig
 import com.microsoft.identity.client.msal.automationapp.AbstractMsalUiTest
 import com.microsoft.identity.client.msal.automationapp.R
 import com.microsoft.identity.client.ui.automation.annotations.RetryOnFailure
@@ -39,6 +40,7 @@ import com.microsoft.identity.labapi.utilities.constants.ProtectionPolicy
 import com.microsoft.identity.labapi.utilities.constants.TempUserType
 import com.microsoft.identity.labapi.utilities.constants.UserType
 import org.junit.Assert
+import org.junit.Assume
 import org.junit.Test
 
 // Using TrueMAM account will require a broker, and will require CP instead of Authenticator

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
@@ -48,6 +48,10 @@ class TestCase2516571 : AbstractMsalUiTest(){
 
     @Test
     fun test_2516571_MAM_BrokerRequired() {
+        Assume.assumeFalse( "Only run this test if there are local flights",
+                BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.isEmpty()
+        );
+        
         // Fetch credentials
         val username: String = mLabAccount.username
         val password: String = mLabAccount.password


### PR DESCRIPTION
* Added a call to confirmCallingAppNotVerified in test_1600567_nonAllowedBrokerApp. When the app is launched, an error message is immediately received, so we need to validate and dispatch this initial message first.

* Introduced an Assume.assumeFalse statement in test_2516571_MAM_BrokerRequired to ensure the test only runs when no local flights are enabled, since the test requires interaction between Authenticator and the broker host.

https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1604258&view=results

[AB#3540776](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3540776)