### PR TITLE
Build perf: enable Gradle configure-on-demand, Fixes AB#3609347

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,7 @@ android.enableJetifier=true
 # https://office.visualstudio.com/Outlook%20Mobile/_wiki/wikis/Outlook-Mobile.wiki/3780/Android-Studio-Gradle-Performance-tips-and-tricks
 org.gradle.parallel=true
 org.gradle.daemon=true
+org.gradle.configureondemand=true
 
 # See https://stackoverflow.com/questions/56075455/expiring-daemon-because-jvm-heap-space-is-exhausted
 # we must make sure that the total size is <7G, as that's the RAM size of VM on the build pipeline.

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -415,7 +415,7 @@ afterEvaluate {
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
                     password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -415,7 +415,7 @@ afterEvaluate {
         repositories {
             maven {
                 name "vsts-maven-adal-android"
-                url "https://identitydivision.pkgs.visualstudio.com/_packaging/AndroidADAL/maven/v1"
+                url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"
                 credentials {
                     username System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
                     password System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")


### PR DESCRIPTION
[AB#3609347](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3609347)

## Summary
Switches Maven publishing from the `AndroidADAL` feed to the `NewAndroid` feed to eliminate upstream-feed traversal latency on dependency resolution in CI.

## Why
- We publish artifacts to **AndroidADAL** but consumers (including downstream pipeline stages in the same release) fetch from **NewAndroid**.
- `NewAndroid` only has `AndroidADAL` configured as an upstream, **after** Maven Central / Google / etc. Every newly-published version pays a full upstream walk on first resolve.
- CI agents are ephemeral (no Gradle cache reuse), so pipelines pay this penalty on every run for every fresh dependency.
- Publishing **directly to NewAndroid** removes the upstream walk and speeds up chained library/test-app builds.

## Companion changes
- `AndroidADAL` will be added as an **upstream of NewAndroid** (manual step in ADO Artifacts UI, outside this PR) so any external consumers still resolving from AndroidADAL keep working.
- Sister PRs in `microsoft-authentication-library-common-for-android`, `microsoft-authentication-library-for-android`, `ad-accounts-for-android`, and the `AuthClientAndroidPipelines` 1ES repo make the same flip.
- ADAL is intentionally excluded (legacy library).
- Authenticator is intentionally excluded.

## Risk
Low — same Azure DevOps organization, same auth, same package coordinates, same retention. Only the publish-target feed name changes.