### PR TITLE
Add rotated Microsoft Edge signature hash to default browser safelist (#2414), Fixes AB#3611726

### DIFF
--- a/auth_config.template.json
+++ b/auth_config.template.json
@@ -128,7 +128,8 @@
     {
       "browser_package_name": "com.microsoft.emmx",
       "browser_signature_hashes": [
-        "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ=="
+        "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ==",
+        "KxJRZ8RFW-6BQa-e4xNE7UmeGU6BWIR_6dzgaAOQWh0rWVENxsXU5TjnWuTR9GqOFbCKMilXKIu7as6VJRjuSw=="
       ]
     },
     {

--- a/msal/src/main/res/raw/msal_default_config.json
+++ b/msal/src/main/res/raw/msal_default_config.json
@@ -76,7 +76,8 @@
     {
       "browser_package_name": "com.microsoft.emmx",
       "browser_signature_hashes": [
-        "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ=="
+        "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ==",
+        "KxJRZ8RFW-6BQa-e4xNE7UmeGU6BWIR_6dzgaAOQWh0rWVENxsXU5TjnWuTR9GqOFbCKMilXKIu7as6VJRjuSw=="
       ]
     },
     {


### PR DESCRIPTION
Fixes [AB#3611726](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3611726)  tracks the MSAL-side default-config update for the customer-reported Edge browser issue.

## Customer-reported issue
Resolves [microsoft-authentication-library-for-android issue 2414](https://github.com/AzureAD/microsoft-authentication-library-for-android/issues/2414): when Microsoft Edge is the user''s default browser, MSAL rejects it with `Browser: com.microsoft.emmx signature hash not match` and falls back to WebView. Confirmed by multiple customers in the issue thread and validated by a working `auth_config.json` workaround.

## Root cause
Edge ships its production APK with **two** signing certificates (APK Signature Scheme v3 lineage). Once host apps started targeting API 28+, `PackageManager` began returning all signers, and the strict-equality check used by browser selection rejected Edge because the safelist only carried one of the two hashes.

## Changes
1. Add the second Edge signing certificate hash to `msal_default_config.json` so the built-in default safelist trusts both legacy and post-rotation Edge installs.
2. Mirror the same change in `auth_config.template.json` so customers copy-pasting the template aren''t broken.

```json
"browser_signature_hashes": [
  "Ivy-Rk6ztai_IudfbyUrSHugzRqAtHWslFvHT0PTvLMsEKLUIgv7ZZbVxygWy_M5mOPpfjZrd3vOx3t-cA6fVQ==",
  "KxJRZ8RFW-6BQa-e4xNE7UmeGU6BWIR_6dzgaAOQWh0rWVENxsXU5TjnWuTR9GqOFbCKMilXKIu7as6VJRjuSw=="
]
```

## Companion PR
This relies on the matcher fix in common at https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3126 (work item 3611725)  without it, the safelist update alone still fails because the in-library `matches()` uses strict `Set.equals` rather than non-empty intersection.

## Risk
**Very low.** Pure data update  adds an additional trusted signer for an existing trusted package. No code paths change.

## Note on the local AB#ID workflow
The repo''s `.github/workflows/validate-pr-ab-id.yml` "Get AB ID" step uses a regex without an `AB#` prefix and without `head -n 1`, so it fails when a PR body references multiple GitHub issues/PRs by number. To work around that here, every other reference uses full URLs or plain text. Worth a follow-up to sync this workflow with the version in the common repo (which uses `(?<=AB#)\d+ | head -n 1`).