### PR TITLE
Replace MSSecurity-1ES pool with Microsoft-hosted agents in pr-msal pipeline, Fixes AB#3549891

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -31,7 +31,7 @@ resources:
     endpoint: ANDROID_GITHUB
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2022'
 stages:
   - stage: build_and_test
     displayName: Build and Test

--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -31,9 +31,7 @@ resources:
     endpoint: ANDROID_GITHUB
 
 pool:
-  name: MSSecurity-1ES-Build-Agents-Pool
-  image: MSSecurity-1ES-Windows-2022
-  os: windows
+  vmImage: 'windows-latest'
 stages:
   - stage: build_and_test
     displayName: Build and Test


### PR DESCRIPTION
## Summary
Replace `MSSecurity-1ES-Build-Agents-Pool` with Microsoft-hosted `vmImage: 'windows-2022'` in the `pr-msal.yml` pipeline.

## Changes
- **File:** `azure-pipelines/pull-request-validation/pr-msal.yml`
- **Before:** `pool: { name: MSSecurity-1ES-Build-Agents-Pool, image: MSSecurity-1ES-Windows-2022, os: windows }`
- **After:** `pool: { vmImage: 'windows-2022' }`

## Affected Jobs
All 4 PR validation jobs now run on Microsoft-hosted agents:
- build_test (PR Branch Testing)
- build_test_dev (Dev Branch Testing)
- spotbugs (SpotBugs analysis)
- lint (Lint checks)

None of these jobs build Broker or require self-hosted agent capabilities.
[AB#3549891](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3549891)