### PR TITLE
Add GetCookies WebApps automation coverage, Fixes AB#3715681

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,7 +2,6 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [PATCH] Reenable GetCookies WebApps API automation coverage (#2557)
 
 Version 8.4.2
 ----------

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Reenable GetCookies WebApps API automation coverage (#2557)
 
 Version 8.4.2
 ----------

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -60,7 +60,7 @@ import org.junit.Test;
 //           must resolve the account from the PRT/broker-account store keyed by homeAccountId
 //           rather than from the (empty) per-clientId MSAL token cache. It must succeed without
 //           falling back to an interactive account picker.
-// GetAllSsoTokens and SignOut are also exercised.
+// GetCookies, GetAllSsoTokens, and SignOut are also exercised.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3571739
 @SupportedBrokers(brokers = BrokerHost.class)
 @LocalBrokerHostDebugUiTest
@@ -80,6 +80,8 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
     private static final String CHECKBOX_IS_STS = BROKER_HOST_PKG + ":id/checkbox_is_sts";
     private static final String BUTTON_EXECUTE_GET_TOKEN = BROKER_HOST_PKG + ":id/button_execute_get_token";
     private static final String BUTTON_EXECUTE_SIGN_OUT = BROKER_HOST_PKG + ":id/button_execute_sign_out";
+    private static final String EDIT_TEXT_COOKIES_URL = BROKER_HOST_PKG + ":id/edit_text_webapps_cookie_url";
+    private static final String BUTTON_GET_COOKIES = BROKER_HOST_PKG + ":id/button_get_webapp_cookies";
     private static final String BUTTON_GET_ALL_SSO_TOKENS = BROKER_HOST_PKG + ":id/button_get_sso_tokens";
     private static final String TEXT_GET_ALL_SSO_TOKENS = BROKER_HOST_PKG + ":id/edit_sso_token";
     private static final String DIALOG_MESSAGE = "android:id/message";
@@ -87,6 +89,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
 
     // Constants
     private static final String LEMON_GLACIER = "https://lemon-glacier-0fa89f11e.1.azurestaticapps.net/";
+    private static final String MICROSOFT_ONLINE = "https://login.microsoftonline.com";
     private static final String SCOPE = "User.Read";
     // Extra token-body params (semicolon-separated key/value lists for the BrokerHost form) that mark
     // the request as an ESTS lookup-mode request. These are the values ESTS sends for a lookup request
@@ -209,7 +212,33 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 silentMsalJsResult.contains(ACCESS_TOKEN_DESCRIPTION)
         );
 
-        // -------- Step 3: GetAllSsoTokens --------
+        // -------- Step 3: GetCookies --------
+        // Navigate to the Broker API tab
+        brokerHost.brokerApiFragment.launch();
+
+        // Scroll down to make the cookies URL field and button visible
+        new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(new UiSelector().resourceId(BUTTON_GET_COOKIES));
+
+        UiAutomatorUtils.handleInput(EDIT_TEXT_COOKIES_URL, MICROSOFT_ONLINE);
+        UiAutomatorUtils.handleButtonClick(BUTTON_GET_COOKIES);
+
+        final String cookiesResult = dismissDialogAndGetText();
+
+        Assert.assertNotNull("GetCookies result should not be null", cookiesResult);
+        Assert.assertFalse(
+                "GetCookies result should not be empty",
+                cookiesResult.isEmpty()
+        );
+        Assert.assertFalse(
+                "GetCookies should be supported",
+                cookiesResult.contains("Unsupported contract")
+        );
+        Assert.assertTrue(
+                "GetCookies should return a successful response",
+                cookiesResult.contains("\"response\"")
+        );
+
+        // -------- Step 4: GetAllSsoTokens --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 
@@ -242,7 +271,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 allSsoTokensResult.isEmpty()
         );
 
-        // -------- Step 4: SignOut --------
+        // -------- Step 5: SignOut --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -92,6 +92,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
     // Constants
     private static final String LEMON_GLACIER = "https://lemon-glacier-0fa89f11e.1.azurestaticapps.net/";
     private static final String MICROSOFT_ONLINE = "https://login.microsoftonline.com";
+    private static final String PRT_COOKIE_NAME = "x-ms-RefreshTokenCredential";
     private static final String SCOPE = "User.Read";
     // Extra token-body params (semicolon-separated key/value lists for the BrokerHost form) that mark
     // the request as an ESTS lookup-mode request. These are the values ESTS sends for a lookup request
@@ -252,17 +253,24 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 "GetCookies response should contain a cookie list",
                 cookiesResponse.response
         );
-        boolean hasUsableCookie = false;
-        for (final CookieItem cookie : cookiesResponse.response) {
-            if (cookie != null && !isBlank(cookie.name) && !isBlank(cookie.data)) {
-                hasUsableCookie = true;
-                break;
-            }
-        }
-        Assert.assertTrue(
-                "GetCookies should return at least one cookie with nonblank name and data",
-                hasUsableCookie
+        Assert.assertFalse(
+                "GetCookies should return at least one cookie",
+                cookiesResponse.response.isEmpty()
         );
+        for (int i = 0; i < cookiesResponse.response.size(); i++) {
+            final CookieItem cookie = cookiesResponse.response.get(i);
+            Assert.assertNotNull("GetCookies should not return a null cookie", cookie);
+            final String expectedName = i == 0 ? PRT_COOKIE_NAME : PRT_COOKIE_NAME + i;
+            Assert.assertEquals(
+                    "GetCookies should enumerate cookie names",
+                    expectedName,
+                    cookie.name
+            );
+            Assert.assertFalse(
+                    "GetCookies should return nonblank cookie data",
+                    isBlank(cookie.data)
+            );
+        }
 
         // -------- Step 4: GetAllSsoTokens --------
         // Navigate to the Broker API tab

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -46,6 +46,8 @@ import com.microsoft.identity.labapi.utilities.constants.UserType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.List;
+
 // WebApps API Tests via BrokerHost Broker API tab
 // End-to-end coverage of the WebApps APIs using the BrokerHost app's Broker API tab, exercising the
 // lookup-mode (Edge token binding) scenario end to end:
@@ -233,9 +235,33 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 "GetCookies should be supported",
                 cookiesResult.contains("Unsupported contract")
         );
+        final int cookiesJsonStart = cookiesResult.indexOf("{");
         Assert.assertTrue(
-                "GetCookies should return a successful response",
-                cookiesResult.contains("\"response\"")
+                "GetCookies result should contain a JSON response",
+                cookiesJsonStart >= 0
+        );
+        final GetCookiesResponse cookiesResponse = ObjectMapper.deserializeJsonStringToObject(
+                cookiesResult.substring(cookiesJsonStart),
+                GetCookiesResponse.class
+        );
+        Assert.assertNotNull(
+                "GetCookies JSON response should not be null",
+                cookiesResponse
+        );
+        Assert.assertNotNull(
+                "GetCookies response should contain a cookie list",
+                cookiesResponse.response
+        );
+        boolean hasUsableCookie = false;
+        for (final CookieItem cookie : cookiesResponse.response) {
+            if (cookie != null && !isBlank(cookie.name) && !isBlank(cookie.data)) {
+                hasUsableCookie = true;
+                break;
+            }
+        }
+        Assert.assertTrue(
+                "GetCookies should return at least one cookie with nonblank name and data",
+                hasUsableCookie
         );
 
         // -------- Step 4: GetAllSsoTokens --------
@@ -322,6 +348,19 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
         } catch (final UiObjectNotFoundException e) {
             throw new AssertionError("Could not find checkbox: " + resourceId, e);
         }
+    }
+
+    private static boolean isBlank(final String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    private static final class GetCookiesResponse {
+        private List<CookieItem> response;
+    }
+
+    private static final class CookieItem {
+        private String name;
+        private String data;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- Add BrokerHost UI automation coverage for the WebApps `GetCookies` API.
- Parse the response and require at least one cookie with nonblank data.
- Verify cookie names use the same base-and-suffix enumeration as `GetAllSsoTokens`.
- Update the Common submodule to the GetCookies contract commit.

## Related Common PRs
- GetCookies reenablement: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3230
- Previous GetCookies disablement: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3135

## Testing
- `:msalautomationapp:assembleLocalBrokerHostDebugAndroidTest`

## Tracking
- [AB#3715681](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3715681)