### PR TITLE
Add AzureFranceSov to AzureCloudInstance enum, Fixes AB#3536002

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MINOR] [Bleu support] Add AzureFranceSov to AzureCloudInstance enum for France sovereign cloud support
 - [PATCH] Update Moshi version to 1.15.2 to address okio vulnerability (CVE-2023-3635) (#2480)
 
 Version 8.2.3

--- a/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
@@ -49,7 +49,13 @@ public enum AzureCloudInstance {
      * US Government cloud.
      * Maps to https://login.microsoftonline.us.
      */
-    AzureUsGov("https://login.microsoftonline.us");
+    AzureUsGov("https://login.microsoftonline.us"),
+
+    /**
+     * France sovereign cloud.
+     * Maps to https://login.sovcloud-identity.fr.
+     */
+    AzureFranceSov("https://login.sovcloud-identity.fr");
 
     private String cloudInstanceUri;
 

--- a/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
+++ b/msal/src/main/java/com/microsoft/identity/client/AzureCloudInstance.java
@@ -55,9 +55,21 @@ public enum AzureCloudInstance {
      * France sovereign cloud.
      * Maps to https://login.sovcloud-identity.fr.
      */
-    AzureFranceSov("https://login.sovcloud-identity.fr");
+    AzureFranceSov("https://login.sovcloud-identity.fr"),
 
-    private String cloudInstanceUri;
+    /**
+     * Germany sovereign cloud (Delos).
+     * Maps to https://login.sovcloud-identity.de.
+     */
+    AzureGermanySov("https://login.sovcloud-identity.de"),
+
+    /**
+     * Singapore sovereign cloud (SovSG).
+     * Maps to https://login.sovcloud-identity.sg.
+     */
+    AzureSingaporeSov("https://login.sovcloud-identity.sg");
+
+    private final String cloudInstanceUri;
 
     AzureCloudInstance(String cloudInstanceUri) {
         this.cloudInstanceUri = cloudInstanceUri;

--- a/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
+++ b/msal/src/main/java/com/microsoft/identity/client/PublicClientApplication.java
@@ -2571,7 +2571,8 @@ public class PublicClientApplication implements IPublicClientApplication, IToken
         final AdalMigrationAdapter adalMigrationAdapter = new AdalMigrationAdapter(
                 mPublicClientConfiguration.getAppContext(),
                 redirects,
-                false
+                false,
+                mPublicClientConfiguration.getDefaultAuthority()
         );
 
         if (adalMigrationAdapter.getMigrationStatus()) {

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityMyOrgTest.java
@@ -74,6 +74,7 @@ public class TokenParametersAuthorityMyOrgTest {
                 {AzureCloudInstance.AzureChina, "https://login.partner.microsoftonline.cn/" + testTenant},
                 {AzureCloudInstance.AzureGermany, "https://login.microsoftonline.de/" + testTenant},
                 {AzureCloudInstance.AzureUsGov, "https://login.microsoftonline.us/" + testTenant},
+                {AzureCloudInstance.AzureFranceSov, "https://login.sovcloud-identity.fr/" + testTenant},
         });
     }
 

--- a/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/TokenParametersAuthorityTest.java
@@ -84,6 +84,8 @@ public class TokenParametersAuthorityTest {
                 {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.microsoftonline.us/common"},
                 {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.microsoftonline.us/organizations"},
                 {AzureCloudInstance.AzureUsGov, AadAuthorityAudience.PersonalMicrosoftAccount, "https://login.microsoftonline.us/consumers"},
+                {AzureCloudInstance.AzureFranceSov, AadAuthorityAudience.AzureAdAndPersonalMicrosoftAccount, "https://login.sovcloud-identity.fr/common"},
+                {AzureCloudInstance.AzureFranceSov, AadAuthorityAudience.AzureAdMultipleOrgs, "https://login.sovcloud-identity.fr/organizations"},
 
         });
     }


### PR DESCRIPTION

Adds a new `AzureFranceSov` value to the `AzureCloudInstance` enum, enabling app developers to target the Bleu sovereign cloud (France) using the type-safe builder pattern:

```java
AcquireTokenParameters.builder()
    .fromAuthority(AzureCloudInstance.AzureFranceSov, AadAuthorityAudience.AzureAdMultipleOrgs)
    ...
```

Points to changes in https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3027
Fixes [AB#3536002](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3536002)