### PR TITLE
Bump Kotlin to 2.0.21 with language/API version pinned to 1.9

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,8 +2,8 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [MINOR] Added v2 private preview interfaces
 - [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9 (#2561)
+- [MINOR] Added v2 private preview interfaces
 
 Version 8.4.2
 ----------

--- a/changelog
+++ b/changelog
@@ -3,6 +3,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 vNext
 ----------
 - [MINOR] Added v2 private preview interfaces
+- [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9 (#2561)
 
 Version 8.4.2
 ----------

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -9,7 +9,7 @@ ext {
 
     // Plugins
     gradleVersion = '8.10.0'
-    kotlinVersion = '1.8.0'
+    kotlinVersion = '2.0.21'
     spotBugsGradlePluginVersion = '4.7.1'
     jupiterApiVersion = '5.6.0'
     

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -140,6 +140,9 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+        // Pinned to 1.9 so published metadata stays readable by consumers still on Kotlin 1.8.
+        languageVersion = "1.9"
+        apiVersion = "1.9"
     }
 
     buildTypes {


### PR DESCRIPTION
Bumps Kotlin from 1.8.0 to 2.0.21, with `languageVersion`/`apiVersion` pinned to 1.9 on every module that publishes a consumable artifact.

### Why

Kotlin 1.8 cannot read dependency metadata stamped by a Kotlin 2.0 compiler, which forces `-Xskip-metadata-version-check` onto any module consuming a modern dependency. That flag is module-wide, so it silently disables the check for *every* dependency, not just the intended one. This removes the need for it.

### How it works

- The **2.0.21 compiler** reads dependency metadata up to Kotlin 2.1, so no skip flag is required.
- **`languageVersion`/`apiVersion = 1.9`** keeps the K1 frontend, so this is *not* a K2 migration — no smart-cast/inference/Lombok-interop fallout.
- Emitted metadata is therefore **version 1.9.0**, which consumers still on Kotlin 1.8 can read. No downstream break for MSAL customers, OneAuth, Teams or Outlook.

Verified by inspecting the compiled output: `kotlin.Metadata(mv=[1,9,0])`.

### Validation

- `:common:compileLocalDebugKotlin` — BUILD SUCCESSFUL
- `:common:compileLocalDebugUnitTestKotlin` — BUILD SUCCESSFUL
- `:common:testLocalDebugUnitTest` — 1925 tests, 1786 passed. The 139 failures are all pre-existing and environmental: the `nativeauth.integration` suites require the pipeline-supplied `MOCK_API_URL`, which is empty on a dev box, and one `PackageUtilsTest` failure is Mockito state bleed from `SignUpOAuth2StrategyTest.setup` in the same worker JVM.

### Notes for reviewers

- Test apps and mock apps are deliberately **not** pinned — nothing consumes their metadata. They will compile under K2, so they are the most likely place to see new errors.
- `common/testutils` **is** pinned: it is `maven-publish` + `kotlin-android`, so it emits metadata consumed by the broker/msal/adal automation suites.
- This also aligns the monorepo with the Authenticator app, which is already on Kotlin 2.0.21 and was previously the de-facto source of truth for the Compose/KSP plugin versions while `kotlinVersion` said 1.8.0.

### Work item

- Fixes [AB#3742062](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3742062) - Bump Kotlin to 2.0.21 across common, broker, msal, adal and android-complete

<!-- BEGIN pr-telemetry -->
assistance: agentic-ide
type: chore
agent-tool: copilot-chat
agent-model: claude-opus-4.5
work-item: [AB#3742062](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3742062)
<!-- END pr-telemetry -->

