### PR TITLE
Fix test_2828864_DCF_CheckSignInFromOtherDeviceOptionAvailable, Fixes AB#3537345

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/AbstractSignInFromOtherDeviceTest.java
@@ -95,8 +95,14 @@ abstract class AbstractSignInFromOtherDeviceTest extends AbstractMsalBrokerTest 
                 .build();
 
         msalSdk.acquireTokenInteractiveAsync(authTestParams, () ->
-                new AadLoginComponentHandler().handleSignInFromOtherDevice(getExpectedDeviceCodeUrl()), TokenRequestTimeout.MEDIUM);
+                new AadLoginComponentHandler().handleSignInFromOtherDevice(), TokenRequestTimeout.MEDIUM);
     }
 
-    abstract protected String getExpectedDeviceCodeUrl();
+    @Override
+    public int getConfigFileResourceId() {
+        if (mAzureEnvironment == AzureEnvironment.AZURE_US_GOVERNMENT) {
+            return R.raw.msal_config_arlington;
+        }
+        return R.raw.msal_config_default;
+    }
 }

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828864.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/dcf/TestCase2828864.java
@@ -82,14 +82,4 @@ public class TestCase2828864 extends AbstractSignInFromOtherDeviceTest {
         this.setAzureEnvironment(AzureEnvironment.AZURE_US_GOVERNMENT);
         this.testSignInFromOtherDevice();
     }
-
-    @Override
-    public int getConfigFileResourceId() {
-        return R.raw.msal_config_default;
-    }
-
-    @Override
-    protected String getExpectedDeviceCodeUrl() {
-        return "https://microsoft.com/devicelogin";
-    }
 }


### PR DESCRIPTION
Refer https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3015 for description,

Fixes [AB#3537345](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3537345)