### PR TITLE
MSAL automation: add com.msft.authentication.testapp to <queries>, Fixes AB#3734780

### DIFF
--- a/msalautomationapp/src/main/AndroidManifest.xml
+++ b/msalautomationapp/src/main/AndroidManifest.xml
@@ -48,6 +48,7 @@
         <package android:name="com.microsoft.office.word" />
         <package android:name="com.microsoft.teams" />
         <package android:name="com.azuresamples.msalandroidapp" />
+        <package android:name="com.msft.authentication.testapp" />
         <package android:name="com.azuresamples.msalnativeauthandroidkotlinsampleapp" />
     </queries>
 


### PR DESCRIPTION
OneAuthTestApp's applicationId is `com.msft.authentication.testapp`. Under Android 11+ package-visibility rules, MSAL Automation App's PackageManager cannot see the target unless declared, so `getLaunchIntentForPackage(com.msft.authentication.testapp)` returns null and `CommonUtils.launchApp()` NPEs on `intent.addFlags(...)`. Adding the package to `<queries>` restores intent resolution.

Mirror of https://github.com/AzureAD/microsoft-authentication-library-for-android/commit/721f55c08 already merged into pedro/LtwWithGradleUpgrade for the LTW test pipeline.

 Fixes [AB#3734780](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3734780)