### PR TITLE
Fixes AB#3584928 Handle Word privacy screen in FOCI SSO test (TestCase833544)

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -73,7 +73,7 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
         outlook.launch();
         outlook.handleFirstRun();
 
-        final FirstPartyAppPromptHandlerParameters promptHandlerParameters= FirstPartyAppPromptHandlerParameters.builder()
+        final FirstPartyAppPromptHandlerParameters promptHandlerParameters = FirstPartyAppPromptHandlerParameters.builder()
                 .prompt(PromptParameter.SELECT_ACCOUNT)
                 .loginHint(username)
                 .broker(mBroker)

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/foci/TestCase833544.java
@@ -73,7 +73,7 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
         outlook.launch();
         outlook.handleFirstRun();
 
-        final FirstPartyAppPromptHandlerParameters promptHandlerParameters = FirstPartyAppPromptHandlerParameters.builder()
+        final FirstPartyAppPromptHandlerParameters promptHandlerParameters= FirstPartyAppPromptHandlerParameters.builder()
                 .prompt(PromptParameter.SELECT_ACCOUNT)
                 .loginHint(username)
                 .broker(mBroker)
@@ -102,6 +102,9 @@ public class TestCase833544 extends AbstractMsalBrokerTest {
         // Sometimes, it might take a bit longer to see this UI page in word app
         final UiObject fileFetchScreen = UiAutomatorUtils.obtainUiObjectWithText("Fetching your files", TimeUnit.SECONDS.toMillis(45));
         Assert.assertTrue(fileFetchScreen.exists());
+
+        // Word may show a "Your privacy option" dialog after sign-in; dismiss it if present
+        UiAutomatorUtils.handleButtonClickForObjectWithTextSafely("Close", CommonUtils.FIND_UI_ELEMENT_TIMEOUT_SHORT);
 
         // Make sure the account exists in Word
         wordApp.confirmAccount(username);


### PR DESCRIPTION
Word intermittently shows a 'Your privacy option' dialog after sign-in via FOCI SSO. This blocks subsequent UI interactions and causes the test to fail. Add a safe dismiss of the 'Close' button if the dialog appears after the 'Fetching your files' screen.

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/af9540ad-71ef-4094-a99a-421dc0318543" />


Fixes [AB#3584928](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3584928)