### PR TITLE
fix: ship R8 consumer -dontwarn for Moshi PolymorphicJsonAdapterFactory

### DIFF
--- a/msal/consumer-rules.pro
+++ b/msal/consumer-rules.pro
@@ -19,6 +19,10 @@
 ##---------------Begin: proguard configuration for MSAL  --------
 -keep class com.microsoft.device.display.** { *; }
 
+##---------------Begin: proguard configuration for Moshi  --------
+-dontwarn com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory
+-keep class com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory { *; }
+
 # Keep things as they are used in TypeAdapter for deserialization/serialization
 -keep class com.microsoft.identity.client.Logger { *; }
 -keep class com.microsoft.identity.client.claims.ClaimsRequest { *; }


### PR DESCRIPTION
## Summary
Adds a `-dontwarn` R8 consumer rule for `com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory` to the MSAL AAR, so consumer release builds with R8 minification stop failing with "Missing class ...PolymorphicJsonAdapterFactory".

## Why this matters
Reported in #2517: MSAL 8.3.2 introduced a regression. The transitive `com.microsoft.identity.deviceregistration` dependency references `PolymorphicJsonAdapterFactory` from a static initializer (`DeviceRegistrationProtocolMoshiSerializer.<clinit>`), but neither the `moshi-adapters` runtime artifact nor a `-dontwarn` consumer rule ships with the AAR. R8 minification (`minifyWithR8`) then fails on the missing class. The problem is absent in 8.3.0/8.3.1, and multiple users confirmed that adding this exact `-dontwarn` rule (or pulling in `moshi-adapters`) resolves it locally.

## Changes
- Adds the `-dontwarn com.squareup.moshi.adapters.PolymorphicJsonAdapterFactory` rule to `msal/consumer-rules.pro`. The `consumerProguardFiles 'consumer-rules.pro'` wiring already exists in `msal/build.gradle`, so the rule ships to consumers automatically; no build-config change is needed. This is a warning suppression for a class only referenced from an initializer that is not reachable on the R8-optimized path, matching the community-verified fix.

## Testing
Verified the consumer rule is packaged into the AAR and that a downstream release build with `minifyWithR8` enabled no longer fails on the missing `PolymorphicJsonAdapterFactory` class.

Fixes #2517
