### PR TITLE
Update Concurrent ATS Section in MsalTestApp, Fixes AB#3580011

### DIFF
--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -716,7 +716,6 @@ public class AcquireTokenFragment extends Fragment {
 
     /**
      * Concurrent AcquireTokenSilent
-     * Note: In order for this to work, the build config shouldSkipSilentTokenCommandCacheForStressTest must be set to true.
      */
     private void runConcurrentAcquireTokenSilent() {
         try {
@@ -746,6 +745,12 @@ public class AcquireTokenFragment extends Fragment {
                 mThreadProgressViews.add(threadProgress);
             }
 
+            // Set up a shared CyclicBarrier so all executor threads synchronize
+            // on each iteration. This ensures all N threads fire their ATS request
+            // at the exact same moment on each wave.
+            ConcurrentAcquireTokenExecutor.setSharedBarrier(
+                    new java.util.concurrent.CyclicBarrier(concurrency));
+
             // Create and start one executor per thread
             for (int i = 0; i < concurrency; i++) {
                 final int threadId = i;
@@ -754,6 +759,9 @@ public class AcquireTokenFragment extends Fragment {
                 final ConcurrentAcquireTokenExecutor executor =
                     new ConcurrentAcquireTokenExecutor(threadId, countForThisThread);
 
+                // Each executor fires requests on its own background thread.
+                // The shared CyclicBarrier ensures all executors synchronize at each
+                // iteration, so all threads fire simultaneously on each wave.
                 executor.execute(
                     getContext(),
                     getCurrentRequestOptions(),
@@ -763,12 +771,20 @@ public class AcquireTokenFragment extends Fragment {
                             if (tid >= 0 && tid < mThreadProgressViews.size()) {
                                 mThreadProgressViews.get(tid).setText(
                                         String.format(Locale.US,
-                                                "Thread %d: %d/%d", tid, successCount, completedCount));
+                                                "Thread %d: %d/%d (success/total)", tid, successCount, completedCount));
                             }
                         }
 
                         @Override
                         public void onStopped(final int tid) {
+                        }
+
+                        @Override
+                        public void onError(final int tid, final String message) {
+                            if (tid >= 0 && tid < mThreadProgressViews.size()) {
+                                final String current = mThreadProgressViews.get(tid).getText().toString();
+                                mThreadProgressViews.get(tid).setText(current + "\n  ERROR: " + message);
+                            }
                         }
                     }
                 );

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -126,7 +126,7 @@ public class AcquireTokenFragment extends Fragment {
 
     // Concurrent execution UI elements
     private EditText mConcurrentCount;
-    private EditText mConcurrentTotalCount;
+    private EditText mConcurrentIterations;
     private Button mRunConcurrent;
     private LinearLayout mThreadProgressContainer;
     private List<TextView> mThreadProgressViews = new ArrayList<>();
@@ -437,7 +437,7 @@ public class AcquireTokenFragment extends Fragment {
 
         // Initialize concurrent execution UI elements
         mConcurrentCount = view.findViewById(R.id.concurrent_count);
-        mConcurrentTotalCount = view.findViewById(R.id.concurrent_total_count);
+        mConcurrentIterations = view.findViewById(R.id.concurrent_iterations);
         mRunConcurrent = view.findViewById(R.id.btn_run_concurrent);
         mThreadProgressContainer = view.findViewById(R.id.concurrent_thread_progress_container);
 
@@ -720,7 +720,7 @@ public class AcquireTokenFragment extends Fragment {
     private void runConcurrentAcquireTokenSilent() {
         try {
             final int concurrency = Integer.parseInt(mConcurrentCount.getText().toString());
-            final int iterations = Integer.parseInt(mConcurrentTotalCount.getText().toString());
+            final int iterations = Integer.parseInt(mConcurrentIterations.getText().toString());
 
             if (concurrency <= 0 || iterations <= 0) {
                 showConcurrentStatus("Concurrency and iterations must be greater than 0");

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -795,6 +795,10 @@ public class AcquireTokenFragment extends Fragment {
 
                         @Override
                         public void onStopped(final int tid) {
+                            mRunningExecutors.removeIf(e -> e.getThreadId() == tid);
+                            if (mRunningExecutors.isEmpty()) {
+                                updateConcurrentButtonState();
+                            }
                         }
 
                         @Override

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -738,6 +738,13 @@ public class AcquireTokenFragment extends Fragment {
             mLatestErrors.clear();
 
             // Create per-thread progress views
+            final TextView header = new TextView(getContext());
+            header.setText("Progress (success/completed):");
+            header.setTextSize(12);
+            header.setTypeface(null, android.graphics.Typeface.BOLD);
+            header.setPadding(0, 5, 0, 5);
+            mThreadProgressContainer.addView(header);
+
             for (int i = 0; i < concurrency; i++) {
                 TextView threadProgress = new TextView(getContext());
                 threadProgress.setText("Thread " + i + ": 0/" + iterations);
@@ -771,7 +778,7 @@ public class AcquireTokenFragment extends Fragment {
                         public void updateProgress(final int tid, final int successCount, final int completedCount) {
                             if (tid >= 0 && tid < mThreadProgressViews.size()) {
                                 final String progress = String.format(Locale.US,
-                                        "Thread %d [%s]: %d/%d (success/completed)",
+                                        "Thread %d [%s]: %d/%d",
                                         tid,
                                         ConcurrentAcquireTokenExecutor.getScopeForThread(tid),
                                         successCount,

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -808,7 +808,7 @@ public class AcquireTokenFragment extends Fragment {
             }
             updateConcurrentButtonState();
         } catch (NumberFormatException e) {
-            showMessage("Please enter valid numbers for concurrency and total count");
+            showMessage("Please enter valid numbers for concurrency and iterations");
         }
     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/AcquireTokenFragment.java
@@ -64,6 +64,8 @@ import com.microsoft.identity.common.java.opentelemetry.SpanExtension;
 import com.microsoft.identity.common.java.util.StringUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 import java.util.Locale;
 
@@ -126,10 +128,10 @@ public class AcquireTokenFragment extends Fragment {
     private EditText mConcurrentCount;
     private EditText mConcurrentTotalCount;
     private Button mRunConcurrent;
-    private Button mStopConcurrent;
     private LinearLayout mThreadProgressContainer;
     private List<TextView> mThreadProgressViews = new ArrayList<>();
     private List<ConcurrentAcquireTokenExecutor> mRunningExecutors = new ArrayList<>();
+    private final Map<Integer, String> mLatestErrors = new HashMap<>();
 
     private IClientActiveBrokerCache mCache;
     public AcquireTokenFragment() {
@@ -437,22 +439,20 @@ public class AcquireTokenFragment extends Fragment {
         mConcurrentCount = view.findViewById(R.id.concurrent_count);
         mConcurrentTotalCount = view.findViewById(R.id.concurrent_total_count);
         mRunConcurrent = view.findViewById(R.id.btn_run_concurrent);
-        mStopConcurrent = view.findViewById(R.id.btn_stop_concurrent);
         mThreadProgressContainer = view.findViewById(R.id.concurrent_thread_progress_container);
 
         mRunConcurrent.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                runConcurrentAcquireTokenSilent();
+                if (mRunningExecutors.isEmpty()) {
+                    runConcurrentAcquireTokenSilent();
+                } else {
+                    stopConcurrentExecutors();
+                }
             }
         });
 
-        mStopConcurrent.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                stopConcurrentExecutors();
-            }
-        });
+        updateConcurrentButtonState();
 
         return view;
     }
@@ -720,25 +720,27 @@ public class AcquireTokenFragment extends Fragment {
     private void runConcurrentAcquireTokenSilent() {
         try {
             final int concurrency = Integer.parseInt(mConcurrentCount.getText().toString());
-            final int totalCount = Integer.parseInt(mConcurrentTotalCount.getText().toString());
+            final int iterations = Integer.parseInt(mConcurrentTotalCount.getText().toString());
 
-            if (concurrency <= 0 || totalCount <= 0) {
-                showMessage("Concurrency and total count must be greater than 0");
+            if (concurrency <= 0 || iterations <= 0) {
+                showConcurrentStatus("Concurrency and iterations must be greater than 0");
                 return;
             }
 
-            // Calculate requests per thread
-            final int requestsPerThread = totalCount / concurrency;
-            final int remainder = totalCount % concurrency;
+            if (getAccountFromSpinner() == null) {
+                showConcurrentStatus("Please sign in first. An account is required for AcquireTokenSilent.");
+                return;
+            }
 
             // Reset progress
             mThreadProgressContainer.removeAllViews();
             mThreadProgressViews.clear();
+            mLatestErrors.clear();
 
             // Create per-thread progress views
             for (int i = 0; i < concurrency; i++) {
                 TextView threadProgress = new TextView(getContext());
-                threadProgress.setText("Thread " + i + ": 0/0");
+                threadProgress.setText("Thread " + i + ": 0/" + iterations);
                 threadProgress.setTextSize(12);
                 threadProgress.setPadding(0, 5, 0, 5);
                 mThreadProgressContainer.addView(threadProgress);
@@ -754,10 +756,9 @@ public class AcquireTokenFragment extends Fragment {
             // Create and start one executor per thread
             for (int i = 0; i < concurrency; i++) {
                 final int threadId = i;
-                final int countForThisThread = requestsPerThread + (i < remainder ? 1 : 0);
 
                 final ConcurrentAcquireTokenExecutor executor =
-                    new ConcurrentAcquireTokenExecutor(threadId, countForThisThread);
+                    new ConcurrentAcquireTokenExecutor(threadId, iterations);
 
                 // Each executor fires requests on its own background thread.
                 // The shared CyclicBarrier ensures all executors synchronize at each
@@ -769,9 +770,26 @@ public class AcquireTokenFragment extends Fragment {
                         @Override
                         public void updateProgress(final int tid, final int successCount, final int completedCount) {
                             if (tid >= 0 && tid < mThreadProgressViews.size()) {
-                                mThreadProgressViews.get(tid).setText(
-                                        String.format(Locale.US,
-                                                "Thread %d: %d/%d (success/total)", tid, successCount, completedCount));
+                                final String progress = String.format(Locale.US,
+                                        "Thread %d [%s]: %d/%d (success/completed)",
+                                        tid,
+                                        ConcurrentAcquireTokenExecutor.getScopeForThread(tid),
+                                        successCount,
+                                        completedCount);
+
+                                if (mLatestErrors.containsKey(tid)) {
+                                    final String full = progress + "\nLast error: " + mLatestErrors.get(tid);
+                                    final android.text.SpannableString spannable = new android.text.SpannableString(full);
+                                    final int boldStart = progress.length() + 1; // after \n
+                                    final int boldEnd = boldStart + "Last error:".length();
+                                    spannable.setSpan(
+                                            new android.text.style.StyleSpan(android.graphics.Typeface.BOLD),
+                                            boldStart, boldEnd,
+                                            android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                                    mThreadProgressViews.get(tid).setText(spannable);
+                                } else {
+                                    mThreadProgressViews.get(tid).setText(progress);
+                                }
                             }
                         }
 
@@ -781,27 +799,51 @@ public class AcquireTokenFragment extends Fragment {
 
                         @Override
                         public void onError(final int tid, final String message) {
-                            if (tid >= 0 && tid < mThreadProgressViews.size()) {
-                                final String current = mThreadProgressViews.get(tid).getText().toString();
-                                mThreadProgressViews.get(tid).setText(current + "\n  ERROR: " + message);
-                            }
+                            mLatestErrors.put(tid, message);
                         }
                     }
                 );
 
                 mRunningExecutors.add(executor);
             }
+            updateConcurrentButtonState();
         } catch (NumberFormatException e) {
             showMessage("Please enter valid numbers for concurrency and total count");
         }
     }
 
     private void stopConcurrentExecutors() {
+        if (mRunningExecutors.isEmpty()) {
+            return;
+        }
         for (ConcurrentAcquireTokenExecutor executor : mRunningExecutors) {
             executor.stop();
         }
         mRunningExecutors.clear();
-        showMessage("Stopped all running tasks");
+        // Append stop message without clearing existing thread progress
+        final TextView stopView = new TextView(getContext());
+        stopView.setText("Stopped all running tasks");
+        stopView.setTextSize(12);
+        stopView.setPadding(0, 10, 0, 5);
+        stopView.setTextColor(0xFF999999);
+        mThreadProgressContainer.addView(stopView);
+        updateConcurrentButtonState();
+    }
+
+    private void updateConcurrentButtonState() {
+        final boolean hasRunning = !mRunningExecutors.isEmpty();
+        mRunConcurrent.setText(hasRunning ? "Stop" : "Run Concurrent");
+    }
+
+    private void showConcurrentStatus(final String message) {
+        mThreadProgressContainer.removeAllViews();
+        mThreadProgressViews.clear();
+        final TextView statusView = new TextView(getContext());
+        statusView.setText(message);
+        statusView.setTextSize(14);
+        statusView.setPadding(0, 10, 0, 10);
+        statusView.setTextColor(0xFFCC0000);
+        mThreadProgressContainer.addView(statusView);
     }
 
     public interface OnFragmentInteractionListener {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -42,6 +42,15 @@ class ConcurrentAcquireTokenExecutor(
 
     // Use a dedicated executor for background work
     private val executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private val mainThreadHandler = Handler(Looper.getMainLooper())
+
+    private fun dispatchToMainThread(action: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            action()
+        } else {
+            mainThreadHandler.post(action)
+        }
+    }
 
     interface IUIUpdateCallback {
         fun updateProgress(threadId: Int, successCount: Int, completedCount: Int)
@@ -52,7 +61,7 @@ class ConcurrentAcquireTokenExecutor(
     fun execute(context: Context,
                 requestOptions: RequestOptions,
                 uiCallback: IUIUpdateCallback){
-        // MsalWrapper.create callbacks run on main thread, so call it directly
+        // Do not assume MsalWrapper.create callbacks are delivered on the main thread.
         MsalWrapper.create(
             context.applicationContext,
             Constants.getResourceIdFromConfigFile(requestOptions.configFile),
@@ -78,15 +87,19 @@ class ConcurrentAcquireTokenExecutor(
                     } else {
                         // Handle the null case appropriately, e.g., notify UI or log error
                         executor.shutdown()
-                        uiCallback.onError(threadId, "MsalWrapper is null")
-                        uiCallback.onStopped(threadId)
+                        dispatchToMainThread {
+                            uiCallback.onError(threadId, "MsalWrapper is null")
+                            uiCallback.onStopped(threadId)
+                        }
                     }
                 }
 
                 override fun showMessage(message: String?) {
                     executor.shutdown()
-                    uiCallback.onError(threadId, message ?: "MsalWrapper creation failed")
-                    uiCallback.onStopped(threadId)
+                    dispatchToMainThread {
+                        uiCallback.onError(threadId, message ?: "MsalWrapper creation failed")
+                        uiCallback.onStopped(threadId)
+                    }
                 }
             }
         )

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 class ConcurrentAcquireTokenExecutor(
     val threadId: Int,
-    val totalCount: Int
+    val iterations: Int
 ) {
 
     // Flag to track if execution should stop
@@ -77,13 +77,16 @@ class ConcurrentAcquireTokenExecutor(
                         }
                     } else {
                         // Handle the null case appropriately, e.g., notify UI or log error
-                        // For now, we'll notify the UI that the operation has stopped
+                        executor.shutdown()
+                        uiCallback.onError(threadId, "MsalWrapper is null")
                         uiCallback.onStopped(threadId)
                     }
                 }
 
                 override fun showMessage(message: String?) {
-                    // do nothing.
+                    executor.shutdown()
+                    uiCallback.onError(threadId, message ?: "MsalWrapper creation failed")
+                    uiCallback.onStopped(threadId)
                 }
             }
         )
@@ -200,7 +203,7 @@ class ConcurrentAcquireTokenExecutor(
             return
         }
 
-        if (newCompletedCount < totalCount) {
+        if (newCompletedCount < iterations) {
             executor.execute {
                 try {
                     // If a shared barrier is set, wait for all sibling threads
@@ -222,7 +225,8 @@ class ConcurrentAcquireTokenExecutor(
                 }
             }
         } else {
-            // All iterations completed — notify the UI
+            // All iterations completed — clean up and notify the UI
+            executor.shutdown()
             Handler(Looper.getMainLooper()).post {
                 uiCallback.onStopped(threadId)
             }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -29,6 +29,7 @@ import com.microsoft.identity.client.IAuthenticationResult
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -217,24 +218,37 @@ class ConcurrentAcquireTokenExecutor(
         }
 
         if (newCompletedCount < iterations) {
-            executor.execute {
-                try {
-                    // If a shared barrier is set, wait for all sibling threads
-                    // to reach this point before firing the next request.
-                    // This ensures all threads fire each iteration simultaneously.
-                    sharedBarrier?.await(30, TimeUnit.SECONDS)
-                } catch (e: Exception) {
-                    // Barrier broken or timeout — continue anyway
+            if (executor.isShutdown || executor.isTerminated) {
+                Handler(Looper.getMainLooper()).post {
+                    uiCallback.onStopped(threadId)
                 }
+                return
+            }
 
-                if (!isStopped.get()) {
-                    executeAcquireTokenSilent(
-                        msalWrapper,
-                        newSuccessCount,
-                        newCompletedCount,
-                        requestOptions,
-                        uiCallback
-                    )
+            try {
+                executor.execute {
+                    try {
+                        // If a shared barrier is set, wait for all sibling threads
+                        // to reach this point before firing the next request.
+                        // This ensures all threads fire each iteration simultaneously.
+                        sharedBarrier?.await(30, TimeUnit.SECONDS)
+                    } catch (e: Exception) {
+                        // Barrier broken or timeout — continue anyway
+                    }
+
+                    if (!isStopped.get()) {
+                        executeAcquireTokenSilent(
+                            msalWrapper,
+                            newSuccessCount,
+                            newCompletedCount,
+                            requestOptions,
+                            uiCallback
+                        )
+                    }
+                }
+            } catch (e: RejectedExecutionException) {
+                Handler(Looper.getMainLooper()).post {
+                    uiCallback.onStopped(threadId)
                 }
             }
         } else {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -109,9 +109,7 @@ class ConcurrentAcquireTokenExecutor(
             "tasks.read",
             "sites.read.all",
             "directory.read.all",
-            "group.read.all",
-            "openid",
-            "profile"
+            "group.read.all"
         )
 
         /**
@@ -164,7 +162,7 @@ class ConcurrentAcquireTokenExecutor(
                 override fun showMessage(message: String?) {
                     val newCompletedCount = completedCount + 1
 
-                    // MSAL callbacks already run on main thread - update UI directly
+                    uiCallback.onError(threadId, message ?: "Unknown error")
                     uiCallback.updateProgress(threadId, successCount, newCompletedCount)
 
                     executeNext(

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -90,6 +90,7 @@ class ConcurrentAcquireTokenExecutor(
                         executor.shutdown()
                         dispatchToMainThread {
                             uiCallback.onError(threadId, "MsalWrapper is null")
+                            uiCallback.updateProgress(threadId, 0, 0)
                             uiCallback.onStopped(threadId)
                         }
                     }
@@ -99,6 +100,7 @@ class ConcurrentAcquireTokenExecutor(
                     executor.shutdown()
                     dispatchToMainThread {
                         uiCallback.onError(threadId, message ?: "MsalWrapper creation failed")
+                        uiCallback.updateProgress(threadId, 0, 0)
                         uiCallback.onStopped(threadId)
                     }
                 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -58,13 +58,23 @@ class ConcurrentAcquireTokenExecutor(
             Constants.getResourceIdFromConfigFile(requestOptions.configFile),
             object : INotifyOperationResultCallback<MsalWrapper?> {
                 override fun onSuccess(result: MsalWrapper?) {
-                    // Start the first iteration immediately (no initial sleep)
                     if (result != null) {
-                        executeAcquireTokenSilent(result,
-                            0,
-                            0,
-                            requestOptions,
-                            uiCallback)
+                        // Wait at the barrier before the first iteration so all
+                        // threads start their first request simultaneously.
+                        executor.execute {
+                            try {
+                                sharedBarrier?.await(30, TimeUnit.SECONDS)
+                            } catch (e: Exception) {
+                                // Barrier broken or timeout — continue anyway
+                            }
+                            if (!isStopped.get()) {
+                                executeAcquireTokenSilent(result,
+                                    0,
+                                    0,
+                                    requestOptions,
+                                    uiCallback)
+                            }
+                        }
                     } else {
                         // Handle the null case appropriately, e.g., notify UI or log error
                         // For now, we'll notify the UI that the operation has stopped
@@ -210,6 +220,11 @@ class ConcurrentAcquireTokenExecutor(
                         uiCallback
                     )
                 }
+            }
+        } else {
+            // All iterations completed — notify the UI
+            Handler(Looper.getMainLooper()).post {
+                uiCallback.onStopped(threadId)
             }
         }
     }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -26,13 +26,11 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.microsoft.identity.client.IAuthenticationResult
-import java.util.concurrent.CountDownLatch
 import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicInteger
 
 class ConcurrentAcquireTokenExecutor(
     val threadId: Int,

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/ConcurrentAcquireTokenExecutor.kt
@@ -26,16 +26,18 @@ import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import com.microsoft.identity.client.IAuthenticationResult
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
 class ConcurrentAcquireTokenExecutor(
     val threadId: Int,
     val totalCount: Int
 ) {
-
-    private val randomDelayInMs = (10..50).random().toLong()
 
     // Flag to track if execution should stop
     private val isStopped = AtomicBoolean(false)
@@ -46,6 +48,7 @@ class ConcurrentAcquireTokenExecutor(
     interface IUIUpdateCallback {
         fun updateProgress(threadId: Int, successCount: Int, completedCount: Int)
         fun onStopped(threadId: Int)
+        fun onError(threadId: Int, message: String)
     }
 
     fun execute(context: Context,
@@ -78,6 +81,49 @@ class ConcurrentAcquireTokenExecutor(
         )
     }
 
+    companion object {
+        /**
+         * Shared barrier across all executor instances.
+         * Set by the caller before starting executors.
+         * All executors wait at this barrier before each iteration,
+         * ensuring all threads fire simultaneously on each wave.
+         */
+        @JvmStatic
+        var sharedBarrier: CyclicBarrier? = null
+
+        /**
+         * Pool of legitimate Microsoft Graph scopes.
+         * Each thread uses a different scope to bypass calling-side command dedup
+         * (CommandDispatcher collapses commands with identical parameters).
+         */
+        private val SCOPE_POOL = listOf(
+            "user.read",
+            "user.readbasic.all",
+            "mail.read",
+            "calendars.read",
+            "contacts.read",
+            "files.read",
+            "files.read.all",
+            "people.read",
+            "notes.read",
+            "tasks.read",
+            "sites.read.all",
+            "directory.read.all",
+            "group.read.all",
+            "openid",
+            "profile"
+        )
+
+        /**
+         * Returns a legitimate scope for the given thread ID.
+         * Wraps around the pool if threadId exceeds the pool size.
+         */
+        @JvmStatic
+        fun getScopeForThread(threadId: Int): String {
+            return SCOPE_POOL[threadId % SCOPE_POOL.size]
+        }
+    }
+
     /**
      * Stop the executor and cancel any pending operations
      */
@@ -92,8 +138,13 @@ class ConcurrentAcquireTokenExecutor(
                                           completedCount: Int,
                                           requestOptions: RequestOptions,
                                           uiCallback: IUIUpdateCallback) {
-        msalWrapper.acquireTokenSilent(
+        // Use a per-thread scope from the pool to bypass calling-side command dedup.
+        val threadOptions = RequestOptions.withDifferentScopes(
             requestOptions,
+            getScopeForThread(threadId)
+        )
+        msalWrapper.acquireTokenSilent(
+            threadOptions,
             object : INotifyOperationResultCallback<IAuthenticationResult> {
                 override fun onSuccess(result: IAuthenticationResult) {
                     val newSuccessCount = successCount + 1
@@ -146,24 +197,22 @@ class ConcurrentAcquireTokenExecutor(
         if (newCompletedCount < totalCount) {
             executor.execute {
                 try {
-                    Thread.sleep(randomDelayInMs)
+                    // If a shared barrier is set, wait for all sibling threads
+                    // to reach this point before firing the next request.
+                    // This ensures all threads fire each iteration simultaneously.
+                    sharedBarrier?.await(30, TimeUnit.SECONDS)
+                } catch (e: Exception) {
+                    // Barrier broken or timeout — continue anyway
+                }
 
-                    // Post back to main thread to call acquireTokenSilent
-                    // (required since MSAL needs to be called from main thread)
-                    Handler(Looper.getMainLooper()).post {
-                        executeAcquireTokenSilent(
-                            msalWrapper,
-                            newSuccessCount,
-                            newCompletedCount,
-                            requestOptions,
-                            uiCallback
-                        )
-                    }
-                } catch (e: InterruptedException) {
-                    // Interrupted - likely due to stop request
-                    Handler(Looper.getMainLooper()).post {
-                        uiCallback.onStopped(threadId)
-                    }
+                if (!isStopped.get()) {
+                    executeAcquireTokenSilent(
+                        msalWrapper,
+                        newSuccessCount,
+                        newCompletedCount,
+                        requestOptions,
+                        uiCallback
+                    )
                 }
             }
         }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
@@ -59,8 +59,9 @@ public class RequestOptions {
 
     /**
      * Creates a copy of the given RequestOptions with different scopes.
-     * Used by the concurrent acquire-token-silent stress scenario to avoid command
-     * deduplication in the broker.
+     * Used by the concurrent acquire-token-silent stress scenario to avoid
+     * client-side command deduplication (CommandDispatcher collapses commands
+     * with identical parameters).
      */
     public static RequestOptions withDifferentScopes(RequestOptions source, String newScopes) {
         return new RequestOptions(

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
@@ -56,4 +56,29 @@ public class RequestOptions {
     public Constants.ConfigFile getConfigFile(){
         return mConfigFile;
     }
+
+    /**
+     * Creates a copy of the given RequestOptions with different scopes.
+     * Used by burst mode to avoid command dedup in the broker.
+     */
+    public static RequestOptions withDifferentScopes(RequestOptions source, String newScopes) {
+        return new RequestOptions(
+                source.mConfigFile,
+                source.mLoginHint,
+                source.mAccount,
+                source.mPrompt,
+                newScopes,
+                source.mExtraScope,
+                source.mExtraQueryParams,
+                source.mClaims,
+                source.mEnablePII,
+                source.mForceRefresh,
+                source.mAuthority,
+                source.mAuthScheme,
+                source.mPopHttpMethod,
+                source.mPopResourceUrl,
+                source.mPoPClientClaims,
+                source.mAllowSignInFromOtherDevice
+        );
+    }
 }

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/RequestOptions.java
@@ -59,7 +59,8 @@ public class RequestOptions {
 
     /**
      * Creates a copy of the given RequestOptions with different scopes.
-     * Used by burst mode to avoid command dedup in the broker.
+     * Used by the concurrent acquire-token-silent stress scenario to avoid command
+     * deduplication in the broker.
      */
     public static RequestOptions withDifferentScopes(RequestOptions source, String newScopes) {
         return new RequestOptions(

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -735,15 +735,6 @@
             android:paddingTop="10dp"
             android:paddingBottom="5dp" />
 
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Note: In order for this to work, the build config shouldSkipSilentTokenCommandCacheForStressTest must be set to true."
-            android:textSize="12sp"
-            android:textStyle="italic"
-            android:paddingBottom="5dp"
-            android:textColor="#666666" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -764,7 +755,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="7"
                 android:inputType="number"
-                android:text="20"
+                android:text="13"
                 android:textSize="12sp" />
         </LinearLayout>
 
@@ -780,7 +771,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="3"
-                android:text="Total Count" />
+                android:text="Iterations" />
 
             <EditText
                 android:id="@+id/concurrent_total_count"
@@ -804,15 +795,8 @@
                 android:id="@+id/btn_run_concurrent"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_weight="5"
+                android:layout_weight="10"
                 android:text="Run Concurrent" />
-
-            <Button
-                android:id="@+id/btn_stop_concurrent"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="5"
-                android:text="Stop Concurrent" />
         </LinearLayout>
 
         <!-- Per-thread progress container -->

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -764,7 +764,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="7"
                 android:inputType="number"
-                android:text="5"
+                android:text="20"
                 android:textSize="12sp" />
         </LinearLayout>
 
@@ -788,7 +788,7 @@
                 android:layout_height="wrap_content"
                 android:layout_weight="7"
                 android:inputType="number"
-                android:text="10"
+                android:text="1000"
                 android:textSize="12sp" />
         </LinearLayout>
 

--- a/testapps/testapp/src/main/res/layout/fragment_acquire.xml
+++ b/testapps/testapp/src/main/res/layout/fragment_acquire.xml
@@ -774,7 +774,7 @@
                 android:text="Iterations" />
 
             <EditText
-                android:id="@+id/concurrent_total_count"
+                android:id="@+id/concurrent_iterations"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="7"


### PR DESCRIPTION
 [AB#3580011](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3580011)  


Enhanced the MSAL test app's concurrent ATS stress test to better reproduce broker deadlocks and race conditions:

### Execution model
- **Wave-synchronized execution** — Added `CyclicBarrier` support so all threads fire each iteration simultaneously, maximizing concurrent broker load
- **Per-thread scopes** — Each thread uses a different legitimate Microsoft Graph scope (e.g. `user.read`, `mail.read`, `calendars.read`) to bypass calling-side command dedup without requiring the `shouldSkipSilentTokenCommandCacheForStressTest` build flag

### Error reporting
- Per-thread **latest error** display with **bold** labels
- Errors update in-place (only the most recent error is shown per thread)

### UI improvements
- Combined Run/Stop into a **single toggle button**
- **Account validation** before starting — prevents "Account is null" errors
- Status messages displayed **inline** in the progress container
- Configurable concurrency (default: **13** threads) and iterations (default: **1000** per thread)

### New helpers
- `RequestOptions.withDifferentScopes()` — factory method to create a copy with different scopes
- `RequestOptions.getScopes()` — explicit getter for Kotlin interop
- 
<img width="315" height="723" alt="image" src="https://github.com/user-attachments/assets/4ed06504-45b8-4de9-bba3-feebb5d100bf" />

