### PR TITLE
Pin kotlin-stdlib to project Kotlin version on dist test configs

### DIFF
--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -111,6 +111,24 @@ def registerJacocoXmlReport = { String taskName, String variant ->
 registerJacocoXmlReport("jacocoTestReport", "localDebug")     // PR validation (local flavor)
 registerJacocoXmlReport("jacocoDistTestReport", "distDebug")  // weekly release (dist flavor)
 
+// The 'dist' flavor test config resolves the latest published testutils/lab-api-utilities
+// (0.0+) and dist common artifacts. Newer published versions can carry a 'strictly'
+// kotlin-stdlib 2.x constraint (same hazard guarded at gradle/versions.gradle for
+// openTelemetryExtensionKotlinVersion), which drags kotlin-stdlib 2.x onto the
+// compileDistDebugUnitTestKotlin classpath and breaks it against the project's Kotlin 1.8
+// compiler ("metadata is 2.2.0, expected version is 1.8.0"). The 'local' flavor is immune
+// because it uses the testutils/LabApiUtilities source projects. Pin kotlin-stdlib to the
+// project's Kotlin version on the dist test configs so the compiler and stdlib metadata
+// stay aligned. Remove once the project upgrades Kotlin to 2.x.
+configurations.matching { it.name.startsWith('testDist') }.configureEach {
+    resolutionStrategy {
+        force "org.jetbrains.kotlin:kotlin-stdlib:$rootProject.ext.kotlinVersion"
+        force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$rootProject.ext.kotlinVersion"
+        force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$rootProject.ext.kotlinVersion"
+        force "org.jetbrains.kotlin:kotlin-stdlib-common:$rootProject.ext.kotlinVersion"
+    }
+}
+
 def robolectricRepoUsername = System.getenv("ENV_VSTS_MVN_CRED_USERNAME") != null ? System.getenv("ENV_VSTS_MVN_CRED_USERNAME") : project.findProperty("vstsUsername")
 def robolectricRepoPassword = System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") != null ? System.getenv("ENV_VSTS_MVN_CRED_ACCESSTOKEN") : project.findProperty("vstsMavenAccessToken")
 


### PR DESCRIPTION
## Summary
Fixes the weekly coverage pipeline failure in `msal:jacocoDistTestReport` (build 1674151), where `compileDistDebugUnitTestKotlin` fails with:

```
Class 'kotlin.Unit' was compiled with an incompatible version of Kotlin.
The binary version of its metadata is 2.2.0, expected version is 1.8.0.
loaded from jetified-kotlin-stdlib-2.2.21.jar
```

## Root cause
The **dist** flavor test config resolves the *latest published* `testutils`/`lab-api-utilities` (`0.0+`) and dist `common` artifacts. Newer published versions carry a `strictly` kotlin-stdlib 2.x constraint, which drags kotlin-stdlib 2.x onto the dist unit-test compile classpath while msal compiles with Kotlin 1.8 — the metadata mismatch then cascades into the "unresolved reference" errors (`listOf`, `toRegex`, `java`, ...).

The **local** flavor (PR checks) is immune because it uses the `testutils`/`LabApiUtilities` **source** projects, not published artifacts. This is why only the weekly/dist coverage path fails.

This is the same hazard already guarded at `gradle/versions.gradle` for `openTelemetryExtensionKotlinVersion` (pinned to avoid a `strictly` kotlin-stdlib 2.x).

## Fix
Force `kotlin-stdlib*` to `rootProject.ext.kotlinVersion` on the `testDist*` configurations via `resolutionStrategy.force` (which overrides even a transitive `strictly`), keeping the compiler and stdlib metadata aligned. Config-only; the local/PR path is unchanged. Remove once the project upgrades Kotlin to 2.x.

## Validation
Config-only change. Full local validation isn't possible because the dist path needs the in-pipeline `…1ESdev.1` published artifacts — real validation is a weekly/dist run.
