### PR TITLE
update to sharepoint resource for Token , Fixes AB#3654871

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3321136.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3321136.kt
@@ -64,7 +64,7 @@ class TestCase3321136 : AbstractMsalBrokerTest() {
         val authTestParams: MsalAuthTestParams = MsalAuthTestParams.builder()
             .activity(mActivity)
             .loginHint(username)
-            .scopes(listOf(*mScopes))
+            .resource("00000003-0000-0ff1-ce00-000000000000") // Office 365 SharePoint Online
             .promptParameter(Prompt.SELECT_ACCOUNT)
             .msalConfigResourceId(configFileResourceId)
             .build()
@@ -100,7 +100,7 @@ class TestCase3321136 : AbstractMsalBrokerTest() {
     }
 
     override fun getScopes(): Array<String> {
-        return arrayOf("user.read")
+        return arrayOf()
     }
 
     override fun getAuthority(): String {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3321139.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3321139.kt
@@ -54,7 +54,7 @@ class TestCase3321139 : AbstractMsalBrokerTest() {
         val authTestParams: MsalAuthTestParams = MsalAuthTestParams.builder()
             .activity(mActivity)
             .loginHint(username)
-            .scopes(listOf(*mScopes))
+            .resource("00000003-0000-0ff1-ce00-000000000000") // Office 365 SharePoint Online
             .promptParameter(Prompt.SELECT_ACCOUNT)
             .msalConfigResourceId(configFileResourceId)
             .build()
@@ -91,7 +91,7 @@ class TestCase3321139 : AbstractMsalBrokerTest() {
     }
 
     override fun getScopes(): Array<String> {
-        return arrayOf("user.read")
+        return arrayOf()
     }
 
     override fun getAuthority(): String {

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3522687.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/strongkey/TestCase3522687.kt
@@ -59,7 +59,7 @@ class TestCase3522687 : AbstractMsalBrokerTest() {
         val authTestParams: MsalAuthTestParams = MsalAuthTestParams.builder()
             .activity(mActivity)
             .loginHint(username)
-            .scopes(listOf(*mScopes))
+            .resource("00000003-0000-0ff1-ce00-000000000000") // Office 365 SharePoint Online
             .promptParameter(Prompt.SELECT_ACCOUNT)
             .msalConfigResourceId(configFileResourceId)
             .build()
@@ -81,7 +81,7 @@ class TestCase3522687 : AbstractMsalBrokerTest() {
     }
 
     override fun getScopes(): Array<String> {
-        return arrayOf("user.read")
+        return arrayOf()
     }
 
     override fun getAuthority(): String {


### PR DESCRIPTION
[AB#3654871](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3654871)

Due to an ongoing CA change [Enforcement for baseline scopes in Conditional Access - Microsoft Entra ID | Microsoft Learn](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-enforcement-resource-exclusions)

User.read is no longer triggered by TP-CA.

Switched to Sharepoint since that's the direct TP-CA scope.
(Also made a change on the portal to make the test app supports sharepoint scopes)

Run: https://identitydivision.visualstudio.com/Engineering/_build/results?buildId=1649620&view=results

https://console.firebase.google.com/u/1/project/msal-automation-app-764c7/testlab/histories/bh.8ea0f850e176ede8/matrices/5652255611600854094/details?stepId=bs.5728d347d675a2e4&testCaseId=1&tabId=video