### PR TITLE
Add SilentAuthReceiver for Doze network-block reproduction, Fixes AB#3612535

### DIFF
--- a/testapps/testapp/src/main/AndroidManifest.xml
+++ b/testapps/testapp/src/main/AndroidManifest.xml
@@ -87,6 +87,15 @@
                     android:path="/1wIqXSqBj7w+h11ZifsnqwgyKrY="/>
             </intent-filter>
         </activity>
+
+        <!-- Receiver for testing silent auth from background context (Doze repro) -->
+        <receiver
+            android:name="com.microsoft.identity.client.testapp.SilentAuthReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.microsoft.identity.client.testapp.SILENT_AUTH" />
+            </intent-filter>
+        </receiver>
     </application>
 
 </manifest>

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -67,10 +67,9 @@ public class SilentAuthReceiver extends BroadcastReceiver {
         Log.w(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
 
         final String scopes = intent.getStringExtra("scopes");
-        final String trimmedScopes = scopes == null ? null : scopes.trim();
-        final String scopeString = StringUtil.isNullOrEmpty(trimmedScopes)
+        final String scopeString = (scopes == null || scopes.trim().isEmpty())
                 ? DEFAULT_SCOPE
-                : trimmedScopes;
+                : scopes.trim();
 
         Log.w(TAG, "Scopes: " + scopeString);
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -1,0 +1,194 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.testapp;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.microsoft.identity.client.AcquireTokenSilentParameters;
+import com.microsoft.identity.client.AuthenticationCallback;
+import com.microsoft.identity.client.IAccount;
+import com.microsoft.identity.client.IAuthenticationResult;
+import com.microsoft.identity.client.IMultipleAccountPublicClientApplication;
+import com.microsoft.identity.client.IPublicClientApplication;
+import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
+import com.microsoft.identity.client.PublicClientApplication;
+import com.microsoft.identity.client.exception.MsalException;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * BroadcastReceiver that triggers acquireTokenSilent from a background context.
+ *
+ * This runs at PROCESS_STATE_RECEIVER priority, which does NOT elevate the
+ * Broker process enough to get a dozable-allow firewall rule. This simulates
+ * the production scenario where Outlook handles an FCM push in the background
+ * and calls the Broker via OneAuth.
+ *
+ * Usage:
+ *   adb shell am broadcast \
+ *     -a com.microsoft.identity.client.testapp.SILENT_AUTH \
+ *     -n com.msft.identity.client.sample.local/com.microsoft.identity.client.testapp.SilentAuthReceiver \
+ *     --es scopes "https://graph.microsoft.com/.default"
+ */
+public class SilentAuthReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "SilentAuthReceiver";
+    public static final String ACTION_SILENT_AUTH =
+            "com.microsoft.identity.client.testapp.SILENT_AUTH";
+
+    @Override
+    public void onReceive(final Context context, final Intent intent) {
+        Log.w(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
+
+        final String scopes = intent.getStringExtra("scopes");
+        final String scopeString = (scopes != null) ? scopes : "https://graph.microsoft.com/.default";
+
+        Log.w(TAG, "Scopes: " + scopeString);
+
+        // Use goAsync() to extend the receiver's lifecycle beyond the 10s limit
+        final PendingResult pendingResult = goAsync();
+
+        // Create PCA with default config (uses broker)
+        final int configResourceId = Constants.getResourceIdFromConfigFile(Constants.ConfigFile.DEFAULT);
+
+        PublicClientApplication.create(context.getApplicationContext(),
+                configResourceId,
+                new PublicClientApplication.ApplicationCreatedListener() {
+                    @Override
+                    public void onCreated(IPublicClientApplication application) {
+                        // Force-disable powerOptCheck so the Broker attempts the real
+                        // network call instead of proactively blocking with a Doze check.
+                        // This matches production Authenticator behavior (which doesn't
+                        // have powerOptCheckEnabled set by OneAuth).
+                        application.getConfiguration().setPowerOptCheckEnabled(false);
+
+                        Log.w(TAG, "PCA created, mode: " +
+                                (application instanceof ISingleAccountPublicClientApplication
+                                        ? "SingleAccount" : "MultipleAccount"));
+                        Log.w(TAG, "powerOptCheckEnabled forced to: " +
+                                application.getConfiguration().isPowerOptCheckForEnabled());
+                        loadAccountsAndAcquire(application, scopeString, pendingResult);
+                    }
+
+                    @Override
+                    public void onError(MsalException exception) {
+                        Log.e(TAG, "Failed to create PCA: " + exception.getMessage(), exception);
+                        pendingResult.finish();
+                    }
+                });
+    }
+
+    private void loadAccountsAndAcquire(
+            final IPublicClientApplication app,
+            final String scopeString,
+            final PendingResult pendingResult) {
+
+        if (app instanceof ISingleAccountPublicClientApplication) {
+            final ISingleAccountPublicClientApplication singleApp =
+                    (ISingleAccountPublicClientApplication) app;
+            try {
+                final IAccount account = singleApp.getCurrentAccount().getCurrentAccount();
+                if (account == null) {
+                    Log.e(TAG, "No signed-in account found in single-account mode.");
+                    pendingResult.finish();
+                    return;
+                }
+                doSilentAuth(app, account, scopeString, pendingResult);
+            } catch (Exception e) {
+                Log.e(TAG, "Error loading account: " + e.getMessage(), e);
+                pendingResult.finish();
+            }
+        } else if (app instanceof IMultipleAccountPublicClientApplication) {
+            final IMultipleAccountPublicClientApplication multiApp =
+                    (IMultipleAccountPublicClientApplication) app;
+            multiApp.getAccounts(new IPublicClientApplication.LoadAccountsCallback() {
+                @Override
+                public void onTaskCompleted(List<IAccount> result) {
+                    if (result == null || result.isEmpty()) {
+                        Log.e(TAG, "No accounts found in multiple-account mode.");
+                        pendingResult.finish();
+                        return;
+                    }
+                    Log.w(TAG, "Found " + result.size() + " account(s). Using first.");
+                    doSilentAuth(app, result.get(0), scopeString, pendingResult);
+                }
+
+                @Override
+                public void onError(MsalException exception) {
+                    Log.e(TAG, "Error loading accounts: " + exception.getMessage(), exception);
+                    pendingResult.finish();
+                }
+            });
+        }
+    }
+
+    private void doSilentAuth(
+            final IPublicClientApplication app,
+            final IAccount account,
+            final String scopeString,
+            final PendingResult pendingResult) {
+
+        Log.w(TAG, "Calling acquireTokenSilent for account: " + account.getUsername());
+        Log.w(TAG, "Authority: " + account.getAuthority());
+
+        final AcquireTokenSilentParameters parameters = new AcquireTokenSilentParameters.Builder()
+                .forAccount(account)
+                .fromAuthority(account.getAuthority())
+                .withScopes(Arrays.asList(scopeString.toLowerCase().split(" ")))
+                .forceRefresh(true)  // Force network call to eSTS (no cache)
+                .withCallback(new AuthenticationCallback() {
+                    @Override
+                    public void onSuccess(IAuthenticationResult authenticationResult) {
+                        Log.w(TAG, "=== SUCCESS === Token acquired silently!");
+                        Log.w(TAG, "Access token (first 20 chars): " +
+                                authenticationResult.getAccessToken().substring(0, 20) + "...");
+                        pendingResult.finish();
+                    }
+
+                    @Override
+                    public void onError(MsalException exception) {
+                        Log.e(TAG, "=== FAILED === " + exception.getClass().getSimpleName());
+                        Log.e(TAG, "Error code: " + exception.getErrorCode());
+                        Log.e(TAG, "Message: " + exception.getMessage());
+                        if (exception.getCause() != null) {
+                            Log.e(TAG, "Cause: " + exception.getCause().getClass().getSimpleName()
+                                    + " - " + exception.getCause().getMessage());
+                        }
+                        pendingResult.finish();
+                    }
+
+                    @Override
+                    public void onCancel() {
+                        Log.w(TAG, "=== CANCELLED ===");
+                        pendingResult.finish();
+                    }
+                })
+                .build();
+
+        app.acquireTokenSilentAsync(parameters);
+    }
+}

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -66,9 +66,10 @@ public class SilentAuthReceiver extends BroadcastReceiver {
         Log.w(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
 
         final String scopes = intent.getStringExtra("scopes");
-        final String scopeString = StringUtil.isNullOrEmpty(scopes) || StringUtil.isNullOrEmpty(scopes.trim())
+        final String trimmedScopes = scopes == null ? null : scopes.trim();
+        final String scopeString = StringUtil.isNullOrEmpty(trimmedScopes)
                 ? "https://graph.microsoft.com/.default"
-                : scopes;
+                : trimmedScopes;
 
         Log.w(TAG, "Scopes: " + scopeString);
 
@@ -156,7 +157,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
             final PendingResult pendingResult) {
 
         Log.i(TAG, "Calling acquireTokenSilent for account: " + account.getUsername());
-        Log.w(TAG, "Authority: " + account.getAuthority());
+        Log.i(TAG, "Authority: " + account.getAuthority());
 
         final AcquireTokenSilentParameters parameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(account)
@@ -195,7 +196,16 @@ public class SilentAuthReceiver extends BroadcastReceiver {
     }
 
     private List<String> parseScopes(final String scopeString) {
-        final String[] rawScopes = scopeString.trim().split("\\s+");
+        if (scopeString == null) {
+            return new ArrayList<>();
+        }
+
+        final String trimmedScopeString = scopeString.trim();
+        if (trimmedScopeString.isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        final String[] rawScopes = trimmedScopeString.split("\\s+");
         final List<String> parsedScopes = new ArrayList<>();
 
         for (final String scope : rawScopes) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -164,8 +164,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                     @Override
                     public void onSuccess(IAuthenticationResult authenticationResult) {
                         Log.w(TAG, "=== SUCCESS === Token acquired silently!");
-                        Log.w(TAG, "Access token (first 20 chars): " +
-                                authenticationResult.getAccessToken().substring(0, 20) + "...");
+                        Log.w(TAG, "Silent token acquisition completed successfully.");
                         pendingResult.finish();
                     }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -64,14 +64,14 @@ public class SilentAuthReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
-        Log.w(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
+        Log.i(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
 
         final String scopes = intent.getStringExtra("scopes");
         final String scopeString = (scopes == null || scopes.trim().isEmpty())
                 ? DEFAULT_SCOPE
                 : scopes.trim();
 
-        Log.w(TAG, "Scopes: " + scopeString);
+        Log.i(TAG, "Scopes: " + scopeString);
 
         // Use goAsync() to extend the receiver's lifecycle beyond the 10s limit
         final PendingResult pendingResult = goAsync();
@@ -90,10 +90,10 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                         // have powerOptCheckEnabled set by OneAuth).
                         application.getConfiguration().setPowerOptCheckEnabled(false);
 
-                        Log.w(TAG, "PCA created, mode: " +
+                        Log.i(TAG, "PCA created, mode: " +
                                 (application instanceof ISingleAccountPublicClientApplication
                                         ? "SingleAccount" : "MultipleAccount"));
-                        Log.w(TAG, "powerOptCheckEnabled forced to: " +
+                        Log.i(TAG, "powerOptCheckEnabled forced to: " +
                                 application.getConfiguration().isPowerOptCheckForEnabled());
                         loadAccountsAndAcquire(application, scopeString, pendingResult);
                     }
@@ -137,7 +137,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                         pendingResult.finish();
                         return;
                     }
-                    Log.w(TAG, "Found " + result.size() + " account(s). Using first.");
+                    Log.i(TAG, "Found " + result.size() + " account(s). Using first.");
                     doSilentAuth(app, result.get(0), scopeString, pendingResult);
                 }
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -58,6 +58,7 @@ import java.util.List;
 public class SilentAuthReceiver extends BroadcastReceiver {
 
     private static final String TAG = "SilentAuthReceiver";
+    private static final String DEFAULT_SCOPE = "https://graph.microsoft.com/.default";
     public static final String ACTION_SILENT_AUTH =
             "com.microsoft.identity.client.testapp.SILENT_AUTH";
 
@@ -68,7 +69,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
         final String scopes = intent.getStringExtra("scopes");
         final String trimmedScopes = scopes == null ? null : scopes.trim();
         final String scopeString = StringUtil.isNullOrEmpty(trimmedScopes)
-                ? "https://graph.microsoft.com/.default"
+                ? DEFAULT_SCOPE
                 : trimmedScopes;
 
         Log.w(TAG, "Scopes: " + scopeString);
@@ -156,7 +157,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
             final String scopeString,
             final PendingResult pendingResult) {
 
-        Log.i(TAG, "Calling acquireTokenSilent for account: " + account.getUsername());
+        Log.i(TAG, "Calling acquireTokenSilent for selected account.");
         Log.i(TAG, "Authority: " + account.getAuthority());
 
         final AcquireTokenSilentParameters parameters = new AcquireTokenSilentParameters.Builder()
@@ -196,16 +197,10 @@ public class SilentAuthReceiver extends BroadcastReceiver {
     }
 
     private List<String> parseScopes(final String scopeString) {
-        if (scopeString == null) {
-            return new ArrayList<>();
-        }
-
-        final String trimmedScopeString = scopeString.trim();
-        if (trimmedScopeString.isEmpty()) {
-            return new ArrayList<>();
-        }
-
-        final String[] rawScopes = trimmedScopeString.split("\\s+");
+        final String normalizedScopeString = StringUtil.isNullOrEmpty(scopeString)
+                ? DEFAULT_SCOPE
+                : scopeString.trim();
+        final String[] rawScopes = normalizedScopeString.split("\\s+");
         final List<String> parsedScopes = new ArrayList<>();
 
         for (final String scope : rawScopes) {

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/SilentAuthReceiver.java
@@ -36,8 +36,9 @@ import com.microsoft.identity.client.IPublicClientApplication;
 import com.microsoft.identity.client.ISingleAccountPublicClientApplication;
 import com.microsoft.identity.client.PublicClientApplication;
 import com.microsoft.identity.client.exception.MsalException;
+import com.microsoft.identity.common.java.util.StringUtil;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -65,7 +66,9 @@ public class SilentAuthReceiver extends BroadcastReceiver {
         Log.w(TAG, "=== SilentAuthReceiver triggered (PROCESS_STATE_RECEIVER) ===");
 
         final String scopes = intent.getStringExtra("scopes");
-        final String scopeString = (scopes != null) ? scopes : "https://graph.microsoft.com/.default";
+        final String scopeString = StringUtil.isNullOrEmpty(scopes) || StringUtil.isNullOrEmpty(scopes.trim())
+                ? "https://graph.microsoft.com/.default"
+                : scopes;
 
         Log.w(TAG, "Scopes: " + scopeString);
 
@@ -79,7 +82,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                 configResourceId,
                 new PublicClientApplication.ApplicationCreatedListener() {
                     @Override
-                    public void onCreated(IPublicClientApplication application) {
+                    public void onCreated(final IPublicClientApplication application) {
                         // Force-disable powerOptCheck so the Broker attempts the real
                         // network call instead of proactively blocking with a Doze check.
                         // This matches production Authenticator behavior (which doesn't
@@ -95,7 +98,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                     }
 
                     @Override
-                    public void onError(MsalException exception) {
+                    public void onError(final MsalException exception) {
                         Log.e(TAG, "Failed to create PCA: " + exception.getMessage(), exception);
                         pendingResult.finish();
                     }
@@ -127,7 +130,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                     (IMultipleAccountPublicClientApplication) app;
             multiApp.getAccounts(new IPublicClientApplication.LoadAccountsCallback() {
                 @Override
-                public void onTaskCompleted(List<IAccount> result) {
+                public void onTaskCompleted(final List<IAccount> result) {
                     if (result == null || result.isEmpty()) {
                         Log.e(TAG, "No accounts found in multiple-account mode.");
                         pendingResult.finish();
@@ -138,7 +141,7 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                 }
 
                 @Override
-                public void onError(MsalException exception) {
+                public void onError(final MsalException exception) {
                     Log.e(TAG, "Error loading accounts: " + exception.getMessage(), exception);
                     pendingResult.finish();
                 }
@@ -152,24 +155,24 @@ public class SilentAuthReceiver extends BroadcastReceiver {
             final String scopeString,
             final PendingResult pendingResult) {
 
-        Log.w(TAG, "Calling acquireTokenSilent for account: " + account.getUsername());
+        Log.i(TAG, "Calling acquireTokenSilent for account: " + account.getUsername());
         Log.w(TAG, "Authority: " + account.getAuthority());
 
         final AcquireTokenSilentParameters parameters = new AcquireTokenSilentParameters.Builder()
                 .forAccount(account)
                 .fromAuthority(account.getAuthority())
-                .withScopes(Arrays.asList(scopeString.toLowerCase().split(" ")))
+                .withScopes(parseScopes(scopeString))
                 .forceRefresh(true)  // Force network call to eSTS (no cache)
                 .withCallback(new AuthenticationCallback() {
                     @Override
-                    public void onSuccess(IAuthenticationResult authenticationResult) {
-                        Log.w(TAG, "=== SUCCESS === Token acquired silently!");
-                        Log.w(TAG, "Silent token acquisition completed successfully.");
+                    public void onSuccess(final IAuthenticationResult authenticationResult) {
+                        Log.i(TAG, "=== SUCCESS === Token acquired silently!");
+                        Log.i(TAG, "Silent token acquisition completed successfully.");
                         pendingResult.finish();
                     }
 
                     @Override
-                    public void onError(MsalException exception) {
+                    public void onError(final MsalException exception) {
                         Log.e(TAG, "=== FAILED === " + exception.getClass().getSimpleName());
                         Log.e(TAG, "Error code: " + exception.getErrorCode());
                         Log.e(TAG, "Message: " + exception.getMessage());
@@ -189,5 +192,18 @@ public class SilentAuthReceiver extends BroadcastReceiver {
                 .build();
 
         app.acquireTokenSilentAsync(parameters);
+    }
+
+    private List<String> parseScopes(final String scopeString) {
+        final String[] rawScopes = scopeString.trim().split("\\s+");
+        final List<String> parsedScopes = new ArrayList<>();
+
+        for (final String scope : rawScopes) {
+            if (!StringUtil.isNullOrEmpty(scope)) {
+                parsedScopes.add(scope);
+            }
+        }
+
+        return parsedScopes;
     }
 }


### PR DESCRIPTION
[AB#3612535](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3612535)


## Summary

Add a BroadcastReceiver to MsalTestApp that triggers acquireTokenSilent from a background process context (PROCESS_STATE_RECEIVER). This enables reliable reproduction of the Doze network-block issue that affects background broker auth triggered by FCM notifications.

## Root Cause (from investigation)

When a **foreground** app binds to Broker via IPC, Android's NetworkPolicyManagerService adds a \dozable-allow\ firewall rule for the Broker's UID — masking the Doze network block during UI testing.

When the caller is in a **background** context (BroadcastReceiver/Service handling FCM), the IPC binding does NOT elevate the Broker enough for \dozable-allow\. The Broker's network call to eSTS fails with \UnknownHostException\.

## Evidence

- Confirmed via \dumpsys netpolicy\ firewall rule logs (UID 11697 dozable-allow toggling)
- Confirmed via AOSP \DeviceIdleController.java\ and \NetworkPolicyManagerService\ source
- Successfully reproduced: \io_error: Unable to resolve host login.microsoftonline.com\

## Files

- **SilentAuthReceiver.java** — BroadcastReceiver that calls acquireTokenSilent with forceRefresh + powerOptCheckEnabled=false
- **AndroidManifest.xml** — Receiver registration with exported=true

## Usage

\\\ash
# Prerequisites: broker + MsalTestApp installed, account signed in
adb shell dumpsys battery unplug
adb shell dumpsys deviceidle force-idle
adb shell am broadcast -a com.microsoft.identity.client.testapp.SILENT_AUTH -n com.msft.identity.client.sample.local/com.microsoft.identity.client.testapp.SilentAuthReceiver
adb logcat -s SilentAuthReceiver:*
# Cleanup:
adb shell dumpsys deviceidle unforce && adb shell dumpsys battery reset
\\\

## Test script

A companion script \scripts/doze-repro-test.sh\ in android-complete automates the full sequence.