### PR TITLE
Gate msal PR check on code-coverage drop

### DIFF
--- a/azure-pipelines/pull-request-validation/pr-msal.yml
+++ b/azure-pipelines/pull-request-validation/pr-msal.yml
@@ -167,6 +167,10 @@ stages:
   - template: azure-pipelines/code-coverage/compare-code-coverage.yml@common
     parameters:
       commonRepoAlias: common
+      # Fail the PR check on any LINE coverage drop and surface a per-class breakdown of where it regressed.
+      metric: LINE
+      tolerance: 0
+      failOnDrop: true
       dependsOn:
         - build_and_test
 ...


### PR DESCRIPTION
## What
Make the msal PR check **fail on a code-coverage drop** and show where it regressed.

`pr-msal.yml` already builds JaCoCo for the PR branch (`jacocoReport`) and the dev branch (`jacocoReportDev`) and calls the shared `compare-code-coverage.yml@common` template. This passes explicit `metric: LINE` / `tolerance: 0` / `failOnDrop: true` so the comparison now gates the PR on any LINE coverage regression and posts a per-class breakdown of exactly which classes lost coverage.

## Depends on
The per-class diff + gating logic lives in `common` (AzureAD/microsoft-authentication-library-common-for-android PR #3194) and is consumed via `@common` (ref: dev) once merged. This mirrors the broker gate (ad-accounts-for-android #237).