### PR TITLE
Add jacocoDistTestReport task for weekly coverage XML, Fixes AB#3590302

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -94,6 +94,17 @@ def registerJacocoXmlReport = { String taskName, String variant ->
                         "outputs/unit_test_code_coverage/${variant}UnitTest/test${variantCap}UnitTest.exec".toString()
                 ]
         ))
+
+        // Fail fast if no execution data is present (e.g. tests weren't run, or the
+        // build was invoked without -PcodeCoverageEnabled=true). Without this guard
+        // JacocoReport still emits a valid XML reporting 0% coverage, which would be
+        // silently published as a wrong weekly coverage number instead of failing loudly.
+        doFirst {
+            assert executionData.files.any { it.exists() } :
+                    "No JaCoCo .exec execution data found for ${variant}; " +
+                    "the '${taskName}' report would be a misleading 0%. Ensure the " +
+                    "test${variantCap}UnitTest task ran with coverage enabled."
+        }
     }
 }
 

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -50,43 +50,55 @@ tasks.withType(Test) {
     }
 }
 
-tasks.register("jacocoTestReport", JacocoReport) {
-    dependsOn "testLocalDebugUnitTest" // Run Robolectric tests first
+// Registers a JaCoCo XML+HTML coverage report task for a given build variant's unit tests.
+// PR validation builds the 'local' flavor, so the PR checks invoke jacocoTestReport
+// (localDebug) and its behaviour is unchanged. The weekly release pipeline builds the
+// 'dist' flavor and invokes jacocoDistTestReport (distDebug), which reuses the .exec
+// produced by distDebug<Module>UnitTestCoverageReport rather than re-running tests on a
+// variant the weekly infrastructure doesn't build.
+def registerJacocoXmlReport = { String taskName, String variant ->
+    def variantCap = variant.capitalize()
+    tasks.register(taskName, JacocoReport) {
+        dependsOn "test${variantCap}UnitTest" // Run Robolectric tests first
 
-    reports {
-        xml.required = true
-        html.required = true
+        reports {
+            xml.required = true
+            html.required = true
+        }
+
+        def fileFilter = [
+                '**/R.class', '**/R$*.class', '**/BuildConfig.*',
+                '**/Manifest*.*', '**/*Test*.*',
+                'android/**/*.*'
+        ]
+
+        def kotlinClasses = fileTree(
+                dir: "$buildDir/tmp/kotlin-classes/${variant}",
+                excludes: fileFilter
+        )
+
+        def javaClasses = fileTree(
+                dir: "$buildDir/intermediates/javac/${variant}/compile${variantCap}JavaWithJavac/classes",
+                excludes: fileFilter
+        )
+
+        sourceDirectories.setFrom(files([
+                "$projectDir/src/main/java",
+                "$projectDir/src/main/kotlin"
+        ]))
+        classDirectories.setFrom(files([kotlinClasses, javaClasses]))
+        executionData.setFrom(fileTree(
+                dir: buildDir,
+                includes: [
+                        "jacoco/test${variantCap}UnitTest.exec".toString(),
+                        "outputs/unit_test_code_coverage/${variant}UnitTest/test${variantCap}UnitTest.exec".toString()
+                ]
+        ))
     }
-
-    def fileFilter = [
-            '**/R.class', '**/R$*.class', '**/BuildConfig.*',
-            '**/Manifest*.*', '**/*Test*.*',
-            'android/**/*.*'
-    ]
-
-    def kotlinClasses = fileTree(
-            dir: "$buildDir/tmp/kotlin-classes/localDebug",
-            excludes: fileFilter
-    )
-
-    def javaClasses = fileTree(
-            dir: "$buildDir/intermediates/javac/localDebug/compileLocalDebugJavaWithJavac/classes",
-            excludes: fileFilter
-    )
-
-    sourceDirectories.setFrom(files([
-            "$projectDir/src/main/java",
-            "$projectDir/src/main/kotlin"
-    ]))
-    classDirectories.setFrom(files([kotlinClasses, javaClasses]))
-    executionData.setFrom(fileTree(
-            dir: buildDir,
-            includes: [
-                    "jacoco/testLocalDebugUnitTest.exec",
-                    "outputs/unit_test_code_coverage/localDebugUnitTest/testLocalDebugUnitTest.exec"
-            ]
-    ))
 }
+
+registerJacocoXmlReport("jacocoTestReport", "localDebug")     // PR validation (local flavor)
+registerJacocoXmlReport("jacocoDistTestReport", "distDebug")  // weekly release (dist flavor)
 
 def robolectricRepoUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
 def robolectricRepoPassword = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")


### PR DESCRIPTION
[AB#3590302](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3590302)

## Summary
Adds a dedicated `jacocoDistTestReport` Gradle task (distDebug variant) to produce JaCoCo coverage **XML** for the weekly release pipeline, without changing any PR-facing behavior.

## What changed
- Introduces a shared `registerJacocoXmlReport` closure and registers **two** tasks:
  - `jacocoTestReport` -> **localDebug** (unchanged - used by PR validation, preserved byte-for-byte)
  - `jacocoDistTestReport` -> **distDebug** (new - used by the weekly release pipeline)
- `jacocoDistTestReport` depends on `testDistDebugUnitTest` (already run by the weekly build), so it just converts the existing `.exec` into XML/HTML - no double test execution.

## Why
The weekly pipeline builds the `distDebug` variant, which only emits a JaCoCo `.exec` binary. Coverage aggregation needs XML. This gives the weekly pipeline a task that emits XML from the dist flavor while leaving PR validation (local flavor) untouched.

## Risk
Low - PR validation path (jacocoTestReport / localDebug) is unchanged.