### PR TITLE
Skip MAM test for AutoBroker build variant, Fixes AB#3665913

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/mam/TestCase2516571.kt
@@ -46,10 +46,17 @@ class TestCase2516571 : AbstractMsalUiTest(){
 
     @Test
     fun test_2516571_MAM_BrokerRequired() {
-        Assume.assumeFalse( "Only run this test if there are local flights",
-                BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.isEmpty()
-        );
-        
+        Assume.assumeFalse(
+            "Skipping: this test does not run on the AutoBroker build variant " +
+                "(SELECTED_BROKER=${BuildConfig.SELECTED_BROKER})",
+            BuildConfig.SELECTED_BROKER == BuildConfig.AutoBroker
+        )
+
+        Assume.assumeFalse(
+            "Only run this test if there are local flights",
+            BuildConfig.COPY_OF_LOCAL_FLIGHTS_FOR_TEST_PURPOSES.isEmpty()
+        )
+
         // Fetch credentials
         val username: String = mLabAccount.username
         val password: String = mLabAccount.password


### PR DESCRIPTION
This pull request updates the `TestCase2516571` test to improve its conditional execution logic. The main changes ensure that the test is skipped when running on the AutoBroker build variant and maintain the check for local flights.

Test execution logic improvements:

* Updated the test method in `TestCase2516571.kt` to skip execution when the `BuildConfig.SELECTED_BROKER` is set to `AutoBroker`, providing a clear skip message.
* Retained the existing check to only run the test if there are local flights, improving test reliability and clarity.


[AB#3665913](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3665913)
