### PR TITLE
Fix changelog: move #2511 from Version 8.3.3 to vNext

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,12 +2,12 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [MINOR] Provide public api to set custom headers for CIAM requests (#2511)
 
 Version 8.3.3
 ----------
 - [PATCH] Update common @24.3.0
 - [PATCH] Move Multiple Listening apps check to the authorization layer (#2494)
-- [MINOR] Provide public api to set custom headers for CIAM requests (#2511)
 
 Version 8.3.2
 ----------


### PR DESCRIPTION
When release-integration/8.3.3 was back-merged into dev (#2520), entry #2511 (which was merged to dev *after* the 8.3.3 RC cut) got listed under `Version 8.3.3`. It actually shipped to dev after 8.3.3 was finalized, so it belongs under `vNext` for the next release.

This PR moves 1 entry from `Version 8.3.3` to `vNext`:

- #2511 Provide public api to set custom headers for CIAM requests

### Verification
Identified by diffing the current dev `changelog` against the file at commit `12b16091c` (final 8.3.3 "remove RC" cut).

[AB#3618269](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3618269)