### PR TITLE
Upgrade buildtools, addresses AB#3699364, Fixes AB#3699364

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -52,9 +52,9 @@ stages:
         displayName: 'Set VSTS Fields in Environment'
       - template: azure-pipelines/templates/steps/automation-cert.yml@common
       - task: JavaToolInstaller@0
-        displayName: Use Java 17
+        displayName: Use Java 21
         inputs:
-          versionSpec: '17'
+          versionSpec: '21'
           jdkArchitectureOption: x64
           jdkSourceOption: PreInstalled
       - task: CodeQL3000Init@0
@@ -65,7 +65,7 @@ stages:
           tasks: clean msal:assembleLocal
           publishJUnitResults: false
           testResultsFiles: '**/build/test-results/TEST-*.xml'
-          jdkVersion: $(BuildParameters.jdkVersion)
+          jdkVersion: 1.21
           jdkArchitecture: $(BuildParameters.jdkArchitecture)
           sqGradlePluginVersion: 2.0.1
       - task: CodeQL3000Finalize@0
@@ -74,7 +74,7 @@ stages:
         inputs:
           tasks: msal:jacocoTestReport  -PcodeCoverageEnabled=true -ProbolectricSdkVersion=${{variables.robolectricSdkVersion}} -PmockApiUrl=$(MOCK_API_URL) -PnativeAuthConfigString=$(NATIVE_AUTH_CONFIG_STRING)
           javaHomeSelection: $(BuildParameters.javaHomeSelection)
-          jdkVersion: 1.17
+          jdkVersion: 1.21
       - publish: $(Build.SourcesDirectory)/msal/build/reports/jacoco/jacocoTestReport/jacocoTestReport.xml
         artifact: jacocoReport
         displayName: 'Publish JaCoCo Report Artifact (PR Branch)'
@@ -163,7 +163,7 @@ stages:
         inputs:
           tasks: clean msal:lintLocalDebug
           publishJUnitResults: false
-          jdkVersion: 1.17
+          jdkVersion: 1.21
   - template: azure-pipelines/code-coverage/compare-code-coverage.yml@common
     parameters:
       commonRepoAlias: common

--- a/azure-pipelines/pull-request-validation/pr-msalautomationapp.yml
+++ b/azure-pipelines/pull-request-validation/pr-msalautomationapp.yml
@@ -8,7 +8,7 @@ name: $(date:yyyyMMdd)$(rev:.r)
 trigger: none
 variables:
 - name: BuildParameters.jdkVersion
-  value: 1.17
+  value: 1.21
 - name: BuildParameters.jdkArchitecture
   value: x64
 
@@ -40,9 +40,9 @@ stages:
         displayName: 'Set VSTS Fields in Environment'
       - template: azure-pipelines/templates/steps/automation-cert.yml@common
       - task: JavaToolInstaller@0
-        displayName: Use Java 17
+        displayName: Use Java 21
         inputs:
-          versionSpec: '17'
+          versionSpec: '21'
           jdkArchitectureOption: x64
           jdkSourceOption: PreInstalled
       - task: Gradle@2

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,13 @@ ariaTenantTokenTest="1e8435186fa849b28b1a402fb5074ff1-0b91a9ec-efad-440c-b92c-ac
 android.useAndroidX=true
 android.enableJetifier=true
 
+# AGP 9 opt-out (STOPGAP, removed in AGP 10): restores the legacy DSL + Variant API
+# (libraryVariants/applicationVariants) still used by common/build.gradle (output naming
+# + per-variant Javadoc). Root gradle.properties governs the whole multi-project build,
+# so this must live here (the copy in common/gradle.properties is not read as a subproject).
+# Track migration to the androidComponents API before AGP 10.
+android.newDsl=false
+
 # https://office.visualstudio.com/Outlook%20Mobile/_wiki/wikis/Outlook-Mobile.wiki/3780/Android-Studio-Gradle-Performance-tips-and-tricks
 org.gradle.parallel=true
 org.gradle.daemon=true

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -3,13 +3,17 @@
 ext {
     // SDK
     minSdkVersion = 24
-    targetSdkVersion = 35
-    compileSdkVersion = 36
-    buildToolsVersion = "36.0.0"
+    targetSdkVersion = 36
+    compileSdkVersion = 37
+    buildToolsVersion = "37.0.0"
 
     // Plugins
-    gradleVersion = '8.10.0'
-    kotlinVersion = '1.8.0'
+    // NOTE: 'gradleVersion' is the AGP (Android Gradle Plugin) version, NOT the Gradle
+    // wrapper version (that lives in gradle/wrapper/gradle-wrapper.properties = 9.3.1).
+    gradleVersion = '9.1.1'
+    // Kotlin 1.8.x has no Gradle 9 support (removed SelfResolvingDependency); AGP 9
+    // built-in Kotlin also needs KGP >= 2.2.10. Matches the upgraded common submodule.
+    kotlinVersion = '2.2.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
     
@@ -42,7 +46,7 @@ ext {
     powerMockVersion = "2.0.9"
     runnerVersion = "1.2.0"
     rulesVersion = "1.2.0"
-    robolectricVersion = "4.14"
+    robolectricVersion = "4.16.1"
     uiAutomatorVersion = "2.2.0"
     daggerVersion = "2.31.2"
     daggerCompilerVersion = "2.31.2"
@@ -67,7 +71,7 @@ ext {
     yubikitAndroidVersion = "2.5.0"
     yubikitPivVersion = "2.5.0"
     powerliftAndroidVersion="1.0.3"
-    kotlinXCoroutinesVersion = "1.6.4"
+    kotlinXCoroutinesVersion = "1.9.0"
     mockkVersion = "1.11.0"
     mockitoKotlinVersion = "4.1.0"
     androidxAnnotationVersion = "1.4.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-all.zip

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
-    id 'com.microsoft.identity.buildsystem' version '0.2.6'
+    id 'com.microsoft.identity.buildsystem' version '0.3.0'
     id 'com.android.library'
     id 'pmd'
     id 'checkstyle'

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -286,8 +286,13 @@ dependencies {
     testImplementation "org.mockito:mockito-core:$rootProject.ext.mockitoCoreVersion"
     testImplementation ("org.robolectric:robolectric:$rootProject.ext.robolectricVersion")
     testImplementation "androidx.test:core:$rootProject.ext.androidxTestCoreVersion"
-    testLocalImplementation project(':testutils')
-    testLocalImplementation project(':LabApiUtilities')
+    // The common-source projects are only on the build when the `common` submodule is checked out
+    // (see settings.gradle). Guard these `local`-flavor project deps so :msal still configures for
+    // DIST/publish builds that consume the PUBLISHED common artifacts instead.
+    if (findProject(':testutils') != null) {
+        testLocalImplementation project(':testutils')
+        testLocalImplementation project(':LabApiUtilities')
+    }
     testDistImplementation("com.microsoft.identity:testutils:0.0+") {
         exclude module: 'common'
         exclude group: 'com.microsoft.identity', module: 'LabApiUtilities'
@@ -313,15 +318,19 @@ dependencies {
     // instrumented tests; the org.gradle.test-retry plugin only covers JVM/Robolectric unit tests).
     // transitive = false keeps only the rule's classes and avoids dragging testutils' whole
     // transitive graph onto the androidTest classpath.
-    androidTestLocalImplementation(project(':testutils')) {
-        transitive = false
+    if (findProject(':testutils') != null) {
+        androidTestLocalImplementation(project(':testutils')) {
+            transitive = false
+        }
     }
     androidTestDistImplementation("com.microsoft.identity:testutils:0.0+") {
         transitive = false
     }
     // 'local' flavor dependencies
-    localApi(project(":common")) {
-        transitive = true
+    if (findProject(':common') != null) {
+        localApi(project(":common")) {
+            transitive = true
+        }
     }
 
     snapshotApi(group: 'com.microsoft.identity', name: 'common', version: commonVersion, changing: true)
@@ -330,7 +339,9 @@ dependencies {
         transitive = true
     }
 
-    testLocalImplementation(testFixtures(project(":common4j")))
+    if (findProject(':common4j') != null) {
+        testLocalImplementation(testFixtures(project(":common4j")))
+    }
     testDistImplementation(testFixtures("com.microsoft.identity:common4j:${common4jVersion}"))
 
     implementation "io.opentelemetry:opentelemetry-api:$rootProject.ext.openTelemetryVersion"

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -1,10 +1,11 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
-    id 'com.microsoft.identity.buildsystem' version '0.2.5'
+    id 'com.microsoft.identity.buildsystem' version '0.2.6'
     id 'com.android.library'
     id 'pmd'
     id 'checkstyle'
     id 'maven-publish'
-    id 'kotlin-android'
     id 'jacoco'
 
     // Test retries
@@ -14,6 +15,14 @@ plugins {
 apply from: 'versioning/version_tasks.gradle'
 
 group = 'com.microsoft.identity.client'
+
+// Built-in Kotlin (AGP 9): replaces the android { kotlinOptions { } } block that the
+// removed 'kotlin-android' plugin previously provided.
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
+}
 
 buildSystem {
     desugar = false
@@ -106,16 +115,12 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode getAppVersionCode()
         versionName getAppVersionName()
-        project.archivesBaseName = "msal"
+        project.base.archivesName = "msal"
         project.version = android.defaultConfig.versionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures {
         buildConfig = true
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
 
     buildTypes {
@@ -183,7 +188,7 @@ android {
 
     libraryVariants.all { variant ->
         variant.outputs.all {
-            def fileName = "${archivesBaseName}-${version}.aar"
+            def fileName = "${project.base.archivesName.get()}-${version}.aar"
             outputFileName = fileName
         }
     }
@@ -365,10 +370,10 @@ afterEvaluate {
     // to include the version number.
     tasks.named("assembleDistRelease").configure {
         if (project.findProperty("renameOutput")?.toString()?.toBoolean() == true) {
-            def buildFile = file("$buildDir/outputs/aar/${archivesBaseName}-dist-release.aar")
+            def buildFile = file("$buildDir/outputs/aar/${project.base.archivesName.get()}-dist-release.aar")
             println "Build file $buildFile"
             doLast {
-                def renamedFile = file("$buildDir/outputs/aar/${archivesBaseName}-${version}.aar")
+                def renamedFile = file("$buildDir/outputs/aar/${project.base.archivesName.get()}-${version}.aar")
                 println "Renaming build file $buildFile to '$renamedFile'"
                 if (!buildFile.renameTo(renamedFile)) {
                     println "Rename failed!"

--- a/msal/src/androidTest/AndroidManifest.xml
+++ b/msal/src/androidTest/AndroidManifest.xml
@@ -4,10 +4,6 @@
     android:versionCode="1"
     android:versionName="1.0">
 
-    <uses-sdk
-        android:minSdkVersion="21"
-        android:targetSdkVersion="25" />
-
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 

--- a/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
+++ b/msal/src/androidTest/java/com/microsoft/identity/client/PublicClientConfigurationTest.java
@@ -66,7 +66,10 @@ public class PublicClientConfigurationTest {
     @Before
     public void setUp() {
         mContext = InstrumentationRegistry.getContext().getApplicationContext();
-        mDefaultConfig = loadConfig(R.raw.msal_default_config);
+        // msal_default_config is a MAIN source-set resource, so it lives in the module R
+        // (com.microsoft.identity.msal.R), not the androidTest R (…msal.test.R) imported above.
+        // Under AGP's non-transitive R classes the test R only exposes androidTest resources.
+        mDefaultConfig = loadConfig(com.microsoft.identity.msal.R.raw.msal_default_config);
     }
 
     @After

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInEmailPasswordTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInEmailPasswordTest.kt
@@ -34,7 +34,6 @@ import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignInResult
 import com.microsoft.identity.nativeauth.statemachine.results.SignOutResult
 import kotlinx.coroutines.runBlocking
-import org.checkerframework.checker.units.qual.s
 import org.junit.Assert
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue

--- a/msalautomationapp/build.gradle
+++ b/msalautomationapp/build.gradle
@@ -1,5 +1,6 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
 
 def msalVersion = "5.10.0"
 
@@ -11,6 +12,14 @@ if (project.hasProperty("distMsalVersion")) {
 def copyOfLocalFlights = ""
 if (project.hasProperty("localFlights")) {
     copyOfLocalFlights = localFlights
+}
+
+// Built-in Kotlin (AGP 9): replaces the android { kotlinOptions { } } block that the
+// removed 'kotlin-android' plugin previously provided.
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
 }
 
 android {
@@ -26,9 +35,8 @@ android {
     }
     buildFeatures {
         buildConfig = true
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
+        // AGP 9 defaults resValues to off; the local/dist flavors define resValue(...) so opt in.
+        resValues = true
     }
     final String BROKER_HOST = "BrokerHost"
     final String BROKER_MICROSOFT_AUTHENTICATOR = "BrokerMicrosoftAuthenticator"

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,10 +1,13 @@
 pluginManagement {
-     // Note: Since our plugin references the android plugin we need to include google() here.
      repositories {
-         // If you don't have access to the package feed uncomment these repositories
+         // Keep ONLY the ADO feed here. Declaring the public repos (gradlePluginPortal/google/
+         // mavenCentral) breaks buildsystem plugin resolution in the 1ES pipelines: they can't
+         // reach the public repos, and the NewAndroid feed proxies google()/gradlePluginPortal()
+         // as upstreams anyway, so AGP still resolves. For a purely local build without feed
+         // access, temporarily uncomment the lines below.
          //  mavenCentral()
-         google()
-         gradlePluginPortal()
+         //  google()
+         //  gradlePluginPortal()
          maven {
              name "vsts-maven-new-android"
              url "https://identitydivision.pkgs.visualstudio.com/_packaging/NewAndroid/maven/v1"

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,6 +28,9 @@ project(':common4j').projectDir = new File('common/common4j')
 project(':LabApiUtilities').projectDir = new File('common/LabApiUtilities')
 
 // test apps
-include ':testapps:sample'
+// Gradle 9 rejects includes whose projectDir does not exist (Gradle 8 tolerated it).
+// 'sample' and 'automationapp' have no directory under testapps/ (only 'testapp' exists),
+// so these dead includes are commented out to allow settings to configure.
+// include ':testapps:sample'
 include ':testapps:testapp'
-include ':testapps:automationapp'
+// include ':testapps:automationapp'

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,17 +18,42 @@ pluginManagement {
          }
      }
  }
-include ':msal', ':common', ':keyvault', ':labapi', ':testutils', ':pop-benchmarker',
-        ':package-inspector', ':msalautomationapp', ':uiautomationutilities', ':common4j',
-        ':LabApiUtilities'
+// msal's own projects that do NOT consume the common submodule source — always included
+// (their directories live in this repo, and :msal only references common in its `local` flavor,
+// which is guarded in msal/build.gradle).
+include ':msal', ':package-inspector'
 
-project(':common').projectDir = new File('common/common')
-project(':keyvault').projectDir = new File('common/keyvault')
-project(':labapi').projectDir = new File('common/labapi')
-project(':testutils').projectDir = new File('common/testutils')
-project(':uiautomationutilities').projectDir = new File('common/uiautomationutilities')
-project(':common4j').projectDir = new File('common/common4j')
-project(':LabApiUtilities').projectDir = new File('common/LabApiUtilities')
+// The projects below live in the `common` git submodule (checked out at msal/common).
+// They are only needed when building common FROM SOURCE (the `local` product flavor, plus
+// the automation/benchmark apps). The `dist`/`snapshot` flavors — including the 1ES weekly
+// DIST publish — instead consume the PUBLISHED com.microsoft.identity:common / :common4j
+// artifacts (via -PdistCommonVersion), and those pipelines often run WITHOUT the submodule
+// checked out.
+//
+// Gradle 8 silently tolerated `include`-ing a project whose directory didn't exist; Gradle 9
+// fails hard ("Configuring project ':X' without an existing directory is not allowed"). So we
+// only include the common-source projects when the submodule is actually present on disk.
+if (new File(settingsDir, 'common/common').exists()) {
+    include ':common', ':keyvault', ':labapi', ':testutils',
+            ':uiautomationutilities', ':common4j', ':LabApiUtilities'
+    // These apps consume common modules FROM SOURCE (project(':common'), project(':LabApiUtilities'),
+    // project(':uiautomationutilities'), project(':common4j')) unconditionally, so they can only
+    // configure when the submodule is present. DIST/publish builds don't build these apps.
+    include ':pop-benchmarker', ':msalautomationapp'
+
+    project(':common').projectDir = new File('common/common')
+    project(':keyvault').projectDir = new File('common/keyvault')
+    project(':labapi').projectDir = new File('common/labapi')
+    project(':testutils').projectDir = new File('common/testutils')
+    project(':uiautomationutilities').projectDir = new File('common/uiautomationutilities')
+    project(':common4j').projectDir = new File('common/common4j')
+    project(':LabApiUtilities').projectDir = new File('common/LabApiUtilities')
+} else {
+    logger.lifecycle("[settings.gradle] 'common' submodule not checked out — skipping " +
+            "common-source project includes. DIST/SNAPSHOT builds use the published " +
+            "com.microsoft.identity:common artifacts; for a source (local-flavor) build run: " +
+            "git submodule update --init --recursive")
+}
 
 // test apps
 // Gradle 9 rejects includes whose projectDir does not exist (Gradle 8 tolerated it).

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,9 +56,15 @@ if (new File(settingsDir, 'common/common').exists()) {
 }
 
 // test apps
-// Gradle 9 rejects includes whose projectDir does not exist (Gradle 8 tolerated it).
-// 'sample' and 'automationapp' have no directory under testapps/ (only 'testapp' exists),
-// so these dead includes are commented out to allow settings to configure.
-// include ':testapps:sample'
+// Gradle 9 rejects `include` of a project whose directory doesn't exist (Gradle 8 tolerated it).
+// Rather than dropping these includes, guard each one so it configures only when its directory is
+// present on disk. This keeps ':testapps:automationapp' / ':testapps:sample' in the build for any
+// context that provides those project directories, while a plain checkout (which only has
+// 'testapp') still configures under Gradle 9 instead of failing hard.
 include ':testapps:testapp'
-// include ':testapps:automationapp'
+if (new File(settingsDir, 'testapps/automationapp').exists()) {
+    include ':testapps:automationapp'
+}
+if (new File(settingsDir, 'testapps/sample').exists()) {
+    include ':testapps:sample'
+}

--- a/testapps/testapp/build.gradle
+++ b/testapps/testapp/build.gradle
@@ -23,9 +23,9 @@
  * // THE SOFTWARE.
  */
 
-apply plugin: 'com.android.application'
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
-apply plugin: 'kotlin-android'
+apply plugin: 'com.android.application'
 
 def msalVersion = "8.3.2"
 
@@ -37,6 +37,14 @@ def otelAriaToken = ""
 
 if(project.hasProperty('otelAriaToken')) {
     otelAriaToken = project.otelAriaToken;
+}
+
+// Built-in Kotlin (AGP 9): replaces the android { kotlinOptions { } } block that the
+// removed 'kotlin-android' plugin previously provided.
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_1_8
+    }
 }
 
 android {
@@ -78,15 +86,14 @@ android {
         release {
             signingConfig signingConfigs.release
             minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
-    }
-    kotlinOptions {
-        jvmTarget = "1.8"
     }
     buildFeatures {
         viewBinding true
         buildConfig true
+        // AGP 9 defaults resValues to off; the local/dist flavors define resValue(...) so opt in.
+        resValues true
     }
     lintOptions {
         abortOnError false
@@ -115,6 +122,9 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.ext.kotlinXCoroutinesVersion"
     implementation "androidx.appcompat:appcompat:$rootProject.ext.appCompatVersion"
+    // Edge-to-edge inset handling in StartActivity uses WindowInsetsCompat.Type (androidx.core >= 1.5.0);
+    // appcompat 1.1.0 only pulls core 1.1.0 transitively, so pin core explicitly.
+    implementation "androidx.core:core:$rootProject.ext.androidxCoreVersion"
     implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.legacySupportV4Version"
     implementation "com.google.android.material:material:$rootProject.ext.materialVersion"
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${rootProject.ext.kotlinVersion}"

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/EmailAttributeSignUpFragment.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/EmailAttributeSignUpFragment.kt
@@ -114,8 +114,8 @@ class EmailAttributeSignUpFragment : Fragment() {
                 var password: CharArray? = null
                 if (binding.passwordText.length() > 0) {
                     password = CharArray(binding.passwordText.length())
+                    (binding.passwordText.text as? android.text.GetChars)?.getChars(0, binding.passwordText.length(), password, 0)
                 }
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0)
 
                 val attributes = UserAttributes.Builder()
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/EmailPasswordSignInSignUpFragment.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/EmailPasswordSignInSignUpFragment.kt
@@ -116,7 +116,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             try {
                 val email = binding.emailText.text.toString()
                 val password = CharArray(binding.passwordText.length());
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0);
+                (binding.passwordText.text as? android.text.GetChars)?.getChars(0, binding.passwordText.length(), password, 0);
 
                 val actionResult = authClient.signIn(
                     username = email,
@@ -167,7 +167,7 @@ class EmailPasswordSignInSignUpFragment : Fragment() {
             try {
                 val email = binding.emailText.text.toString()
                 val password = CharArray(binding.passwordText.length());
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0);
+                (binding.passwordText.text as? android.text.GetChars)?.getChars(0, binding.passwordText.length(), password, 0);
 
                 val actionResult = authClient.signUp(
                     username = email,

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/PasswordResetNewPasswordFragment.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/PasswordResetNewPasswordFragment.kt
@@ -75,7 +75,7 @@ class PasswordResetNewPasswordFragment : Fragment() {
         CoroutineScope(Dispatchers.Main).launch {
             try {
                 val password = CharArray(binding.passwordText.length());
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0);
+                (binding.passwordText.text as? android.text.GetChars)?.getChars(0, binding.passwordText.length(), password, 0);
 
                 val actionResult = currentState.submitPassword(password)
 

--- a/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/SignUpPasswordFragment.kt
+++ b/testapps/testapp/src/main/java/com/microsoft/identity/client/testapp/nativeauth/SignUpPasswordFragment.kt
@@ -76,7 +76,7 @@ class SignUpPasswordFragment : Fragment() {
         CoroutineScope(Dispatchers.Main).launch {
             try {
                 val password = CharArray(binding.passwordText.length());
-                binding.passwordText.text?.getChars(0, binding.passwordText.length(), password, 0);
+                (binding.passwordText.text as? android.text.GetChars)?.getChars(0, binding.passwordText.length(), password, 0);
 
                 val actionResult = currentState.submitPassword(password)
 


### PR DESCRIPTION
[AB#3699364](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3699364)


File | Type of change | Change details | Why
-- | -- | -- | --
gradle-wrapper.properties | Version bump | Gradle 8.11.1 → 9.3.1 | AGP 9.1.1 requires Gradle 9.3.1 (min & default).
versions.gradle | Version bump | AGP (gradleVersion) 8.10.0 → 9.1.1 | Only AGP 9.x can compile against API 37.
versions.gradle | Version bump | Kotlin 1.8.0 → 2.2.21 | Gradle 9 can't run KGP < 2.2 (removed SelfResolvingDependency); AGP 9 built-in Kotlin needs KGP ≥ 2.2.10.
versions.gradle | Version bump | kotlinx-coroutines 1.6.4 → 1.9.0 | K2 + transitively-upgraded coroutines-core 1.9.0 broke runTest in coroutines-test 1.6.4 (UncompletedCoroutinesError); aligned the stack.
versions.gradle | Version bump | Robolectric 4.14 → 4.16.1 | 4.14 maxes at SDK 35; targetSdk 36 fails with targetSdkVersion=36 > maxSdkVersion=35 until 4.16.1.
versions.gradle | Upgrade target | compileSdk 36→37, targetSdk 35→36, buildTools 37.0.0 (minSdk unchanged) | Core upgrade goal (API 37). minSdk deliberately left at 24.
gradle.properties | New flag (stopgap) | Added android.newDsl=false | AGP 9 removes the legacy libraryVariants Variant API by default, which common still uses. Stopgap — removed in AGP 10.
settings.gradle | Cleanup | Commented out dead :testapps:sample / :testapps:automationapp includes | Gradle 9 rejects includes whose project directory doesn't exist (Gradle 8 tolerated it).
build.gradle | Plugin bump | com.microsoft.identity.buildsystem 0.2.5 → 0.2.6 | 0.2.5 bundled SpotBugs 4.7.1 which calls JavaPluginConvention (removed in Gradle 9); 0.2.6 bundles SpotBugs 6.x.
build.gradle | AGP 9 DSL | Removed id 'kotlin-android'; kotlinOptions {} → top-level kotlin { compilerOptions { jvmTarget } } | AGP 9 enables built-in Kotlin; the legacy plugin is rejected and kotlinOptions no longer exists.
build.gradle | Gradle 9 DSL | archivesBaseName → project.base.archivesName (set + reads) | The archivesBaseName convention property was removed in Gradle 9.
build.gradle | AGP 9 DSL | Removed kotlin-android + kotlinOptions → kotlin {}; added resValues true | AGP 9 built-in Kotlin; AGP 9 defaults resValues off and the flavors use resValue(...).
build.gradle | AGP 9 DSL + dep | kotlin-android/kotlinOptions → kotlin {}; proguard-android.txt → -optimize.txt; resValues true; pinned androidx.core:core:1.5.0 | AGP-9 fixes; AGP 9 disallows the non-optimized ProGuard file; core pin fixes a pre-existing WindowInsetsCompat.Type break (needs core ≥ 1.5.0).
.../nativeauth/SignInEmailPasswordTest.kt | Source fix | Removed stray import org.checkerframework…qual.s | Accidental unused import that only resolved via old Robolectric/Guava's transitive checkerframework; Robolectric 4.16.1's Guava dropped it.
testapp NativeAuth fragments (EmailAttributeSignUp, EmailPasswordSignInSignUp, PasswordResetNewPassword, SignUpPassword) | Source fix (K2) | editText.text?.getChars(...) → cast receiver to android.text.GetChars | Kotlin 2.2 (K2) no longer resolves getChars inherited from the Java GetChars super-interface on Editable; casting to the declaring interface fixes it.
pr-msal.yml | CI config | build_test + lint → JDK 21; build_test_dev (dev baseline) stays JDK 17 | Robolectric under SDK 36 requires JDK 21; the dev-baseline job builds old Kotlin 1.8 which needs JDK 17.
pr-msalautomationapp.yml | CI config | JDK 17 → 21 | PR-branch job builds API-37 code on the new toolchain.
common (submodule pointer) | Submodule bump | gitlink → upgraded common commit 77f927a0d | msal must build against the Gradle 9 / AGP 9 / API 37-ready common. ⚠️ Realign to the merged common SHA before final merge.

