### PR TITLE
Verify WebApps contracts before automation calls, Fixes AB#3715681

### DIFF
--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -38,6 +38,7 @@ import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.Micr
 import com.microsoft.identity.client.ui.automation.interaction.microsoftsts.MicrosoftStsPromptHandlerParameters;
 import com.microsoft.identity.client.ui.automation.utils.UiAutomatorUtils;
 import com.microsoft.identity.common.java.commands.webapps.WebAppsGetTokenSubOperationResponse;
+import com.microsoft.identity.common.java.commands.webapps.WebAppsSupportedContracts;
 import com.microsoft.identity.common.java.util.ObjectMapper;
 import com.microsoft.identity.common.java.util.ThreadUtils;
 import com.microsoft.identity.labapi.utilities.constants.TempUserType;
@@ -46,6 +47,7 @@ import com.microsoft.identity.labapi.utilities.constants.UserType;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 // WebApps API Tests via BrokerHost Broker API tab
@@ -62,7 +64,7 @@ import java.util.List;
 //           must resolve the account from the PRT/broker-account store keyed by homeAccountId
 //           rather than from the (empty) per-clientId MSAL token cache. It must succeed without
 //           falling back to an interactive account picker.
-// GetCookies, GetAllSsoTokens, and SignOut are also exercised.
+// Supported contracts are checked before GetCookies, GetAllSsoTokens, and SignOut are exercised.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3571739
 @SupportedBrokers(brokers = BrokerHost.class)
 @LocalBrokerHostDebugUiTest
@@ -82,6 +84,8 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
     private static final String CHECKBOX_IS_STS = BROKER_HOST_PKG + ":id/checkbox_is_sts";
     private static final String BUTTON_EXECUTE_GET_TOKEN = BROKER_HOST_PKG + ":id/button_execute_get_token";
     private static final String BUTTON_EXECUTE_SIGN_OUT = BROKER_HOST_PKG + ":id/button_execute_sign_out";
+    private static final String BUTTON_GET_SUPPORTED_WEBAPP_CONTRACTS =
+            BROKER_HOST_PKG + ":id/button_get_supported_webapp_contracts";
     private static final String EDIT_TEXT_COOKIES_URL = BROKER_HOST_PKG + ":id/edit_text_webapps_cookie_url";
     private static final String BUTTON_GET_COOKIES = BROKER_HOST_PKG + ":id/button_get_webapp_cookies";
     private static final String BUTTON_GET_ALL_SSO_TOKENS = BROKER_HOST_PKG + ":id/button_get_sso_tokens";
@@ -110,7 +114,46 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
 
         final BrokerHost brokerHost = (BrokerHost) mBroker;
 
-        // -------- Step 1: Interactive GetToken (lookup mode) --------
+        // -------- Step 1: Get supported WebApps contracts --------
+        // Real callers query supported contracts before attempting a WebApps operation.
+        brokerHost.brokerApiFragment.launch();
+
+        new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(
+                new UiSelector().resourceId(BUTTON_GET_SUPPORTED_WEBAPP_CONTRACTS)
+        );
+        UiAutomatorUtils.handleButtonClick(BUTTON_GET_SUPPORTED_WEBAPP_CONTRACTS);
+
+        final String supportedContractsResult = dismissDialogAndGetText();
+        Assert.assertNotNull(
+                "Supported WebApps contracts result should not be null",
+                supportedContractsResult
+        );
+        final int contractsJsonStart = supportedContractsResult.indexOf("[");
+        Assert.assertTrue(
+                "Supported WebApps contracts result should contain a JSON array: "
+                        + supportedContractsResult,
+                contractsJsonStart >= 0
+        );
+        final String[] supportedContracts = ObjectMapper.deserializeJsonStringToObject(
+                supportedContractsResult.substring(contractsJsonStart),
+                String[].class
+        );
+        Assert.assertNotNull(
+                "Supported WebApps contracts JSON should not be null",
+                supportedContracts
+        );
+        final List<String> supportedContractsList = Arrays.asList(supportedContracts);
+        for (final String expectedContract : Arrays.asList(
+                WebAppsSupportedContracts.GET_TOKEN,
+                WebAppsSupportedContracts.SIGN_OUT,
+                WebAppsSupportedContracts.GET_COOKIES)) {
+            Assert.assertTrue(
+                    "Broker should advertise the " + expectedContract + " WebApps contract",
+                    supportedContractsList.contains(expectedContract)
+            );
+        }
+
+        // -------- Step 2: Interactive GetToken (lookup mode) --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 
@@ -175,7 +218,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
         final String homeAccountId = resultJson.getAccount().getHomeAccountId();
         Assert.assertNotNull("homeAccountId should not be null", homeAccountId);
 
-        // -------- Step 2: Silent GetToken (MSAL JS) --------
+        // -------- Step 3: Silent GetToken (MSAL JS) --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 
@@ -215,7 +258,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 silentMsalJsResult.contains(ACCESS_TOKEN_DESCRIPTION)
         );
 
-        // -------- Step 3: GetCookies --------
+        // -------- Step 4: GetCookies --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 
@@ -272,7 +315,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
             );
         }
 
-        // -------- Step 4: GetAllSsoTokens --------
+        // -------- Step 5: GetAllSsoTokens --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 
@@ -305,7 +348,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 allSsoTokensResult.isEmpty()
         );
 
-        // -------- Step 5: SignOut --------
+        // -------- Step 6: SignOut --------
         // Navigate to the Broker API tab
         brokerHost.brokerApiFragment.launch();
 

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -416,12 +416,12 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
 
     @Override
     public UserType getJsonUserType() {
-        return UserType.BASIC;
+        return null;
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return null;
+        return TempUserType.BASIC;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -53,18 +53,19 @@ import java.util.List;
 // WebApps API Tests via BrokerHost Broker API tab
 // End-to-end coverage of the WebApps APIs using the BrokerHost app's Broker API tab, exercising the
 // lookup-mode (Edge token binding) scenario end to end:
-//   Step 1: an interactive GetToken sent as a lookup-mode request (nativebroker=1 +
+//   Step 1: query the supported WebApps contracts and verify that all known operations are present.
+//   Step 2: an interactive GetToken sent as a lookup-mode request (nativebroker=1 +
 //           nativebroker_mode=Lookup extra params, the values ESTS sends for a lookup request).
 //           A lookup-mode request establishes the PRT-backed broker account and registers the
 //           client, but is NOT persisted to the per-clientId MSAL token cache. Because the
 //           lookup-mode response carries "none" for the tokens, we only assert that a successful
 //           (non-error) response comes back, then read the homeAccountId from it.
-//   Step 2: a silent MSAL JS GetToken supplying only that homeAccountId (no login hint), like the
+//   Step 3: a silent MSAL JS GetToken supplying only that homeAccountId (no login hint), like the
 //           real MSAL JS client. This is the request that used to fail with UiRequired: the broker
 //           must resolve the account from the PRT/broker-account store keyed by homeAccountId
 //           rather than from the (empty) per-clientId MSAL token cache. It must succeed without
 //           falling back to an interactive account picker.
-// Supported contracts are checked before GetCookies, GetAllSsoTokens, and SignOut are exercised.
+// GetCookies, GetAllSsoTokens, and SignOut are exercised after the GetToken flow.
 // https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3571739
 @SupportedBrokers(brokers = BrokerHost.class)
 @LocalBrokerHostDebugUiTest
@@ -129,13 +130,14 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
                 supportedContractsResult
         );
         final int contractsJsonStart = supportedContractsResult.indexOf("[");
+        final int contractsJsonEnd = supportedContractsResult.lastIndexOf("]");
         Assert.assertTrue(
-                "Supported WebApps contracts result should contain a JSON array: "
+                "Supported WebApps contracts result should contain a complete JSON array: "
                         + supportedContractsResult,
-                contractsJsonStart >= 0
+                contractsJsonStart >= 0 && contractsJsonEnd > contractsJsonStart
         );
         final String[] supportedContracts = ObjectMapper.deserializeJsonStringToObject(
-                supportedContractsResult.substring(contractsJsonStart),
+                supportedContractsResult.substring(contractsJsonStart, contractsJsonEnd + 1),
                 String[].class
         );
         Assert.assertNotNull(

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -416,12 +416,12 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
 
     @Override
     public UserType getJsonUserType() {
-        return null;
+        return UserType.BASIC;
     }
 
     @Override
     public TempUserType getTempUserType() {
-        return TempUserType.BASIC;
+        return null;
     }
 
     @Override

--- a/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
+++ b/msalautomationapp/src/androidTest/java/com/microsoft/identity/client/msal/automationapp/testpass/broker/brokerapi/TestCase3571739.java
@@ -94,7 +94,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
     private static final String DIALOG_OK_BUTTON = "android:id/button1";
 
     // Constants
-    private static final String LEMON_GLACIER = "https://lemon-glacier-0fa89f11e.1.azurestaticapps.net/";
+    private static final String GRAY_WAVE = "https://gray-wave-0bd4f371e.7.azurestaticapps.net/";
     private static final String MICROSOFT_ONLINE = "https://login.microsoftonline.com";
     private static final String PRT_COOKIE_NAME = "x-ms-RefreshTokenCredential";
     private static final String SCOPE = "User.Read";
@@ -226,7 +226,7 @@ public class TestCase3571739 extends AbstractMsalBrokerTest {
         new UiScrollable(new UiSelector().scrollable(true)).scrollIntoView(new UiSelector().resourceId(INPUT_LOGIN_HINT));
 
         // Set sender origin for MSAL JS
-        UiAutomatorUtils.handleInput(INPUT_SENDER_ORIGIN, LEMON_GLACIER);
+        UiAutomatorUtils.handleInput(INPUT_SENDER_ORIGIN, GRAY_WAVE);
 
         // Fill the WebApps GetToken form for a silent MSAL JS request. This is the request that used
         // to fail with UiRequired after a lookup-mode establishing request: the per-clientId MSAL


### PR DESCRIPTION
## Summary
- Query supported WebApps contracts through BrokerHost before executing WebApps operations.
- Parse the returned JSON and fail if any known contract is missing: `GetToken`, `SignOut`, or `GetCookies`.
- Use the Gray Wave WebApps origin for the direct MSAL JS request.

## Related PRs
- BrokerHost Gray Wave configuration: https://msft.ghe.com/security/ad-accounts-for-android/pull/284
- GetCookies automation coverage: https://github.com/AzureAD/microsoft-authentication-library-for-android/pull/2557
- Common GetCookies contract: https://github.com/AzureAD/microsoft-authentication-library-common-for-android/pull/3230
- Broker GetCookies implementation: https://msft.ghe.com/security/ad-accounts-for-android/pull/278

## Testing
- `.\gradlew.bat :msalautomationapp:compileLocalBrokerHostDebugAndroidTestJavaWithJavac`
- Manual device run completed successfully with the Gray Wave configuration.

## Tracking
- [AB#3715681](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3715681)