### PR TITLE
Implement Native Auth V2 sign-in with password and email OTP MFA, Fixes AB#3729067

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -1348,7 +1348,7 @@ public class CommandParametersAdapter {
      * @param claimsRequest (Optional) claims request to send with the token request
      * @return Command parameter object
      */
-    public static SignInV2StartCommandParameters createSignInV2StartCommandParameters(
+    public static SignInV2StartCommandParameters createNativeAuthV2SignInCommandParameters(
             @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
             @NonNull final OAuth2TokenCache tokenCache,
             @NonNull final String username,

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -66,9 +66,12 @@ import com.microsoft.identity.common.java.nativeauth.authorities.NativeAuthCIAMA
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.MFAChallengeAuthMethodCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.MFASubmitChallengeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectMFAMethodCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitCodeCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitMFAChallengeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitNewPasswordCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitPasswordCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordV2StartCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordResendCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordStartCommandParameters;
@@ -78,6 +81,7 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInR
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInStartCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInSubmitPasswordCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInV2StartCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInWithContinuationTokenCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpResendCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignUpStartCommandParameters;
@@ -1325,6 +1329,213 @@ public class CommandParametersAdapter {
                         .scopes(scopes)
                         .claimsRequestJson(claimsRequestJson)
                         .clientId(configuration.getClientId())
+                        .correlationId(continuationState.getCorrelationId())
+                        .build();
+
+        return commandParameters;
+    }
+
+    /**
+     * Creates command parameter for [[com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignInStartCommand]] of Native Auth.
+     *
+     * @param configuration PCA configuration
+     * @param tokenCache token cache for storing results
+     * @param username username of the account signing in
+     * @param password (Optional) password to submit for the password first factor. The caller's
+     *                 array is passed through unchanged so the same buffer can be cleared later.
+     * @param scopes (Optional) scopes to request for the resulting access token
+     * @param claimsRequest (Optional) claims request to send with the token request
+     * @return Command parameter object
+     */
+    public static SignInV2StartCommandParameters createSignInV2StartCommandParameters(
+            @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache tokenCache,
+            @NonNull final String username,
+            @Nullable final char[] password,
+            @Nullable final List<String> scopes,
+            @Nullable final ClaimsRequest claimsRequest) throws ClientException {
+
+        final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+
+        final String claimsRequestJson = ClaimsRequest.getJsonStringFromClaimsRequest(claimsRequest);
+
+        final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
+                AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
+                null
+        );
+
+        final SignInV2StartCommandParameters commandParameters =
+                SignInV2StartCommandParameters.builder()
+                        .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
+                        .applicationName(configuration.getAppContext().getPackageName())
+                        .applicationVersion(getPackageVersion(configuration.getAppContext()))
+                        .clientId(configuration.getClientId())
+                        .isSharedDevice(configuration.getIsSharedDevice())
+                        .redirectUri(configuration.getRedirectUri())
+                        .oAuth2TokenCache(tokenCache)
+                        .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
+                        .sdkType(SdkType.MSAL)
+                        .sdkVersion(PublicClientApplication.getSdkVersion())
+                        .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
+                        .authority(authority)
+                        .authenticationScheme(authenticationScheme)
+                        .challengeType(configuration.getChallengeTypes())
+                        .requestInterceptor(configuration.getRequestInterceptor())
+                        .capabilities(configuration.getCapabilities())
+                        .username(username)
+                        .password(password)
+                        .scopes(scopes)
+                        .claimsRequestJson(claimsRequestJson)
+                        .correlationId(DiagnosticContext.INSTANCE.getThreadCorrelationId())
+                        .build();
+
+        return commandParameters;
+    }
+
+    /**
+     * Creates command parameter for [[com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitPasswordCommand]] of Native Auth.
+     *
+     * @param configuration PCA configuration
+     * @param tokenCache token cache for storing results
+     * @param password the password to verify
+     * @param continuationState opaque continuation state from the previous V2 response
+     * @return Command parameter object
+     */
+    public static NativeAuthV2SubmitPasswordCommandParameters createNativeAuthV2SubmitPasswordCommandParameters(
+            @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache tokenCache,
+            @NonNull final char[] password,
+            @NonNull final NativeAuthV2ContinuationState continuationState) throws ClientException {
+
+        final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+
+        final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
+                AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
+                null
+        );
+
+        final NativeAuthV2SubmitPasswordCommandParameters commandParameters =
+                NativeAuthV2SubmitPasswordCommandParameters.builder()
+                        .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
+                        .applicationName(configuration.getAppContext().getPackageName())
+                        .applicationVersion(getPackageVersion(configuration.getAppContext()))
+                        .clientId(configuration.getClientId())
+                        .isSharedDevice(configuration.getIsSharedDevice())
+                        .redirectUri(configuration.getRedirectUri())
+                        .oAuth2TokenCache(tokenCache)
+                        .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
+                        .sdkType(SdkType.MSAL)
+                        .sdkVersion(PublicClientApplication.getSdkVersion())
+                        .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
+                        .authority(authority)
+                        .authenticationScheme(authenticationScheme)
+                        .challengeType(configuration.getChallengeTypes())
+                        .requestInterceptor(configuration.getRequestInterceptor())
+                        .capabilities(configuration.getCapabilities())
+                        .password(password)
+                        .continuationState(continuationState)
+                        .scopes(continuationState.scopesForTokenRequest())
+                        .claimsRequestJson(continuationState.claimsRequestJsonForTokenRequest())
+                        .correlationId(continuationState.getCorrelationId())
+                        .build();
+
+        return commandParameters;
+    }
+
+    /**
+     * Creates command parameter for [[com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand]] of Native Auth.
+     *
+     * @param configuration PCA configuration
+     * @param tokenCache token cache for storing results
+     * @param methodId server-issued ID of the authentication method the app selected
+     * @param continuationState opaque continuation state from the previous V2 response
+     * @return Command parameter object
+     */
+    public static NativeAuthV2SelectMFAMethodCommandParameters createNativeAuthV2SelectMFAMethodCommandParameters(
+            @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache tokenCache,
+            @NonNull final String methodId,
+            @NonNull final NativeAuthV2ContinuationState continuationState) throws ClientException {
+
+        final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+
+        final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
+                AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
+                null
+        );
+
+        final NativeAuthV2SelectMFAMethodCommandParameters commandParameters =
+                NativeAuthV2SelectMFAMethodCommandParameters.builder()
+                        .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
+                        .applicationName(configuration.getAppContext().getPackageName())
+                        .applicationVersion(getPackageVersion(configuration.getAppContext()))
+                        .clientId(configuration.getClientId())
+                        .isSharedDevice(configuration.getIsSharedDevice())
+                        .redirectUri(configuration.getRedirectUri())
+                        .oAuth2TokenCache(tokenCache)
+                        .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
+                        .sdkType(SdkType.MSAL)
+                        .sdkVersion(PublicClientApplication.getSdkVersion())
+                        .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
+                        .authority(authority)
+                        .authenticationScheme(authenticationScheme)
+                        .challengeType(configuration.getChallengeTypes())
+                        .requestInterceptor(configuration.getRequestInterceptor())
+                        .capabilities(configuration.getCapabilities())
+                        .methodId(methodId)
+                        .continuationState(continuationState)
+                        .scopes(continuationState.scopesForTokenRequest())
+                        .claimsRequestJson(continuationState.claimsRequestJsonForTokenRequest())
+                        .correlationId(continuationState.getCorrelationId())
+                        .build();
+
+        return commandParameters;
+    }
+
+    /**
+     * Creates command parameter for [[com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitMFAChallengeCommand]] of Native Auth.
+     *
+     * @param configuration PCA configuration
+     * @param tokenCache token cache for storing results
+     * @param code the one-time code the user entered
+     * @param continuationState opaque continuation state from the previous V2 response
+     * @return Command parameter object
+     */
+    public static NativeAuthV2SubmitMFAChallengeCommandParameters createNativeAuthV2SubmitMFAChallengeCommandParameters(
+            @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache tokenCache,
+            @NonNull final String code,
+            @NonNull final NativeAuthV2ContinuationState continuationState) throws ClientException {
+
+        final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+
+        final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
+                AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
+                null
+        );
+
+        final NativeAuthV2SubmitMFAChallengeCommandParameters commandParameters =
+                NativeAuthV2SubmitMFAChallengeCommandParameters.builder()
+                        .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
+                        .applicationName(configuration.getAppContext().getPackageName())
+                        .applicationVersion(getPackageVersion(configuration.getAppContext()))
+                        .clientId(configuration.getClientId())
+                        .isSharedDevice(configuration.getIsSharedDevice())
+                        .redirectUri(configuration.getRedirectUri())
+                        .oAuth2TokenCache(tokenCache)
+                        .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
+                        .sdkType(SdkType.MSAL)
+                        .sdkVersion(PublicClientApplication.getSdkVersion())
+                        .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
+                        .authority(authority)
+                        .authenticationScheme(authenticationScheme)
+                        .challengeType(configuration.getChallengeTypes())
+                        .requestInterceptor(configuration.getRequestInterceptor())
+                        .capabilities(configuration.getCapabilities())
+                        .code(code)
+                        .continuationState(continuationState)
+                        .scopes(continuationState.scopesForTokenRequest())
+                        .claimsRequestJson(continuationState.claimsRequestJsonForTokenRequest())
                         .correlationId(continuationState.getCorrelationId())
                         .build();
 

--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -1205,6 +1205,7 @@ public class CommandParametersAdapter {
                         .requestInterceptor(configuration.getRequestInterceptor())
                         .continuationState(continuationState)
                         .scopes(continuationState.scopesForTokenRequest())
+                        .claimsRequestJson(continuationState.claimsRequestJsonForTokenRequest())
                         .clientId(configuration.getClientId())
                         .correlationId(continuationState.getCorrelationId())
                         .build();

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/AuthMethod.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/AuthMethod.kt
@@ -24,7 +24,9 @@ package com.microsoft.identity.nativeauth
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthConstants
 import com.microsoft.identity.common.java.nativeauth.providers.responses.signin.AuthenticationMethodApiResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
 import com.microsoft.identity.common.java.nativeauth.util.ILoggable
 
 /**
@@ -82,6 +84,32 @@ data class AuthMethod(
  */
 internal fun List<AuthenticationMethodApiResult>.toListOfAuthMethods(): List<AuthMethod> {
     return this.map { it.toAuthMethod() }
+}
+
+/**
+ * Converts a list of Native Auth V2 server methods to a list of [AuthMethod] objects.
+ */
+@JvmName("toListOfAuthMethodsV2")
+internal fun List<NativeAuthV2AuthMethod>.toListOfV2AuthMethods(): List<AuthMethod> {
+    return this.map { it.toAuthMethod() }
+}
+
+/**
+ * Converts a Native Auth V2 server method to an [AuthMethod] object.
+ *
+ * The V2 HAL model carries a single normalized method `type`, so it maps to
+ * [AuthMethod.challengeChannel]. [AuthMethod.challengeType] reports `oob` for an email method,
+ * which is always delivered as an out-of-band one-time code and matches the value V1 reports for
+ * the same method; any other type is passed through unchanged rather than guessed at.
+ */
+internal fun NativeAuthV2AuthMethod.toAuthMethod(): AuthMethod {
+    val isEmail = this.type.equals(NativeAuthConstants.ChallengeChannel.EMAIL, ignoreCase = true)
+    return AuthMethod(
+        id = this.id,
+        challengeType = if (isEmail) NativeAuthConstants.ChallengeType.OOB else this.type,
+        loginHint = this.hint,
+        challengeChannel = this.type
+    )
 }
 
 /**

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/INativeAuthPublicClientApplication.kt
@@ -198,8 +198,8 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * Warning: This API is experimental. It may be changed in the future without notice. Do not use in production applications.
      *
      * @param parameters parameters used for the signIn operation.
-     * @return [NativeAuthResultV2] see the detailed possible return states under the object.
-     * @throws [MsalException] if an account is already signed in.
+     * @return a [NativeAuthResultV2] terminal result, action-required state, or error result.
+     * Account conflicts are returned as an error result rather than thrown.
      */
     suspend fun signInV2(parameters: NativeAuthSignInParameters): NativeAuthResultV2
 
@@ -209,8 +209,10 @@ interface INativeAuthPublicClientApplication : IPublicClientApplication {
      * Warning: This API is experimental. It may be changed in the future without notice. Do not use in production applications.
      *
      * @param parameters parameters used for the signIn operation.
-     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.NativeAuthV2Callback] to receive the result.
-     * @throws [MsalException] if an account is already signed in.
+     * @param callback [com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication.NativeAuthV2Callback]
+     * invoked on a background thread. Terminal results, action-required states, and error results,
+     * including account conflicts, are delivered through
+     * [com.microsoft.identity.nativeauth.statemachine.states.Callback.onResult].
      */
     fun signInV2(parameters: NativeAuthSignInParameters, callback: NativeAuthPublicClientApplication.NativeAuthV2Callback)
 

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -628,7 +628,7 @@ class NativeAuthPublicClientApplication(
                     )
                 }
 
-                val cmdParams = CommandParametersAdapter.createSignInV2StartCommandParameters(
+                val cmdParams = CommandParametersAdapter.createNativeAuthV2SignInCommandParameters(
                     nativeAuthConfig,
                     nativeAuthConfig.oAuth2TokenCache,
                     parameters.username,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -101,6 +101,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.CodeRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.launchOwningPasswordSnapshot
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -773,9 +774,14 @@ class NativeAuthPublicClientApplication(
             correlationId = null,
             methodName = "${TAG}.signInV2(parameters: NativeAuthSignInParameters, callback: NativeAuthV2Callback)"
         )
-        pcaScope.launch {
+        val parametersSnapshot = NativeAuthSignInParameters(parameters.username).also {
+            it.password = parameters.password?.copyOf()
+            it.scopes = parameters.scopes?.toList()
+            it.claimsRequest = parameters.claimsRequest
+        }
+        pcaScope.launchOwningPasswordSnapshot(parametersSnapshot.password) {
             try {
-                callback.onResult(signInV2(parameters))
+                callback.onResult(signInV2(parametersSnapshot))
             } catch (e: MsalException) {
                 Logger.error(TAG, "Exception thrown in signInV2", e)
                 callback.onError(e)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -49,6 +49,7 @@ import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResetPasswordStartCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SignInStartCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.ResetPasswordStartCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.SignInCommandResult
@@ -60,6 +61,7 @@ import com.microsoft.identity.common.java.providers.microsoft.azureactivedirecto
 import com.microsoft.identity.common.java.util.ResultFuture
 import com.microsoft.identity.common.java.util.StringUtil
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResetPasswordStartCommand
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignInStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.ResetPasswordStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.SignInStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.SignUpStartCommand
@@ -76,6 +78,7 @@ import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordError
 import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordErrorV2
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorV2
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpError
 import com.microsoft.identity.nativeauth.statemachine.errors.SignUpErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.results.GetAccountResult
@@ -95,6 +98,8 @@ import com.microsoft.identity.nativeauth.statemachine.states.SignUpAttributesReq
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignUpPasswordRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.CodeRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.utils.getCancellable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
@@ -599,7 +604,167 @@ class NativeAuthPublicClientApplication(
             correlationId = null,
             methodName = "${TAG}.signInV2(parameters: NativeAuthSignInParameters)"
         )
-        return notImplementedV2(NativeAuthFlowScenarioV2.SIGN_IN)
+        return withContext(Dispatchers.IO) {
+            var correlationId = DiagnosticContext.INSTANCE.threadCorrelationId ?: "UNSET"
+            // Copied so the caller keeps ownership of its own buffer, while this copy is cleared
+            // below on every exit path, including cancellation. A password is never stored in a
+            // Parcelable state or in the opaque continuation state.
+            val passwordCopy = parameters.password?.copyOf()
+            try {
+                // Kept inside the try so an already-signed-in account is surfaced through the V2
+                // result contract rather than escaping as a thrown MsalClientException, matching
+                // resetPasswordV2. Android V1 behaviour is otherwise preserved: V2 rejects sign-in
+                // while an account is signed in, and does not support repeated same-account or
+                // switch-account sign-in.
+                verifyNoUserIsSignedIn()
+
+                if (parameters.username.isBlank()) {
+                    return@withContext SignInErrorV2(
+                        errorType = ErrorTypes.INVALID_USERNAME,
+                        errorMessage = "Empty or blank username",
+                        correlationId = correlationId,
+                        scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                    )
+                }
+
+                val cmdParams = CommandParametersAdapter.createSignInV2StartCommandParameters(
+                    nativeAuthConfig,
+                    nativeAuthConfig.oAuth2TokenCache,
+                    parameters.username,
+                    passwordCopy,
+                    parameters.scopes,
+                    parameters.claimsRequest
+                )
+                correlationId = cmdParams.correlationId ?: correlationId
+
+                val command = NativeAuthV2SignInStartCommand(
+                    cmdParams,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_SIGN_IN_START
+                )
+
+                ensureActive()
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+
+                when (val result = rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2SignInStartCommandResult>()) {
+                    is NativeAuthV2CommandResult.Complete -> {
+                        val localAuthResult = result.authenticationResult
+                        if (localAuthResult != null) {
+                            NativeAuthResultV2.Complete(
+                                resultValue = AccountState.createFromAuthenticationResult(
+                                    authenticationResult = AuthenticationResultAdapter.adapt(localAuthResult),
+                                    correlationId = result.correlationId,
+                                    config = nativeAuthConfig
+                                ),
+                                scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                            )
+                        } else {
+                            Logger.warn(TAG, result.correlationId, "V2 signIn Complete with no authentication result.")
+                            SignInErrorV2(
+                                errorMessage = "Sign in completed but no authentication result was returned.",
+                                correlationId = result.correlationId,
+                                scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                            )
+                        }
+                    }
+                    is NativeAuthV2CommandResult.PasswordRequired -> {
+                        NativeAuthResultV2.PasswordRequired(
+                            nextState = PasswordRequiredStateV2(
+                                continuationState = result.continuationState,
+                                scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                                config = nativeAuthConfig
+                            ),
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                        )
+                    }
+                    is NativeAuthV2CommandResult.MFARequired -> {
+                        val authMethods = result.authMethods.toListOfV2AuthMethods()
+                        NativeAuthResultV2.MFARequired(
+                            nextState = MFARequiredStateV2(
+                                continuationState = result.continuationState,
+                                authMethods = authMethods,
+                                scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                                config = nativeAuthConfig
+                            ),
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                            authMethods = authMethods
+                        )
+                    }
+                    is NativeAuthV2CommandResult.InvalidCredentials -> {
+                        SignInErrorV2(
+                            errorType = SignInErrorTypes.INVALID_CREDENTIALS,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+                    is NativeAuthV2CommandResult.UserNotFound -> {
+                        SignInErrorV2(
+                            errorType = ErrorTypes.USER_NOT_FOUND,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+                    is INativeAuthCommandResult.InvalidUsername -> {
+                        SignInErrorV2(
+                            errorType = ErrorTypes.INVALID_USERNAME,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+                    is NativeAuthV2CommandResult.NotImplemented -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.NOT_IMPLEMENTED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                        )
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        SignInErrorV2(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
+                        SignInErrorV2(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                            errorCodes = result.errorCodes,
+                            exception = result.exception
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in signInV2", e)
+                SignInErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in signInV2.",
+                    correlationId = correlationId,
+                    scenario = NativeAuthFlowScenarioV2.SIGN_IN,
+                    exception = e
+                )
+            } finally {
+                StringUtil.overwriteWithNull(passwordCopy)
+            }
+        }
     }
 
     override fun signInV2(parameters: NativeAuthSignInParameters, callback: NativeAuthV2Callback) {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -688,8 +688,7 @@ class NativeAuthPublicClientApplication(
                                 scenario = NativeAuthFlowScenarioV2.SIGN_IN,
                                 config = nativeAuthConfig
                             ),
-                            scenario = NativeAuthFlowScenarioV2.SIGN_IN,
-                            authMethods = authMethods
+                            scenario = NativeAuthFlowScenarioV2.SIGN_IN
                         )
                     }
                     is NativeAuthV2CommandResult.InvalidCredentials -> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrorsV2.kt
@@ -78,5 +78,9 @@ class MFASubmitChallengeErrorV2(
     exception: Exception? = null
 ) : NativeAuthErrorV2(errorType, error, errorMessage, correlationId, scenario, errorCodes, exception) {
 
-    fun isInvalidChallenge(): Boolean = this.errorType == ErrorTypes.INVALID_CHALLENGE
+    /**
+     * Returns true when the submitted MFA one-time code was rejected and the caller can retry on
+     * the same [com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2].
+     */
+    fun isInvalidCode(): Boolean = this.errorType == ErrorTypes.INVALID_CODE
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/MFAErrorsV2.kt
@@ -79,8 +79,8 @@ class MFASubmitChallengeErrorV2(
 ) : NativeAuthErrorV2(errorType, error, errorMessage, correlationId, scenario, errorCodes, exception) {
 
     /**
-     * Returns true when the submitted MFA one-time code was rejected and the caller can retry on
-     * the same [com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2].
+     * Returns true when the submitted MFA challenge was rejected and the caller can retry on the
+     * same [com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2].
      */
-    fun isInvalidCode(): Boolean = this.errorType == ErrorTypes.INVALID_CODE
+    fun isInvalidChallenge(): Boolean = this.errorType == ErrorTypes.INVALID_CODE
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
@@ -78,5 +78,25 @@ class SubmitPasswordErrorV2(
     exception: Exception? = null
 ) : NativeAuthErrorV2(errorType, error, errorMessage, correlationId, scenario, errorCodes, exception) {
 
+    /**
+     * Returns true if the password submitted through
+     * [com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2.submitPassword]
+     * was rejected. The caller can retry on the same state instance.
+     */
+    fun isInvalidPassword(): Boolean = this.errorType == ErrorTypes.INVALID_PASSWORD
+
+    /**
+     * Always false for this error.
+     *
+     * A deferred password rejection is reported as [isInvalidPassword], matching MSAL iOS/macOS:
+     * the account was already accepted at the sign-in entry point, so only the password was wrong.
+     * Invalid credentials are reported by
+     * [com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication.signInV2] as a
+     * [SignInErrorV2] instead. Retained only for source compatibility.
+     */
+    @Deprecated(
+        message = "A password rejected by PasswordRequiredStateV2.submitPassword is an invalid password, not invalid credentials. Use isInvalidPassword() instead.",
+        replaceWith = ReplaceWith("isInvalidPassword()")
+    )
     fun isInvalidCredentials(): Boolean = this.errorType == SignInErrorTypes.INVALID_CREDENTIALS
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
@@ -86,13 +86,13 @@ class SubmitPasswordErrorV2(
     fun isInvalidPassword(): Boolean = this.errorType == ErrorTypes.INVALID_PASSWORD
 
     /**
-     * Always false for this error.
-     *
      * A deferred password rejection is reported as [isInvalidPassword], matching MSAL iOS/macOS:
      * the account was already accepted at the sign-in entry point, so only the password was wrong.
      * Invalid credentials are reported by
      * [com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication.signInV2] as a
-     * [SignInErrorV2] instead. Retained only for source compatibility.
+     * [SignInErrorV2] instead. This method returns true only when this error was explicitly
+     * constructed with [SignInErrorTypes.INVALID_CREDENTIALS], and is retained for source
+     * compatibility.
      */
     @Deprecated(
         message = "A password rejected by PasswordRequiredStateV2.submitPassword is an invalid password, not invalid credentials. Use isInvalidPassword() instead.",

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
@@ -86,8 +86,8 @@ class SubmitPasswordErrorV2(
     fun isInvalidPassword(): Boolean = this.errorType == ErrorTypes.INVALID_PASSWORD
 
     /**
-     * A deferred password rejection is reported as [isInvalidPassword], matching MSAL iOS/macOS:
-     * the account was already accepted at the sign-in entry point, so only the password was wrong.
+     * A deferred password rejection is reported as [isInvalidPassword], the account was already accepted 
+     * at the sign-in entry point, so only the password was wrong.
      * Invalid credentials are reported by
      * [com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication.signInV2] as a
      * [SignInErrorV2] instead. This method returns true only when this error was explicitly

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/SignInErrorsV2.kt
@@ -84,19 +84,4 @@ class SubmitPasswordErrorV2(
      * was rejected. The caller can retry on the same state instance.
      */
     fun isInvalidPassword(): Boolean = this.errorType == ErrorTypes.INVALID_PASSWORD
-
-    /**
-     * A deferred password rejection is reported as [isInvalidPassword], the account was already accepted 
-     * at the sign-in entry point, so only the password was wrong.
-     * Invalid credentials are reported by
-     * [com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication.signInV2] as a
-     * [SignInErrorV2] instead. This method returns true only when this error was explicitly
-     * constructed with [SignInErrorTypes.INVALID_CREDENTIALS], and is retained for source
-     * compatibility.
-     */
-    @Deprecated(
-        message = "A password rejected by PasswordRequiredStateV2.submitPassword is an invalid password, not invalid credentials. Use isInvalidPassword() instead.",
-        replaceWith = ReplaceWith("isInvalidPassword()")
-    )
-    fun isInvalidCredentials(): Boolean = this.errorType == SignInErrorTypes.INVALID_CREDENTIALS
 }

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
@@ -39,6 +39,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredSta
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthVerificationRequiredStateV2
+import java.util.Collections
 
 /**
  * NativeAuthResultV2 is the single unified result for the Native Auth V2 surface.
@@ -145,8 +146,10 @@ interface NativeAuthResultV2 : Result {
     class MFARequired(
         override val nextState: MFARequiredStateV2,
         override val scenario: NativeAuthFlowScenarioV2,
-        val authMethods: List<AuthMethod>
-    ) : Result.SuccessResult(nextState = nextState), NativeAuthResultV2
+        authMethods: List<AuthMethod>
+    ) : Result.SuccessResult(nextState = nextState), NativeAuthResultV2 {
+        val authMethods: List<AuthMethod> = Collections.unmodifiableList(ArrayList(authMethods))
+    }
 
     /**
      * MFAVerificationRequired Result, which indicates an MFA challenge was sent and the user must

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
@@ -39,7 +39,6 @@ import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredSta
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthVerificationRequiredStateV2
-import java.util.Collections
 
 /**
  * NativeAuthResultV2 is the single unified result for the Native Auth V2 surface.
@@ -141,14 +140,16 @@ interface NativeAuthResultV2 : Result {
      * select an authentication method.
      *
      * @param nextState the current state with follow-on methods.
-     * @param authMethods the authentication methods available to the user.
      */
     class MFARequired(
         override val nextState: MFARequiredStateV2,
-        override val scenario: NativeAuthFlowScenarioV2,
-        authMethods: List<AuthMethod>
+        override val scenario: NativeAuthFlowScenarioV2
     ) : Result.SuccessResult(nextState = nextState), NativeAuthResultV2 {
-        val authMethods: List<AuthMethod> = Collections.unmodifiableList(ArrayList(authMethods))
+        /**
+         * The authentication methods available to the user.
+         */
+        val authMethods: List<AuthMethod>
+            get() = nextState.authMethods
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
@@ -204,17 +204,6 @@ class MFARequiredStateV2 internal constructor(
                             channel = result.challengeChannel
                         )
                     }
-                    is NativeAuthV2CommandResult.AuthMethodBlocked -> {
-                        MFARequestChallengeErrorV2(
-                            errorType = ErrorTypes.AUTH_METHOD_BLOCKED,
-                            error = result.error,
-                            errorMessage = result.errorDescription,
-                            correlationId = result.correlationId,
-                            scenario = scenario,
-                            errorCodes = result.errorCodes,
-                            subError = result.subError
-                        )
-                    }
                     is NativeAuthV2CommandResult.NotImplemented -> {
                         NativeAuthErrorV2(
                             errorType = ErrorTypes.NOT_IMPLEMENTED,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
@@ -54,6 +54,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Collections
 
 /**
  * State that requires the user to select an authentication method for multi-factor authentication.
@@ -74,9 +75,10 @@ class MFARequiredStateV2 internal constructor(
     /**
      * The authentication methods the server offered for this multi-factor step.
      */
-    val authMethods: List<AuthMethod> = emptyList()
+    authMethods: List<AuthMethod> = emptyList()
 ) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config, continuationState) {
     private val TAG: String = MFARequiredStateV2::class.java.simpleName
+    val authMethods: List<AuthMethod> = Collections.unmodifiableList(ArrayList(authMethods))
 
     internal constructor(
         continuationState: NativeAuthV2ContinuationState,

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
@@ -26,37 +26,100 @@ package com.microsoft.identity.nativeauth.statemachine.states
 import android.os.Parcel
 import android.os.Parcelable
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.internal.CommandParametersAdapter
+import com.microsoft.identity.common.java.controllers.CommandDispatcher
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId
 import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectMFAMethodCommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthConstants
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.util.checkAndWrapCommandResultType
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand
+import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
+import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
-import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.serializable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * State that requires the user to select an authentication method for multi-factor authentication.
+ *
+ * No challenge is sent until the app selects a method explicitly. [authMethods] is exactly the set
+ * the server offered for this step; selecting anything else fails without issuing a request. This
+ * increment supports email one-time codes only, so any other channel returns a typed
+ * not-supported error rather than following the wrong link.
  */
 class MFARequiredStateV2 internal constructor(
-    continuationToken: String,
+    continuationToken: String?,
     correlationId: String,
     scenario: NativeAuthFlowScenarioV2,
-    config: NativeAuthPublicClientApplicationConfiguration
-) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config) {
+    config: NativeAuthPublicClientApplicationConfiguration,
+    continuationState: NativeAuthV2ContinuationState? = null,
+
+    /**
+     * The authentication methods the server offered for this multi-factor step.
+     */
+    val authMethods: List<AuthMethod> = emptyList()
+) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config, continuationState) {
     private val TAG: String = MFARequiredStateV2::class.java.simpleName
 
+    internal constructor(
+        continuationState: NativeAuthV2ContinuationState,
+        authMethods: List<AuthMethod>,
+        scenario: NativeAuthFlowScenarioV2,
+        config: NativeAuthPublicClientApplicationConfiguration
+    ) : this(
+        continuationToken = null,
+        correlationId = continuationState.correlationId,
+        scenario = scenario,
+        config = config,
+        continuationState = continuationState,
+        authMethods = authMethods
+    )
+
     private constructor(parcel: Parcel) : this(
-        continuationToken = parcel.readString() ?: "",
+        continuationToken = parcel.readString(),
         correlationId = parcel.readString() ?: "UNSET",
         scenario = NativeAuthFlowScenarioV2.valueOf(parcel.readString() ?: NativeAuthFlowScenarioV2.UNKNOWN.name),
-        // Also drains the continuationState field written by the base class, so the read order
-        // stays symmetric with NativeAuthBaseStateV2.writeToParcel even though this state has none.
-        config = parcel.readConfigAndSkipContinuationState()
+        config = parcel.serializable<NativeAuthPublicClientApplicationConfiguration>() as NativeAuthPublicClientApplicationConfiguration,
+        continuationState = parcel.serializable<NativeAuthV2ContinuationState>(),
+        authMethods = parcel.createTypedArrayList(AuthMethod.CREATOR) ?: emptyList()
     )
+
+    /**
+     * Writes the base fields first, then this state's own [authMethods], so the read order in the
+     * `Parcel` constructor above stays symmetric. The base fields themselves are still written
+     * only by the base implementation.
+     */
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        super.writeToParcel(parcel, flags)
+        parcel.writeTypedList(authMethods)
+    }
 
     interface SelectAuthMethodCallback : Callback<NativeAuthResultV2>
 
+    /**
+     * Requests a challenge on the selected authentication method; callback variant.
+     *
+     * @param method one of the methods listed in [authMethods].
+     * @param verificationContact unused by this flow; the server already knows the contact bound to
+     * [method]. Retained for signature compatibility with the wider Native Auth V2 surface.
+     * @param callback [SelectAuthMethodCallback] to receive the result.
+     */
     fun selectAuthMethod(method: AuthMethod, verificationContact: String? = null, callback: SelectAuthMethodCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -73,13 +136,120 @@ class MFARequiredStateV2 internal constructor(
         }
     }
 
+    /**
+     * Requests a challenge on the selected authentication method; Kotlin coroutines variant.
+     *
+     * @param method one of the methods listed in [authMethods].
+     * @param verificationContact unused by this flow; see the callback variant.
+     * @return [NativeAuthResultV2] see detailed possible return state under the object.
+     */
     suspend fun selectAuthMethod(method: AuthMethod, verificationContact: String? = null): NativeAuthResultV2 {
         LogSession.logMethodCall(
             tag = TAG,
             correlationId = correlationId,
             methodName = "${TAG}.selectAuthMethod(method: AuthMethod, verificationContact: String?)"
         )
-        return notImplemented()
+        val state = continuationState ?: return invalidState()
+
+        val offeredMethod = authMethods.firstOrNull { it.id == method.id }
+            ?: return MFARequestChallengeErrorV2(
+                errorType = ErrorTypes.INVALID_STATE,
+                errorMessage = "The selected authentication method is not one of the methods the server offered.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+
+        if (!offeredMethod.challengeChannel.equals(NativeAuthConstants.ChallengeChannel.EMAIL, ignoreCase = true)) {
+            return MFARequestChallengeErrorV2(
+                errorMessage = "Only email authentication methods are supported for multi-factor authentication.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val parameters = CommandParametersAdapter.createNativeAuthV2SelectMFAMethodCommandParameters(
+                    config,
+                    config.oAuth2TokenCache,
+                    offeredMethod.id,
+                    state
+                )
+                val command = NativeAuthV2SelectMFAMethodCommand(
+                    parameters,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_SIGN_IN_SELECT_MFA_METHOD
+                )
+                ensureActive()
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+                when (val result = rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2SelectMFAMethodCommandResult>()) {
+                    is NativeAuthV2CommandResult.MFAVerificationRequired -> {
+                        NativeAuthResultV2.MFAVerificationRequired(
+                            nextState = MFAVerificationRequiredStateV2(
+                                continuationState = result.continuationState,
+                                scenario = scenario,
+                                config = config
+                            ),
+                            scenario = scenario,
+                            codeLength = result.codeLength,
+                            sentTo = result.challengeTargetLabel,
+                            channel = result.challengeChannel
+                        )
+                    }
+                    is NativeAuthV2CommandResult.AuthMethodBlocked -> {
+                        MFARequestChallengeErrorV2(
+                            errorType = ErrorTypes.AUTH_METHOD_BLOCKED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            subError = result.subError
+                        )
+                    }
+                    is NativeAuthV2CommandResult.NotImplemented -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.NOT_IMPLEMENTED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        MFARequestChallengeErrorV2(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
+                        MFARequestChallengeErrorV2(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            exception = result.exception
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in selectAuthMethod", e)
+                MFARequestChallengeErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in selectAuthMethod.",
+                    correlationId = correlationId,
+                    scenario = scenario,
+                    exception = e
+                )
+            }
+        }
     }
 
     companion object CREATOR : Parcelable.Creator<MFARequiredStateV2> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFARequiredStateV2.kt
@@ -60,8 +60,9 @@ import kotlinx.coroutines.withContext
  *
  * No challenge is sent until the app selects a method explicitly. [authMethods] is exactly the set
  * the server offered for this step; selecting anything else fails without issuing a request. This
- * increment supports email one-time codes only, so any other channel returns a typed
- * not-supported error rather than following the wrong link.
+ * increment supports email one-time codes only, so any other channel returns a not-implemented
+ * error ([com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2.isNotImplemented])
+ * rather than following the wrong link.
  */
 class MFARequiredStateV2 internal constructor(
     continuationToken: String?,
@@ -160,7 +161,11 @@ class MFARequiredStateV2 internal constructor(
             )
 
         if (!offeredMethod.challengeChannel.equals(NativeAuthConstants.ChallengeChannel.EMAIL, ignoreCase = true)) {
+            // Reported as not-implemented rather than a bare error so the app can tell "this SDK
+            // increment only supports email one-time codes" apart from an unspecified server error,
+            // which is what an untyped error would be indistinguishable from.
             return MFARequestChallengeErrorV2(
+                errorType = ErrorTypes.NOT_IMPLEMENTED,
                 errorMessage = "Only email authentication methods are supported for multi-factor authentication.",
                 correlationId = correlationId,
                 scenario = scenario

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
@@ -26,36 +26,78 @@ package com.microsoft.identity.nativeauth.statemachine.states
 import android.os.Parcel
 import android.os.Parcelable
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.internal.CommandParametersAdapter
+import com.microsoft.identity.common.java.controllers.CommandDispatcher
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId
 import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SubmitMFAChallengeCommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.util.checkAndWrapCommandResultType
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitMFAChallengeCommand
+import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.serializable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * State that requires the user to submit a multi-factor authentication challenge.
+ *
+ * A wrong code is a recoverable [MFASubmitChallengeErrorV2] with
+ * [MFASubmitChallengeErrorV2.isInvalidChallenge]; the caller retries on this same state instance,
+ * or requests a fresh challenge from the [MFARequiredStateV2] it still holds. No error result
+ * carries a next state.
  */
 class MFAVerificationRequiredStateV2 internal constructor(
-    continuationToken: String,
+    continuationToken: String?,
     correlationId: String,
     scenario: NativeAuthFlowScenarioV2,
-    config: NativeAuthPublicClientApplicationConfiguration
-) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config) {
+    config: NativeAuthPublicClientApplicationConfiguration,
+    continuationState: NativeAuthV2ContinuationState? = null
+) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config, continuationState) {
     private val TAG: String = MFAVerificationRequiredStateV2::class.java.simpleName
 
+    internal constructor(
+        continuationState: NativeAuthV2ContinuationState,
+        scenario: NativeAuthFlowScenarioV2,
+        config: NativeAuthPublicClientApplicationConfiguration
+    ) : this(
+        continuationToken = null,
+        correlationId = continuationState.correlationId,
+        scenario = scenario,
+        config = config,
+        continuationState = continuationState
+    )
+
     private constructor(parcel: Parcel) : this(
-        continuationToken = parcel.readString() ?: "",
+        continuationToken = parcel.readString(),
         correlationId = parcel.readString() ?: "UNSET",
         scenario = NativeAuthFlowScenarioV2.valueOf(parcel.readString() ?: NativeAuthFlowScenarioV2.UNKNOWN.name),
-        // Also drains the continuationState field written by the base class, so the read order
-        // stays symmetric with NativeAuthBaseStateV2.writeToParcel even though this state has none.
-        config = parcel.readConfigAndSkipContinuationState()
+        config = parcel.serializable<NativeAuthPublicClientApplicationConfiguration>() as NativeAuthPublicClientApplicationConfiguration,
+        continuationState = parcel.serializable<NativeAuthV2ContinuationState>()
     )
 
     interface SubmitChallengeCallback : Callback<NativeAuthResultV2>
 
+    /**
+     * Submits the multi-factor one-time code; callback variant.
+     *
+     * @param challenge the one-time code the user entered.
+     * @param callback [SubmitChallengeCallback] to receive the result.
+     */
     fun submitChallenge(challenge: String, callback: SubmitChallengeCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -72,13 +114,100 @@ class MFAVerificationRequiredStateV2 internal constructor(
         }
     }
 
+    /**
+     * Submits the multi-factor one-time code; Kotlin coroutines variant.
+     *
+     * @param challenge the one-time code the user entered.
+     * @return [NativeAuthResultV2] see detailed possible return state under the object.
+     */
     suspend fun submitChallenge(challenge: String): NativeAuthResultV2 {
         LogSession.logMethodCall(
             tag = TAG,
             correlationId = correlationId,
             methodName = "${TAG}.submitChallenge(challenge: String)"
         )
-        return notImplemented()
+        val state = continuationState ?: return invalidState()
+        if (challenge.isEmpty()) {
+            return MFASubmitChallengeErrorV2(
+                errorType = ErrorTypes.INVALID_CHALLENGE,
+                errorMessage = "Challenge cannot be empty.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+        }
+        return withContext(Dispatchers.IO) {
+            try {
+                val parameters = CommandParametersAdapter.createNativeAuthV2SubmitMFAChallengeCommandParameters(
+                    config,
+                    config.oAuth2TokenCache,
+                    challenge,
+                    state
+                )
+                val command = NativeAuthV2SubmitMFAChallengeCommand(
+                    parameters,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_SIGN_IN_SUBMIT_MFA_CHALLENGE
+                )
+                ensureActive()
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+                when (val result = rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2SubmitMFAChallengeCommandResult>()) {
+                    is NativeAuthV2CommandResult.Complete -> {
+                        mapCompleteResult(result)
+                    }
+                    is NativeAuthV2CommandResult.IncorrectCode -> {
+                        MFASubmitChallengeErrorV2(
+                            errorType = ErrorTypes.INVALID_CHALLENGE,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            subError = result.subError
+                        )
+                    }
+                    is NativeAuthV2CommandResult.NotImplemented -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.NOT_IMPLEMENTED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        MFASubmitChallengeErrorV2(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
+                        MFASubmitChallengeErrorV2(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            exception = result.exception
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in submitChallenge", e)
+                MFASubmitChallengeErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in submitChallenge.",
+                    correlationId = correlationId,
+                    scenario = scenario,
+                    exception = e
+                )
+            }
+        }
     }
 
     companion object CREATOR : Parcelable.Creator<MFAVerificationRequiredStateV2> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
@@ -33,9 +33,11 @@ import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2ResendCodeCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SubmitMFAChallengeCommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
 import com.microsoft.identity.common.java.nativeauth.util.checkAndWrapCommandResultType
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResendCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitMFAChallengeCommand
 import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
@@ -57,9 +59,10 @@ import kotlinx.coroutines.withContext
  * State that requires the user to submit a multi-factor authentication challenge.
  *
  * A wrong code is a recoverable [MFASubmitChallengeErrorV2] with
- * [MFASubmitChallengeErrorV2.isInvalidChallenge]; the caller retries on this same state instance,
- * or requests a fresh challenge from the [MFARequiredStateV2] it still holds. No error result
- * carries a next state.
+ * [MFASubmitChallengeErrorV2.isInvalidCode]; the caller retries on this same state instance or
+ * requests a fresh challenge through [resendChallenge]. Successful resends return a fresh
+ * [NativeAuthResultV2.MFAVerificationRequired] whose state carries the latest opaque continuation
+ * required for subsequent submit/resend calls. No error result carries a next state.
  */
 class MFAVerificationRequiredStateV2 internal constructor(
     continuationToken: String?,
@@ -91,6 +94,7 @@ class MFAVerificationRequiredStateV2 internal constructor(
     )
 
     interface SubmitChallengeCallback : Callback<NativeAuthResultV2>
+    interface ResendChallengeCallback : Callback<NativeAuthResultV2>
 
     /**
      * Submits the multi-factor one-time code; callback variant.
@@ -129,7 +133,7 @@ class MFAVerificationRequiredStateV2 internal constructor(
         val state = continuationState ?: return invalidState()
         if (challenge.isEmpty()) {
             return MFASubmitChallengeErrorV2(
-                errorType = ErrorTypes.INVALID_CHALLENGE,
+                errorType = ErrorTypes.INVALID_CODE,
                 errorMessage = "Challenge cannot be empty.",
                 correlationId = correlationId,
                 scenario = scenario
@@ -157,7 +161,7 @@ class MFAVerificationRequiredStateV2 internal constructor(
                     }
                     is NativeAuthV2CommandResult.IncorrectCode -> {
                         MFASubmitChallengeErrorV2(
-                            errorType = ErrorTypes.INVALID_CHALLENGE,
+                            errorType = ErrorTypes.INVALID_CODE,
                             error = result.error,
                             errorMessage = result.errorDescription,
                             correlationId = result.correlationId,
@@ -202,6 +206,112 @@ class MFAVerificationRequiredStateV2 internal constructor(
                 MFASubmitChallengeErrorV2(
                     errorType = ErrorTypes.CLIENT_EXCEPTION,
                     errorMessage = "MSAL client exception occurred in submitChallenge.",
+                    correlationId = correlationId,
+                    scenario = scenario,
+                    exception = e
+                )
+            }
+        }
+    }
+
+    /**
+     * Requests the service to resend the MFA challenge; callback variant.
+     *
+     * @param callback [ResendChallengeCallback] to receive the result.
+     */
+    fun resendChallenge(callback: ResendChallengeCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.resendChallenge(callback: ResendChallengeCallback)"
+        )
+        NativeAuthPublicClientApplication.pcaScope.launch {
+            try {
+                callback.onResult(resendChallenge())
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in resendChallenge", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Requests the service to resend the MFA challenge; Kotlin coroutines variant.
+     *
+     * @return [NativeAuthResultV2] a fresh [NativeAuthResultV2.MFAVerificationRequired] on
+     * success, or a [NativeAuthErrorV2] for redirect/API/not-implemented/invalid-state cases.
+     */
+    suspend fun resendChallenge(): NativeAuthResultV2 {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.resendChallenge()"
+        )
+        val state = continuationState ?: return invalidState()
+        return withContext(Dispatchers.IO) {
+            try {
+                val parameters = CommandParametersAdapter.createNativeAuthV2ResendCodeCommandParameters(
+                    config,
+                    config.oAuth2TokenCache,
+                    state
+                )
+                val command = NativeAuthV2ResendCodeCommand(
+                    parameters,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_SIGN_IN_RESEND_MFA_CHALLENGE
+                )
+                ensureActive()
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+                when (val result = rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2ResendCodeCommandResult>()) {
+                    is NativeAuthV2CommandResult.CodeRequired -> {
+                        NativeAuthResultV2.MFAVerificationRequired(
+                            nextState = MFAVerificationRequiredStateV2(result.continuationState, scenario, config),
+                            scenario = scenario,
+                            codeLength = result.codeLength,
+                            sentTo = result.challengeTargetLabel,
+                            channel = result.challengeChannel
+                        )
+                    }
+                    is NativeAuthV2CommandResult.Complete -> {
+                        mapCompleteResult(result)
+                    }
+                    is NativeAuthV2CommandResult.NotImplemented -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.NOT_IMPLEMENTED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
+                        NativeAuthErrorV2(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            exception = result.exception
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in resendChallenge", e)
+                NativeAuthErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in resendChallenge.",
                     correlationId = correlationId,
                     scenario = scenario,
                     exception = e

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/MFAVerificationRequiredStateV2.kt
@@ -59,7 +59,7 @@ import kotlinx.coroutines.withContext
  * State that requires the user to submit a multi-factor authentication challenge.
  *
  * A wrong code is a recoverable [MFASubmitChallengeErrorV2] with
- * [MFASubmitChallengeErrorV2.isInvalidCode]; the caller retries on this same state instance or
+ * [MFASubmitChallengeErrorV2.isInvalidChallenge]; the caller retries on this same state instance or
  * requests a fresh challenge through [resendChallenge]. Successful resends return a fresh
  * [NativeAuthResultV2.MFAVerificationRequired] whose state carries the latest opaque continuation
  * required for subsequent submit/resend calls. No error result carries a next state.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/NativeAuthBaseStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/NativeAuthBaseStateV2.kt
@@ -89,7 +89,7 @@ abstract class NativeAuthBaseStateV2 internal constructor(
         } else {
             Logger.warn(TAG, result.correlationId, "V2 Complete result has no inline sign-in token; returning API error.")
             NativeAuthErrorV2(
-                errorMessage = "Password reset completed but no sign-in result was returned.",
+                errorMessage = "Native Auth V2 flow completed but no authentication result was returned.",
                 correlationId = result.correlationId,
                 scenario = scenario
             )

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
@@ -172,8 +172,7 @@ class PasswordRequiredStateV2 internal constructor(
                                 scenario = scenario,
                                 config = config
                             ),
-                            scenario = scenario,
-                            authMethods = authMethods
+                            scenario = scenario
                         )
                     }
                     is NativeAuthV2CommandResult.IncorrectPassword -> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
@@ -26,36 +26,81 @@ package com.microsoft.identity.nativeauth.statemachine.states
 import android.os.Parcel
 import android.os.Parcelable
 import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.internal.CommandParametersAdapter
+import com.microsoft.identity.common.java.controllers.CommandDispatcher
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId
 import com.microsoft.identity.common.java.logging.LogSession
 import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SubmitPasswordCommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.util.checkAndWrapCommandResultType
+import com.microsoft.identity.common.java.util.StringUtil
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitPasswordCommand
+import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.SubmitPasswordErrorV2
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import com.microsoft.identity.nativeauth.toListOfV2AuthMethods
+import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.serializable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 /**
  * State that requires the user to submit a password.
+ *
+ * A password rejected here is a [SubmitPasswordErrorV2] with
+ * [SubmitPasswordErrorV2.isInvalidPassword], not an invalid-credentials error: the account itself
+ * was already accepted at the sign-in entry point and only the deferred password was wrong. The
+ * caller retries on this same state instance; no error result carries a next state.
  */
 class PasswordRequiredStateV2 internal constructor(
-    continuationToken: String,
+    continuationToken: String?,
     correlationId: String,
     scenario: NativeAuthFlowScenarioV2,
-    config: NativeAuthPublicClientApplicationConfiguration
-) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config) {
+    config: NativeAuthPublicClientApplicationConfiguration,
+    continuationState: NativeAuthV2ContinuationState? = null
+) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config, continuationState) {
     private val TAG: String = PasswordRequiredStateV2::class.java.simpleName
 
+    internal constructor(
+        continuationState: NativeAuthV2ContinuationState,
+        scenario: NativeAuthFlowScenarioV2,
+        config: NativeAuthPublicClientApplicationConfiguration
+    ) : this(
+        continuationToken = null,
+        correlationId = continuationState.correlationId,
+        scenario = scenario,
+        config = config,
+        continuationState = continuationState
+    )
+
     private constructor(parcel: Parcel) : this(
-        continuationToken = parcel.readString() ?: "",
+        continuationToken = parcel.readString(),
         correlationId = parcel.readString() ?: "UNSET",
         scenario = NativeAuthFlowScenarioV2.valueOf(parcel.readString() ?: NativeAuthFlowScenarioV2.UNKNOWN.name),
-        // Also drains the continuationState field written by the base class, so the read order
-        // stays symmetric with NativeAuthBaseStateV2.writeToParcel even though this state has none.
-        config = parcel.readConfigAndSkipContinuationState()
+        config = parcel.serializable<NativeAuthPublicClientApplicationConfiguration>() as NativeAuthPublicClientApplicationConfiguration,
+        continuationState = parcel.serializable<NativeAuthV2ContinuationState>()
     )
 
     interface SubmitPasswordCallback : Callback<NativeAuthResultV2>
 
+    /**
+     * Submits the password; callback variant.
+     *
+     * @param password the password to submit. The caller's buffer is copied, and only the copy is
+     * cleared once the request completes.
+     * @param callback [SubmitPasswordCallback] to receive the result.
+     */
     fun submitPassword(password: CharArray, callback: SubmitPasswordCallback) {
         LogSession.logMethodCall(
             tag = TAG,
@@ -72,13 +117,118 @@ class PasswordRequiredStateV2 internal constructor(
         }
     }
 
+    /**
+     * Submits the password; Kotlin coroutines variant.
+     *
+     * @param password the password to submit. The caller's buffer is copied, and only the copy is
+     * cleared once the request completes.
+     * @return [NativeAuthResultV2] see detailed possible return state under the object.
+     */
     suspend fun submitPassword(password: CharArray): NativeAuthResultV2 {
         LogSession.logMethodCall(
             tag = TAG,
             correlationId = correlationId,
             methodName = "${TAG}.submitPassword(password: CharArray)"
         )
-        return notImplemented()
+        val state = continuationState ?: return invalidState()
+        if (password.isEmpty()) {
+            return SubmitPasswordErrorV2(
+                errorType = ErrorTypes.INVALID_PASSWORD,
+                errorMessage = "Password cannot be empty.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+        }
+        return withContext(Dispatchers.IO) {
+            // Copied so the caller keeps ownership of its own buffer, while this copy is cleared
+            // below on every exit path, including cancellation.
+            val passwordCopy = password.copyOf()
+            try {
+                val parameters = CommandParametersAdapter.createNativeAuthV2SubmitPasswordCommandParameters(
+                    config,
+                    config.oAuth2TokenCache,
+                    passwordCopy,
+                    state
+                )
+                val command = NativeAuthV2SubmitPasswordCommand(
+                    parameters,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_SIGN_IN_SUBMIT_PASSWORD
+                )
+                ensureActive()
+                val rawCommandResult = CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+                when (val result = rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2SubmitPasswordCommandResult>()) {
+                    is NativeAuthV2CommandResult.Complete -> {
+                        mapCompleteResult(result)
+                    }
+                    is NativeAuthV2CommandResult.MFARequired -> {
+                        val authMethods = result.authMethods.toListOfV2AuthMethods()
+                        NativeAuthResultV2.MFARequired(
+                            nextState = MFARequiredStateV2(
+                                continuationState = result.continuationState,
+                                authMethods = authMethods,
+                                scenario = scenario,
+                                config = config
+                            ),
+                            scenario = scenario,
+                            authMethods = authMethods
+                        )
+                    }
+                    is NativeAuthV2CommandResult.IncorrectPassword -> {
+                        SubmitPasswordErrorV2(
+                            errorType = ErrorTypes.INVALID_PASSWORD,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes
+                        )
+                    }
+                    is NativeAuthV2CommandResult.NotImplemented -> {
+                        NativeAuthErrorV2(
+                            errorType = ErrorTypes.NOT_IMPLEMENTED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.Redirect -> {
+                        SubmitPasswordErrorV2(
+                            errorType = ErrorTypes.BROWSER_REQUIRED,
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario
+                        )
+                    }
+                    is INativeAuthCommandResult.APIError -> {
+                        SubmitPasswordErrorV2(
+                            error = result.error,
+                            errorMessage = result.errorDescription,
+                            correlationId = result.correlationId,
+                            scenario = scenario,
+                            errorCodes = result.errorCodes,
+                            exception = result.exception
+                        )
+                    }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in submitPassword", e)
+                SubmitPasswordErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in submitPassword.",
+                    correlationId = correlationId,
+                    scenario = scenario,
+                    exception = e
+                )
+            } finally {
+                StringUtil.overwriteWithNull(passwordCopy)
+            }
+        }
     }
 
     companion object CREATOR : Parcelable.Creator<PasswordRequiredStateV2> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/PasswordRequiredStateV2.kt
@@ -48,11 +48,11 @@ import com.microsoft.identity.nativeauth.statemachine.errors.SubmitPasswordError
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
 import com.microsoft.identity.nativeauth.toListOfV2AuthMethods
 import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.launchOwningPasswordSnapshot
 import com.microsoft.identity.nativeauth.utils.serializable
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
@@ -107,9 +107,10 @@ class PasswordRequiredStateV2 internal constructor(
             correlationId = correlationId,
             methodName = "${TAG}.submitPassword(password: CharArray, callback: SubmitPasswordCallback)"
         )
-        NativeAuthPublicClientApplication.pcaScope.launch {
+        val passwordSnapshot = password.copyOf()
+        NativeAuthPublicClientApplication.pcaScope.launchOwningPasswordSnapshot(passwordSnapshot) {
             try {
-                callback.onResult(submitPassword(password))
+                callback.onResult(submitPassword(passwordSnapshot))
             } catch (e: MsalException) {
                 Logger.error(TAG, "Exception thrown in submitPassword", e)
                 callback.onError(e)

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/utils/CoroutineExtensions.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/utils/CoroutineExtensions.kt
@@ -24,8 +24,12 @@
 package com.microsoft.identity.nativeauth.utils
 
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
+import com.microsoft.identity.common.java.util.StringUtil
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runInterruptible
 
 internal suspend fun <T> FinalizableResultFuture<T>.getCancellable(): T {
@@ -35,4 +39,26 @@ internal suspend fun <T> FinalizableResultFuture<T>.getCancellable(): T {
         cancelSignal()
         throw exception
     }
+}
+
+/**
+ * Launches [block] in this [CoroutineScope], guaranteeing that [passwordSnapshot] is cleared once
+ * the launched job completes -- including when the job is cancelled before [block] ever starts
+ * running (for example, because this scope was already cancelled at the time of the call).
+ *
+ * [block] remains responsible for clearing [passwordSnapshot] itself once it has consumed it
+ * (typically via a `try`/`finally` around command submission). This function is purely a safety
+ * net for the case where [block] never runs at all: [StringUtil.overwriteWithNull] is idempotent
+ * and null-tolerant, so invoking it again here after [block] already cleared the array is
+ * harmless.
+ */
+internal fun CoroutineScope.launchOwningPasswordSnapshot(
+    passwordSnapshot: CharArray?,
+    block: suspend CoroutineScope.() -> Unit
+): Job {
+    val job = launch(block = block)
+    job.invokeOnCompletion {
+        StringUtil.overwriteWithNull(passwordSnapshot)
+    }
+    return job
 }

--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -646,7 +646,7 @@ public class CommandParametersTest {
     }
 
         @Test
-        public void testCreateSignInV2StartCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+        public void testCreateNativeAuthV2SignInCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
             final String correlationId = "00000000-0000-0000-0000-000000000011";
             final RequestContext requestContext = new RequestContext();
             requestContext.put(DiagnosticContext.CORRELATION_ID, correlationId);
@@ -661,7 +661,7 @@ public class CommandParametersTest {
                 final ClaimsRequest claimsRequest = getAccessTokenClaimsRequest("xms_cc", "cp1");
 
                 final SignInV2StartCommandParameters commandParameters =
-                        CommandParametersAdapter.createSignInV2StartCommandParameters(
+                        CommandParametersAdapter.createNativeAuthV2SignInCommandParameters(
                                 configuration,
                                 tokenCache,
                                 username,

--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -690,9 +690,10 @@ public class CommandParametersTest {
             final OAuth2TokenCache tokenCache = getCache();
             final char[] password = "Password123!".toCharArray();
             final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String claimsRequestJson = "claims-request-json";
             final String correlationId = "00000000-0000-0000-0000-000000000012";
             final NativeAuthV2ContinuationState continuationState =
-                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+                    getNativeAuthV2ContinuationState(correlationId, scopes, claimsRequestJson);
 
             final NativeAuthV2SubmitPasswordCommandParameters commandParameters =
                     CommandParametersAdapter.createNativeAuthV2SubmitPasswordCommandParameters(
@@ -705,6 +706,7 @@ public class CommandParametersTest {
             Assert.assertSame(password, commandParameters.password);
             Assert.assertSame(continuationState, commandParameters.continuationState);
             Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(claimsRequestJson, commandParameters.claimsRequestJson);
             Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
             Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
         }
@@ -715,9 +717,10 @@ public class CommandParametersTest {
             final OAuth2TokenCache tokenCache = getCache();
             final String methodId = "email-1";
             final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String claimsRequestJson = "claims-request-json";
             final String correlationId = "00000000-0000-0000-0000-000000000013";
             final NativeAuthV2ContinuationState continuationState =
-                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+                    getNativeAuthV2ContinuationState(correlationId, scopes, claimsRequestJson);
 
             final NativeAuthV2SelectMFAMethodCommandParameters commandParameters =
                     CommandParametersAdapter.createNativeAuthV2SelectMFAMethodCommandParameters(
@@ -730,6 +733,7 @@ public class CommandParametersTest {
             Assert.assertEquals(methodId, commandParameters.methodId);
             Assert.assertSame(continuationState, commandParameters.continuationState);
             Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(claimsRequestJson, commandParameters.claimsRequestJson);
             Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
             Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
         }
@@ -740,9 +744,10 @@ public class CommandParametersTest {
             final OAuth2TokenCache tokenCache = getCache();
             final String code = "123456";
             final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String claimsRequestJson = "claims-request-json";
             final String correlationId = "00000000-0000-0000-0000-000000000014";
             final NativeAuthV2ContinuationState continuationState =
-                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+                    getNativeAuthV2ContinuationState(correlationId, scopes, claimsRequestJson);
 
             final NativeAuthV2SubmitMFAChallengeCommandParameters commandParameters =
                     CommandParametersAdapter.createNativeAuthV2SubmitMFAChallengeCommandParameters(
@@ -755,6 +760,7 @@ public class CommandParametersTest {
             Assert.assertEquals(code, commandParameters.code);
             Assert.assertSame(continuationState, commandParameters.continuationState);
             Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(claimsRequestJson, commandParameters.claimsRequestJson);
             Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
             Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
         }
@@ -791,9 +797,10 @@ public class CommandParametersTest {
         final NativeAuthPublicClientApplicationConfiguration configuration = getNativeAuthConfiguration(NATIVE_AUTH_CONFIG_FILE);
         final OAuth2TokenCache tokenCache = getCache();
         final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+        final String claimsRequestJson = "claims-request-json";
         final String correlationId = "00000000-0000-0000-0000-000000000003";
         final NativeAuthV2ContinuationState continuationState =
-                getNativeAuthV2ContinuationState(correlationId, scopes, null);
+                getNativeAuthV2ContinuationState(correlationId, scopes, claimsRequestJson);
 
         final NativeAuthV2ResendCodeCommandParameters commandParameters =
                 CommandParametersAdapter.createNativeAuthV2ResendCodeCommandParameters(
@@ -804,6 +811,7 @@ public class CommandParametersTest {
 
         Assert.assertSame(continuationState, commandParameters.continuationState);
         Assert.assertEquals(scopes, commandParameters.scopes);
+        Assert.assertEquals(claimsRequestJson, commandParameters.claimsRequestJson);
         Assert.assertEquals(configuration.getChallengeTypes(), commandParameters.challengeType);
         Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
         Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());

--- a/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
+++ b/msal/src/test/java/com/microsoft/identity/client/CommandParametersTest.java
@@ -44,10 +44,14 @@ import com.microsoft.identity.common.java.constants.FidoConstants;
 import com.microsoft.identity.common.java.logging.DiagnosticContext;
 import com.microsoft.identity.common.java.logging.RequestContext;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectMFAMethodCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitMFAChallengeCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitPasswordCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitNewPasswordCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.ResetPasswordV2StartCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInV2StartCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.JITChallengeAuthMethodCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.JITContinueCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.MFAChallengeAuthMethodCommandParameters;
@@ -640,6 +644,120 @@ public class CommandParametersTest {
             DiagnosticContext.INSTANCE.clear();
         }
     }
+
+        @Test
+        public void testCreateSignInV2StartCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+            final String correlationId = "00000000-0000-0000-0000-000000000011";
+            final RequestContext requestContext = new RequestContext();
+            requestContext.put(DiagnosticContext.CORRELATION_ID, correlationId);
+            DiagnosticContext.INSTANCE.setRequestContext(requestContext);
+
+            try {
+                final NativeAuthPublicClientApplicationConfiguration configuration = getNativeAuthConfiguration(NATIVE_AUTH_CONFIG_FILE);
+                final OAuth2TokenCache tokenCache = getCache();
+                final String username = "username@example.com";
+                final char[] password = "Password123!".toCharArray();
+                final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+                final ClaimsRequest claimsRequest = getAccessTokenClaimsRequest("xms_cc", "cp1");
+
+                final SignInV2StartCommandParameters commandParameters =
+                        CommandParametersAdapter.createSignInV2StartCommandParameters(
+                                configuration,
+                                tokenCache,
+                                username,
+                                password,
+                                scopes,
+                                claimsRequest
+                        );
+
+                Assert.assertEquals(username, commandParameters.username);
+                Assert.assertSame(password, commandParameters.password);
+                Assert.assertEquals(scopes, commandParameters.scopes);
+                Assert.assertEquals(
+                        ClaimsRequest.getJsonStringFromClaimsRequest(claimsRequest),
+                        commandParameters.claimsRequestJson
+                );
+                Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
+                Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
+            } finally {
+                DiagnosticContext.INSTANCE.clear();
+            }
+        }
+
+        @Test
+        public void testCreateNativeAuthV2SubmitPasswordCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+            final NativeAuthPublicClientApplicationConfiguration configuration = getNativeAuthConfiguration(NATIVE_AUTH_CONFIG_FILE);
+            final OAuth2TokenCache tokenCache = getCache();
+            final char[] password = "Password123!".toCharArray();
+            final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String correlationId = "00000000-0000-0000-0000-000000000012";
+            final NativeAuthV2ContinuationState continuationState =
+                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+
+            final NativeAuthV2SubmitPasswordCommandParameters commandParameters =
+                    CommandParametersAdapter.createNativeAuthV2SubmitPasswordCommandParameters(
+                            configuration,
+                            tokenCache,
+                            password,
+                            continuationState
+                    );
+
+            Assert.assertSame(password, commandParameters.password);
+            Assert.assertSame(continuationState, commandParameters.continuationState);
+            Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
+            Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
+        }
+
+        @Test
+        public void testCreateNativeAuthV2SelectMFAMethodCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+            final NativeAuthPublicClientApplicationConfiguration configuration = getNativeAuthConfiguration(NATIVE_AUTH_CONFIG_FILE);
+            final OAuth2TokenCache tokenCache = getCache();
+            final String methodId = "email-1";
+            final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String correlationId = "00000000-0000-0000-0000-000000000013";
+            final NativeAuthV2ContinuationState continuationState =
+                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+
+            final NativeAuthV2SelectMFAMethodCommandParameters commandParameters =
+                    CommandParametersAdapter.createNativeAuthV2SelectMFAMethodCommandParameters(
+                            configuration,
+                            tokenCache,
+                            methodId,
+                            continuationState
+                    );
+
+            Assert.assertEquals(methodId, commandParameters.methodId);
+            Assert.assertSame(continuationState, commandParameters.continuationState);
+            Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
+            Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
+        }
+
+        @Test
+        public void testCreateNativeAuthV2SubmitMFAChallengeCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {
+            final NativeAuthPublicClientApplicationConfiguration configuration = getNativeAuthConfiguration(NATIVE_AUTH_CONFIG_FILE);
+            final OAuth2TokenCache tokenCache = getCache();
+            final String code = "123456";
+            final List<String> scopes = Arrays.asList("api://scope/read", "offline_access");
+            final String correlationId = "00000000-0000-0000-0000-000000000014";
+            final NativeAuthV2ContinuationState continuationState =
+                    getNativeAuthV2ContinuationState(correlationId, scopes, null);
+
+            final NativeAuthV2SubmitMFAChallengeCommandParameters commandParameters =
+                    CommandParametersAdapter.createNativeAuthV2SubmitMFAChallengeCommandParameters(
+                            configuration,
+                            tokenCache,
+                            code,
+                            continuationState
+                    );
+
+            Assert.assertEquals(code, commandParameters.code);
+            Assert.assertSame(continuationState, commandParameters.continuationState);
+            Assert.assertEquals(scopes, commandParameters.scopes);
+            Assert.assertEquals(correlationId, commandParameters.getCorrelationId());
+            Assert.assertSame(tokenCache, commandParameters.getOAuth2TokenCache());
+        }
 
     @Test
     public void testCreateNativeAuthV2SubmitCodeCommandParameters_CommandParamsContainsExpectedParams() throws ClientException {

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
@@ -1,0 +1,286 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.client.e2e.tests.network.nativeauth
+
+import com.microsoft.identity.client.e2e.utils.assertResult
+import com.microsoft.identity.client.exception.MsalClientException
+import com.microsoft.identity.internal.testutils.nativeauth.ConfigType
+import com.microsoft.identity.internal.testutils.nativeauth.api.TemporaryEmailService
+import com.microsoft.identity.internal.testutils.nativeauth.api.models.NativeAuthTestConfig
+import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.parameters.NativeAuthGetAccessTokenParameters
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.SubmitPasswordErrorV2
+import com.microsoft.identity.nativeauth.statemachine.results.GetAccessTokenResult
+import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Ignore
+import org.junit.Test
+
+/**
+ * End-to-end coverage for Native Auth V2 sign-in: password as the first factor, and password
+ * followed by an email one-time code.
+ *
+ * Every test here is gated with [Ignore] because the V2 authorize-challenge sign-in endpoints are
+ * not available on the tenant/slice these E2E tests run against; see each reason string. The tests
+ * are kept compiled, and therefore maintained, so they can be enabled unchanged once a V2-capable
+ * slice exists. The equivalent behaviour is asserted today without a service in
+ * `com.microsoft.identity.nativeauth.v2.NativeAuthV2SignInTest`.
+ *
+ * Credentials come from the existing secure lab infrastructure exactly as the V1 suites do; no
+ * captured token, continuation token, authorization code, password or one-time code appears here.
+ */
+class SignInV2EmailPasswordTest : NativeAuthPublicClientApplicationAbstractTest() {
+
+    private val tempEmailApi = TemporaryEmailService()
+
+    private lateinit var resources: List<NativeAuthTestConfig.Resource>
+
+    lateinit var application: INativeAuthPublicClientApplication
+    lateinit var config: NativeAuthTestConfig.Config
+
+    private val defaultConfigType = ConfigType.SIGN_IN_PASSWORD
+    private val mfaConfigType = ConfigType.SIGN_IN_MFA_SINGLE_AUTH
+    private val defaultChallengeTypes = listOf("password", "oob")
+    private val defaultCapabilities = listOf("mfa_required", "registration_required")
+
+    /**
+     * Sign in with a valid email and password supplied at the entry point, and receive tokens.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testSuccessWithPasswordAtEntry() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val param = NativeAuthSignInParameters(username = config.email)
+            param.password = getSafePassword().toCharArray()
+            val result = application.signInV2(param)
+            assertResult<NativeAuthResultV2.Complete>(result)
+        }
+    }
+
+    /**
+     * Omit the password at the entry point, then submit it from the password-required state.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testSuccessWithDeferredPassword() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val result = application.signInV2(NativeAuthSignInParameters(username = config.email))
+            assertResult<NativeAuthResultV2.PasswordRequired>(result)
+
+            val submitResult = (result as NativeAuthResultV2.PasswordRequired)
+                .nextState.submitPassword(getSafePassword().toCharArray())
+            assertResult<NativeAuthResultV2.Complete>(submitResult)
+        }
+    }
+
+    /**
+     * An unknown account is reported as user-not-found.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testErrorIsUserNotFound() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val param = NativeAuthSignInParameters(username = INVALID_EMAIL)
+            param.password = getSafePassword().toCharArray()
+            val result = application.signInV2(param)
+            assertTrue(result is SignInErrorV2)
+            assertTrue((result as SignInErrorV2).isUserNotFound())
+        }
+    }
+
+    /**
+     * A wrong password supplied at the entry point is invalid credentials, matching MSAL iOS V2.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testErrorEntryPasswordIsInvalidCredentials() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val param = NativeAuthSignInParameters(username = config.email)
+            param.password = INVALID_PASSWORD.toCharArray()
+            val result = application.signInV2(param)
+            assertTrue(result is SignInErrorV2)
+            assertTrue((result as SignInErrorV2).isInvalidCredentials())
+        }
+    }
+
+    /**
+     * A wrong password submitted from the password-required state is an invalid password, not
+     * invalid credentials, matching MSAL iOS V2. The caller retries on the state it already holds.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testErrorDeferredPasswordIsInvalidPassword() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val result = application.signInV2(NativeAuthSignInParameters(username = config.email))
+            assertResult<NativeAuthResultV2.PasswordRequired>(result)
+            val passwordState = (result as NativeAuthResultV2.PasswordRequired).nextState
+
+            val wrongPassword = passwordState.submitPassword(INVALID_PASSWORD.toCharArray())
+            assertTrue(wrongPassword is SubmitPasswordErrorV2)
+            assertTrue((wrongPassword as SubmitPasswordErrorV2).isInvalidPassword())
+
+            // Retrying on the retained state succeeds; the error carried no state of its own.
+            val retry = passwordState.submitPassword(getSafePassword().toCharArray())
+            assertResult<NativeAuthResultV2.Complete>(retry)
+        }
+    }
+
+    /**
+     * Password first factor followed by an email one-time code: submit an invalid code, request a
+     * fresh challenge from the retained MFA state, then submit the correct code and complete.
+     * Also asserts the scopes requested at sign in are present in the resulting token.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testSuccessWithEmailOtpMfaAfterInvalidCode() {
+        config = getConfig(mfaConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+        resources = config.resources
+
+        retryOperation {
+            runBlocking {
+                val username = config.email
+                val scopeA = resources[0].scopes[0]
+                val scopeB = resources[0].scopes[1]
+
+                val param = NativeAuthSignInParameters(username = username)
+                param.password = getSafePassword().toCharArray()
+                param.scopes = listOf(scopeA, scopeB)
+                val result = application.signInV2(param)
+                assertResult<NativeAuthResultV2.MFARequired>(result)
+
+                val mfaState = (result as NativeAuthResultV2.MFARequired).nextState
+                val emailMethod = result.authMethods.first { it.challengeChannel == "email" }
+
+                val challengeResult = mfaState.selectAuthMethod(emailMethod)
+                assertResult<NativeAuthResultV2.MFAVerificationRequired>(challengeResult)
+                challengeResult as NativeAuthResultV2.MFAVerificationRequired
+                assertNotNull(challengeResult.sentTo)
+                assertEquals("email", challengeResult.channel)
+                assertTrue(challengeResult.codeLength > 0)
+
+                val incorrect = challengeResult.nextState.submitChallenge(INCORRECT_CODE)
+                assertTrue(incorrect is MFASubmitChallengeErrorV2)
+                assertTrue((incorrect as MFASubmitChallengeErrorV2).isInvalidChallenge())
+
+                // A fresh challenge is requested from the retained MFA state, not from the error.
+                val freshChallenge = mfaState.selectAuthMethod(emailMethod)
+                assertResult<NativeAuthResultV2.MFAVerificationRequired>(freshChallenge)
+
+                val otp = tempEmailApi.retrieveCodeFromInbox(username)
+                val complete = (freshChallenge as NativeAuthResultV2.MFAVerificationRequired)
+                    .nextState.submitChallenge(otp)
+                assertResult<NativeAuthResultV2.Complete>(complete)
+
+                val accountState = (complete as NativeAuthResultV2.Complete).resultValue
+                val getAccessTokenResult =
+                    accountState.getAccessToken(NativeAuthGetAccessTokenParameters())
+                assertResult<GetAccessTokenResult.Complete>(getAccessTokenResult)
+                val authResult = (getAccessTokenResult as GetAccessTokenResult.Complete).resultValue
+                assertTrue(authResult.scope.contains(scopeA))
+                assertTrue(authResult.scope.contains(scopeB))
+            }
+        }
+    }
+
+    /**
+     * Selecting a method the current MFA state never offered is rejected without contacting the
+     * service, and the retained state remains usable.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testErrorSelectingAMethodTheServerDidNotOffer() {
+        config = getConfig(mfaConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val param = NativeAuthSignInParameters(username = config.email)
+            param.password = getSafePassword().toCharArray()
+            val result = application.signInV2(param)
+            assertResult<NativeAuthResultV2.MFARequired>(result)
+
+            val mfaState = (result as NativeAuthResultV2.MFARequired).nextState
+            val stale = com.microsoft.identity.nativeauth.AuthMethod(
+                id = "not-offered",
+                challengeType = "oob",
+                loginHint = null,
+                challengeChannel = "email"
+            )
+            val staleResult = mfaState.selectAuthMethod(stale)
+            assertTrue(staleResult is com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeErrorV2)
+
+            // The real method still works afterwards.
+            val emailMethod = result.authMethods.first { it.challengeChannel == "email" }
+            assertResult<NativeAuthResultV2.MFAVerificationRequired>(mfaState.selectAuthMethod(emailMethod))
+        }
+    }
+
+    /**
+     * Signing in while an account is already signed in is rejected, preserving Android V1
+     * behaviour. Repeated same-account and switch-account sign in are not supported in V2.
+     */
+    @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
+    @Test
+    fun testErrorWhenAnAccountIsAlreadySignedIn() {
+        config = getConfig(defaultConfigType)
+        application = setupPCA(config, defaultChallengeTypes, defaultCapabilities)
+
+        runBlocking {
+            val first = NativeAuthSignInParameters(username = config.email)
+            first.password = getSafePassword().toCharArray()
+            assertResult<NativeAuthResultV2.Complete>(application.signInV2(first))
+
+            val second = NativeAuthSignInParameters(username = config.email)
+            second.password = getSafePassword().toCharArray()
+            val result = application.signInV2(second)
+
+            assertTrue(result is SignInErrorV2)
+            val error = result as SignInErrorV2
+            assertFalse(error.isInvalidCredentials())
+            assertTrue(error.exception is MsalClientException)
+            assertEquals("An account is already signed in.", error.exception!!.message)
+        }
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
@@ -169,7 +169,7 @@ class SignInV2EmailPasswordTest : NativeAuthPublicClientApplicationAbstractTest(
 
     /**
      * Password first factor followed by an email one-time code: submit an invalid code, request a
-     * fresh challenge from the retained MFA state, then submit the correct code and complete.
+     * fresh challenge from the retained verification state, then submit the correct code and complete.
      * Also asserts the scopes requested at sign in are present in the resulting token.
      */
     @Ignore("Native Auth V2 sign-in endpoints are not available on the E2E slice.")
@@ -203,10 +203,9 @@ class SignInV2EmailPasswordTest : NativeAuthPublicClientApplicationAbstractTest(
 
                 val incorrect = challengeResult.nextState.submitChallenge(INCORRECT_CODE)
                 assertTrue(incorrect is MFASubmitChallengeErrorV2)
-                assertTrue((incorrect as MFASubmitChallengeErrorV2).isInvalidChallenge())
+                assertTrue((incorrect as MFASubmitChallengeErrorV2).isInvalidCode())
 
-                // A fresh challenge is requested from the retained MFA state, not from the error.
-                val freshChallenge = mfaState.selectAuthMethod(emailMethod)
+                val freshChallenge = challengeResult.nextState.resendChallenge()
                 assertResult<NativeAuthResultV2.MFAVerificationRequired>(freshChallenge)
 
                 val otp = tempEmailApi.retrieveCodeFromInbox(username)

--- a/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/client/e2e/tests/network/nativeauth/SignInV2EmailPasswordTest.kt
@@ -203,7 +203,7 @@ class SignInV2EmailPasswordTest : NativeAuthPublicClientApplicationAbstractTest(
 
                 val incorrect = challengeResult.nextState.submitChallenge(INCORRECT_CODE)
                 assertTrue(incorrect is MFASubmitChallengeErrorV2)
-                assertTrue((incorrect as MFASubmitChallengeErrorV2).isInvalidCode())
+                assertTrue((incorrect as MFASubmitChallengeErrorV2).isInvalidChallenge())
 
                 val freshChallenge = challengeResult.nextState.resendChallenge()
                 assertResult<NativeAuthResultV2.MFAVerificationRequired>(freshChallenge)

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/utils/CoroutineExtensionsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/utils/CoroutineExtensionsTest.kt
@@ -1,0 +1,77 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.nativeauth.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [launchOwningPasswordSnapshot], covering both the normal-completion cleanup path
+ * and the safety-net path where the launched job is cancelled before its body ever runs.
+ */
+class CoroutineExtensionsTest {
+
+    @Test
+    fun launchOwningPasswordSnapshotClearsTheSnapshotAfterNormalCompletion() = runTest {
+        val snapshot = "Password123!".toCharArray()
+        var bodyRan = false
+
+        val job = launchOwningPasswordSnapshot(snapshot) {
+            // Intentionally does not clear the array itself, so this test proves the extension's
+            // own completion handler -- not the body -- is what performs the clearing.
+            bodyRan = true
+        }
+        job.join()
+
+        assertTrue(bodyRan)
+        assertArrayEquals(CharArray("Password123!".length), snapshot)
+    }
+
+    @Test
+    fun launchOwningPasswordSnapshotClearsTheSnapshotWhenTheJobIsCancelledBeforeItsBodyEverRuns() {
+        val snapshot = "Password123!".toCharArray()
+        val parentJob = Job()
+        // Cancelling the parent job up-front means any coroutine subsequently launched as its
+        // child is cancelled before it ever gets a chance to run.
+        parentJob.cancel()
+        val scope = CoroutineScope(parentJob)
+        var bodyRan = false
+
+        val job = scope.launchOwningPasswordSnapshot(snapshot) {
+            bodyRan = true
+        }
+        // The job is cancelled up-front, but completion (and therefore the invokeOnCompletion
+        // handler that clears the snapshot) can still finish asynchronously; wait for it.
+        runBlocking { job.join() }
+
+        assertTrue(job.isCancelled)
+        assertFalse("The job body must not have run", bodyRan)
+        assertArrayEquals(CharArray("Password123!".length), snapshot)
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
@@ -26,6 +26,7 @@ import com.microsoft.identity.client.exception.MsalClientException
 import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeErrorV2
 import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeErrorV2
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
 import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
 import com.microsoft.identity.nativeauth.statemachine.errors.RegisterStrongAuthChallengeErrorV2
 import com.microsoft.identity.nativeauth.statemachine.errors.RegisterStrongAuthSubmitChallengeErrorV2
@@ -182,10 +183,10 @@ class NativeAuthV2ErrorsTest {
     @Test
     fun testMFASubmitChallengeErrorV2UtilityMethods() {
         assertTrue(
-            MFASubmitChallengeErrorV2(errorType = "invalid_challenge", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidChallenge()
+            MFASubmitChallengeErrorV2(errorType = ErrorTypes.INVALID_CODE, errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidCode()
         )
         val error = MFASubmitChallengeErrorV2(errorType = "other", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN, subError = "sub")
-        assertFalse(error.isInvalidChallenge())
+        assertFalse(error.isInvalidCode())
         assertEquals("sub", error.subError)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
@@ -183,10 +183,10 @@ class NativeAuthV2ErrorsTest {
     @Test
     fun testMFASubmitChallengeErrorV2UtilityMethods() {
         assertTrue(
-            MFASubmitChallengeErrorV2(errorType = ErrorTypes.INVALID_CODE, errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidCode()
+            MFASubmitChallengeErrorV2(errorType = ErrorTypes.INVALID_CODE, errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidChallenge()
         )
         val error = MFASubmitChallengeErrorV2(errorType = "other", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN, subError = "sub")
-        assertFalse(error.isInvalidCode())
+        assertFalse(error.isInvalidChallenge())
         assertEquals("sub", error.subError)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
@@ -83,14 +83,6 @@ class NativeAuthV2ErrorsTest {
     }
 
     @Test
-    fun testSubmitPasswordErrorV2DoesNotExposeInvalidCredentials() {
-        assertFalse(
-            "SubmitPasswordErrorV2 must expose isInvalidPassword instead of isInvalidCredentials",
-            SubmitPasswordErrorV2::class.java.methods.any { it.name == "isInvalidCredentials" }
-        )
-    }
-
-    @Test
     fun testSignUpErrorV2UtilityMethods() {
         assertTrue(
             SignUpErrorV2(errorType = "user_already_exists", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isUserAlreadyExists()

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ErrorsTest.kt
@@ -75,10 +75,18 @@ class NativeAuthV2ErrorsTest {
     @Test
     fun testSubmitPasswordErrorV2UtilityMethods() {
         assertTrue(
-            SubmitPasswordErrorV2(errorType = "invalid_credentials", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidCredentials()
+            SubmitPasswordErrorV2(errorType = "invalid_password", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidPassword()
         )
         assertFalse(
-            SubmitPasswordErrorV2(errorType = "other", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidCredentials()
+            SubmitPasswordErrorV2(errorType = "other", errorMessage = errorMessage, correlationId = correlationId, scenario = NativeAuthFlowScenarioV2.UNKNOWN).isInvalidPassword()
+        )
+    }
+
+    @Test
+    fun testSubmitPasswordErrorV2DoesNotExposeInvalidCredentials() {
+        assertFalse(
+            "SubmitPasswordErrorV2 must expose isInvalidPassword instead of isInvalidCredentials",
+            SubmitPasswordErrorV2::class.java.methods.any { it.name == "isInvalidCredentials" }
         )
     }
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceJavaTest.java
@@ -41,6 +41,7 @@ import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters;
 import com.microsoft.identity.nativeauth.parameters.NativeAuthSignUpParameters;
 import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2;
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2;
+import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorV2;
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2;
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2;
 
@@ -88,10 +89,15 @@ public class NativeAuthV2InterfaceJavaTest extends PublicClientApplicationAbstra
     }
 
     @Test
-    public void signInV2ReturnsNotImplemented() throws ExecutionException, InterruptedException, TimeoutException {
+    public void signInV2RejectsBlankUsername() throws ExecutionException, InterruptedException, TimeoutException {
+        // A blank username is rejected before any command is dispatched, so this exercises the
+        // Java callback surface of the now-implemented signInV2 without needing a service.
         final ResultFuture<NativeAuthResultV2> future = new ResultFuture<>();
-        application.signInV2(new NativeAuthSignInParameters(username), newCallback(future));
-        assertNotImplemented(future.get(30, TimeUnit.SECONDS), NativeAuthFlowScenarioV2.SIGN_IN);
+        application.signInV2(new NativeAuthSignInParameters(" "), newCallback(future));
+        final NativeAuthResultV2 result = future.get(30, TimeUnit.SECONDS);
+        assertTrue(result instanceof SignInErrorV2);
+        assertTrue(((SignInErrorV2) result).isInvalidUsername());
+        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, result.getScenario());
     }
 
     @Test
@@ -129,7 +135,7 @@ public class NativeAuthV2InterfaceJavaTest extends PublicClientApplicationAbstra
     @Test
     public void resultDefaultImplsDelegateToBaseResult() throws ExecutionException, InterruptedException, TimeoutException {
         final ResultFuture<NativeAuthResultV2> future = new ResultFuture<>();
-        application.signInV2(new NativeAuthSignInParameters(username), newCallback(future));
+        application.signUpV2(new NativeAuthSignUpParameters(username), newCallback(future));
         final NativeAuthResultV2 result = future.get(30, TimeUnit.SECONDS);
         assertFalse(NativeAuthResultV2.DefaultImpls.isSuccess(result));
         assertFalse(NativeAuthResultV2.DefaultImpls.isComplete(result));

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceJavaTest.java
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceJavaTest.java
@@ -43,6 +43,7 @@ import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2;
 import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2;
 import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorV2;
 import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2;
+import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2;
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2;
 
 import org.junit.Before;
@@ -133,6 +134,31 @@ public class NativeAuthV2InterfaceJavaTest extends PublicClientApplicationAbstra
     }
 
     @Test
+    public void mfaVerificationRequiredResendChallengeReturnsInvalidState() throws ExecutionException, InterruptedException, TimeoutException {
+        final MFAVerificationRequiredStateV2 state = new MFAVerificationRequiredStateV2(
+                "continuation-token",
+                "correlation-id",
+                NativeAuthFlowScenarioV2.SIGN_IN,
+                new NativeAuthPublicClientApplicationConfiguration(),
+                null
+        );
+        final ResultFuture<NativeAuthResultV2> future = new ResultFuture<>();
+        state.resendChallenge(new MFAVerificationRequiredStateV2.ResendChallengeCallback() {
+            @Override
+            public void onResult(final NativeAuthResultV2 result) {
+                future.setResult(result);
+            }
+
+            @Override
+            public void onError(@NonNull final BaseException exception) {
+                future.setException(exception);
+            }
+        });
+
+        assertInvalidState(future.get(30, TimeUnit.SECONDS), NativeAuthFlowScenarioV2.SIGN_IN);
+    }
+
+    @Test
     public void resultDefaultImplsDelegateToBaseResult() throws ExecutionException, InterruptedException, TimeoutException {
         final ResultFuture<NativeAuthResultV2> future = new ResultFuture<>();
         application.signUpV2(new NativeAuthSignUpParameters(username), newCallback(future));
@@ -161,6 +187,15 @@ public class NativeAuthV2InterfaceJavaTest extends PublicClientApplicationAbstra
         NativeAuthErrorV2 error = (NativeAuthErrorV2) result;
         assertTrue(error.isNotImplemented());
         assertFalse(error.isBrowserRequired());
+        assertEquals(scenario, error.getScenario());
+    }
+
+    private void assertInvalidState(final NativeAuthResultV2 result, final NativeAuthFlowScenarioV2 scenario) {
+        assertTrue(result instanceof NativeAuthErrorV2);
+        final NativeAuthErrorV2 error = (NativeAuthErrorV2) result;
+        assertFalse(error.isNotImplemented());
+        assertFalse(error.isBrowserRequired());
+        assertEquals("The continuation state is unavailable. Restart the flow.", error.getErrorMessage());
         assertEquals(scenario, error.getScenario());
     }
 }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -138,13 +138,6 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
     }
 
     @Test
-    fun signInV2ReturnsNotImplemented() = runTest {
-        val result = application.signInV2(NativeAuthSignInParameters(username = username))
-        val error = assertNotImplemented(result)
-        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, error.scenario)
-    }
-
-    @Test
     fun signUpV2ReturnsNotImplemented() = runTest {
         val result = application.signUpV2(NativeAuthSignUpParameters(username = username))
         val error = assertNotImplemented(result, NativeAuthFlowScenarioV2.SIGN_UP)
@@ -648,13 +641,13 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         assertInvalidState(codeRequired.submitCode("1234"))
         assertInvalidState(codeRequired.resendCode())
 
-        assertNotImplemented(PasswordRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitPassword("password".toCharArray()))
+        assertInvalidState(PasswordRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitPassword("password".toCharArray()))
         assertNotImplemented(NewPasswordRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitNewPassword("password".toCharArray()))
         assertNotImplemented(SignInAfterResetPasswordStateV2("continuation-token", "correlation-id", scenario, config).signIn())
         assertNotImplemented(AttributesRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitAttributes(attributes))
         assertNotImplemented(AttributesInvalidStateV2("continuation-token", "correlation-id", scenario, config).submitAttributes(attributes))
-        assertNotImplemented(MFARequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
-        assertNotImplemented(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
+        assertInvalidState(MFARequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
+        assertInvalidState(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
         assertNotImplemented(StrongAuthRegistrationRequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
         assertNotImplemented(StrongAuthVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
     }
@@ -839,11 +832,12 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
 
     private fun createContinuationState(): NativeAuthV2ContinuationState {
         val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 7 }
+            .single { it.parameterCount == 8 }
         constructor.isAccessible = true
         return constructor.newInstance(
             "opaque-token",
             emptyMap<String, String>(),
+            emptyMap<String, Map<String, String>>(),
             listOf("scope"),
             null,
             correlationId,

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -648,6 +648,7 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         assertNotImplemented(AttributesInvalidStateV2("continuation-token", "correlation-id", scenario, config).submitAttributes(attributes))
         assertInvalidState(MFARequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
         assertInvalidState(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
+        assertInvalidState(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).resendChallenge())
         assertNotImplemented(StrongAuthRegistrationRequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
         assertNotImplemented(StrongAuthVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
     }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -41,8 +41,6 @@ import com.microsoft.identity.common.java.logging.DiagnosticContext
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
-import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
-import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult
 import com.microsoft.identity.common.java.util.ResultFuture
@@ -831,21 +829,8 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         } returns future
     }
 
-    private fun createContinuationState(): NativeAuthV2ContinuationState {
-        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 8 }
-        constructor.isAccessible = true
-        return constructor.newInstance(
-            "opaque-token",
-            emptyMap<String, String>(),
-            emptyMap<String, Map<String, String>>(),
-            listOf("scope"),
-            null,
-            correlationId,
-            NativeAuthV2LinkRelation.RESET_PASSWORD.value,
-            NativeAuthV2FlowScenario.RESET_PASSWORD
-        ) as NativeAuthV2ContinuationState
-    }
+    private fun createContinuationState(): NativeAuthV2ContinuationState =
+        newContinuationState(correlationId)
 
     @Suppress("unused")
     private fun exhaustiveWhen(result: NativeAuthResultV2): String = when (result) {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
@@ -137,12 +137,19 @@ class NativeAuthV2ResultsTest {
     @Test
     fun testMFARequiredExposesExpectedValues() {
         val authMethods = mutableListOf(AuthMethod("id", "oob", "user@email.com", "email"))
-        val result = NativeAuthResultV2.MFARequired(
-            nextState = MFARequiredStateV2(continuationToken, correlationId, scenario, config),
-            scenario = scenario,
+        val nextState = MFARequiredStateV2(
+            continuationToken,
+            correlationId,
+            scenario,
+            config,
             authMethods = authMethods
         )
+        val result = NativeAuthResultV2.MFARequired(
+            nextState = nextState,
+            scenario = scenario
+        )
         assertEquals(authMethods, result.authMethods)
+        assertSame(nextState.authMethods, result.authMethods)
         assertEquals(scenario, result.scenario)
 
         authMethods.clear()

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
@@ -136,7 +136,7 @@ class NativeAuthV2ResultsTest {
 
     @Test
     fun testMFARequiredExposesExpectedValues() {
-        val authMethods = listOf(AuthMethod("id", "oob", "user@email.com", "email"))
+        val authMethods = mutableListOf(AuthMethod("id", "oob", "user@email.com", "email"))
         val result = NativeAuthResultV2.MFARequired(
             nextState = MFARequiredStateV2(continuationToken, correlationId, scenario, config),
             scenario = scenario,
@@ -144,6 +144,15 @@ class NativeAuthV2ResultsTest {
         )
         assertEquals(authMethods, result.authMethods)
         assertEquals(scenario, result.scenario)
+
+        authMethods.clear()
+        assertEquals(1, result.authMethods.size)
+        try {
+            (result.authMethods as MutableList<AuthMethod>).clear()
+            org.junit.Assert.fail("Expected authMethods to be unmodifiable")
+        } catch (_: UnsupportedOperationException) {
+            // Expected.
+        }
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -499,7 +499,11 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
         val result = state.selectAuthMethod(state.authMethods.single())
 
         assertTrue(result is MFARequestChallengeErrorV2)
-        assertFalse((result as MFARequestChallengeErrorV2).isAuthMethodBlocked())
+        val error = result as MFARequestChallengeErrorV2
+        // Distinguishable from an unspecified server error: this increment supports email only.
+        assertTrue(error.isNotImplemented())
+        assertFalse(error.isAuthMethodBlocked())
+        assertFalse(error.isBrowserRequired())
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -1,0 +1,781 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+package com.microsoft.identity.nativeauth.v2
+
+import android.content.Context
+import android.os.Parcel
+import androidx.test.core.app.ApplicationProvider
+import com.microsoft.identity.client.PublicClientApplication
+import com.microsoft.identity.client.e2e.shadows.ShadowAndroidSdkStorageEncryptionManager
+import com.microsoft.identity.client.e2e.tests.PublicClientApplicationAbstractTest
+import com.microsoft.identity.client.exception.MsalClientException
+import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.common.java.controllers.CommandDispatcher
+import com.microsoft.identity.common.java.commands.BaseCommand
+import com.microsoft.identity.common.java.commands.ICommandResult
+import com.microsoft.identity.common.java.controllers.CommandResult
+import com.microsoft.identity.common.java.exception.BaseException
+import com.microsoft.identity.common.java.logging.DiagnosticContext
+import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
+import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
+import com.microsoft.identity.common.java.result.FinalizableResultFuture
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignInStartCommand
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitMFAChallengeCommand
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitPasswordCommand
+import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
+import com.microsoft.identity.nativeauth.parameters.NativeAuthSignInParameters
+import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.MFARequestChallengeErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.MFASubmitChallengeErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.SignInErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.SubmitPasswordErrorV2
+import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import com.microsoft.identity.nativeauth.statemachine.states.Callback
+import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
+import com.microsoft.identity.common.java.util.ResultFuture
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkObject
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.KClass
+
+/**
+ * Parity coverage for Native Auth V2 sign-in: password first factor and password followed by email
+ * one-time-code MFA.
+ *
+ * Every scenario is driven through mocked Common command results, so the whole public surface is
+ * exercised without a service. The live end-to-end equivalents are gated separately on a
+ * V2-capable slice.
+ *
+ * The scenarios mirror the in-scope iOS V2 cases: password success, unknown user, an invalid
+ * entry-supplied password reported as invalid credentials, an invalid deferred password reported as
+ * an invalid password, deferred-password state, password + email MFA success, invalid OTP followed
+ * by a fresh challenge, browser-required, and the Android V1 existing-account rejection.
+ */
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(shadows = [ShadowAndroidSdkStorageEncryptionManager::class])
+class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
+
+    private lateinit var context: Context
+    private lateinit var application: INativeAuthPublicClientApplication
+    private val username = "user@email.com"
+
+    override fun getConfigFilePath() = "src/test/res/raw/native_auth_native_only_test_config.json"
+
+    @Before
+    override fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+        val configFile = File(getConfigFilePath())
+        try {
+            application = PublicClientApplication.createNativeAuthPublicClientApplication(context, configFile)
+        } catch (e: MsalException) {
+            fail(e.message)
+        }
+        CommandDispatcher.getSilentExecutorPoolSize()
+        mockkStatic(CommandDispatcher::class)
+    }
+
+    @After
+    fun tearDown() {
+        unmockkStatic(CommandDispatcher::class)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Password first factor
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun signInV2RejectsBlankUsernameWithoutIssuingACommand() = runTest {
+        mockkObject(DiagnosticContext.INSTANCE)
+        every { DiagnosticContext.INSTANCE.threadCorrelationId } returns correlationId
+        try {
+            val result = application.signInV2(signInParameters(username = " "))
+            assertTrue(result is SignInErrorV2)
+            val error = result as SignInErrorV2
+            assertTrue(error.isInvalidUsername())
+            assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, error.scenario)
+            assertEquals(correlationId, error.correlationId)
+        } finally {
+            unmockkObject(DiagnosticContext.INSTANCE)
+        }
+    }
+
+    @Test
+    fun signInV2WithoutPasswordReturnsPasswordRequiredState() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.PasswordRequired(correlationId, createContinuationState()),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val result = application.signInV2(NativeAuthSignInParameters(username))
+
+        assertTrue(result is NativeAuthResultV2.PasswordRequired)
+        result as NativeAuthResultV2.PasswordRequired
+        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, result.scenario)
+        // The public state exposes no continuation token; the opaque DTO carries it instead.
+        assertNull(result.nextState.continuationToken)
+        assertEquals(correlationId, result.nextState.correlationId)
+    }
+
+    @Test
+    fun signInV2WithWrongEntryPasswordIsInvalidCredentials() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.InvalidCredentials(
+                correlationId,
+                "invalid_grant",
+                "AADSTS50126: invalid username or password.",
+                "invalidUserNameOrPassword",
+                errorCodes
+            ),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val result = application.signInV2(signInParameters(password = "WrongPassword!".toCharArray()))
+
+        assertTrue(result is SignInErrorV2)
+        result as SignInErrorV2
+        assertTrue(result.isInvalidCredentials())
+        assertFalse(result.isUserNotFound())
+        assertEquals(errorCodes, result.errorCodes)
+        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, result.scenario)
+        // A recoverable-looking error must not hand back a state to continue from.
+        assertNull((result as NativeAuthResultV2).let { (it as? NativeAuthResultV2.PasswordRequired)?.nextState })
+    }
+
+    @Test
+    fun signInV2WithUnknownUserIsUserNotFound() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.UserNotFound(
+                correlationId,
+                "invalid_grant",
+                "AADSTS50034: user not found.",
+                errorCodes
+            ),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val result = application.signInV2(signInParameters()) as SignInErrorV2
+
+        assertTrue(result.isUserNotFound())
+        assertFalse(result.isInvalidCredentials())
+        assertEquals(errorCodes, result.errorCodes)
+    }
+
+    @Test
+    fun signInV2MapsBrowserRequiredToSignInError() = runTest {
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val result = application.signInV2(signInParameters()) as SignInErrorV2
+
+        assertTrue(result.isBrowserRequired())
+    }
+
+    @Test
+    fun signInV2ClearsTheCallersPasswordCopyAndLeavesTheOriginalIntact() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.InvalidCredentials(
+                correlationId,
+                "invalid_grant",
+                "invalid",
+                "invalidUserNameOrPassword"
+            ),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val callerPassword = "Password123!".toCharArray()
+        application.signInV2(signInParameters(password = callerPassword))
+
+        // signInV2 copies the buffer, so the caller's own array is untouched while the copy handed
+        // to Common is cleared. A password is never stored in a state or continuation state.
+        assertEquals("Password123!", String(callerPassword))
+    }
+
+    @Test
+    fun signInV2PropagatesCancellationRatherThanReportingAnAuthError() = runTest {
+        enqueueCancellation(NativeAuthV2SignInStartCommand::class)
+
+        try {
+            application.signInV2(signInParameters())
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected: cancellation is not an authentication failure.
+        }
+    }
+
+    @Test
+    fun signInV2RejectsSignInWhenAnAccountIsAlreadySignedIn() = runTest {
+        mockkObject(NativeAuthPublicClientApplication.Companion)
+        every {
+            NativeAuthPublicClientApplication.getCurrentAccountInternal(any())
+        } returns mockk<com.microsoft.identity.client.IAccount>()
+        try {
+            // Android V1 behaviour is preserved: V2 rejects sign-in while an account is signed in,
+            // and does not implement the iOS repeated/switch-account behaviour.
+            val suspendResult = application.signInV2(signInParameters())
+            assertTrue(suspendResult is SignInErrorV2)
+            assertEquals(ErrorTypes.CLIENT_EXCEPTION, (suspendResult as SignInErrorV2).errorType)
+            val cause = suspendResult.exception
+            assertTrue(cause is MsalClientException)
+            assertEquals("An account is already signed in.", cause?.message)
+
+            val callbackResult = ResultFuture<NativeAuthResultV2>()
+            application.signInV2(
+                signInParameters(),
+                object : NativeAuthPublicClientApplication.NativeAuthV2Callback {
+                    override fun onResult(result: NativeAuthResultV2) = callbackResult.setResult(result)
+                    override fun onError(exception: BaseException) =
+                        callbackResult.setException(IllegalStateException("Expected callback.onResult", exception))
+                }
+            )
+            val delivered = callbackResult.get(10, TimeUnit.SECONDS)
+            assertTrue(delivered is SignInErrorV2)
+            assertEquals(ErrorTypes.CLIENT_EXCEPTION, (delivered as SignInErrorV2).errorType)
+        } finally {
+            unmockkObject(NativeAuthPublicClientApplication.Companion)
+        }
+    }
+
+    @Test
+    fun signInV2CallbackAndSuspendSurfacesAgree() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.PasswordRequired(correlationId, createContinuationState()),
+            NativeAuthV2SignInStartCommand::class
+        )
+        val suspendResult = application.signInV2(signInParameters(password = null))
+
+        enqueueResult(
+            NativeAuthV2CommandResult.PasswordRequired(correlationId, createContinuationState()),
+            NativeAuthV2SignInStartCommand::class
+        )
+        val future = ResultFuture<NativeAuthResultV2>()
+        application.signInV2(
+            signInParameters(password = null),
+            object : NativeAuthPublicClientApplication.NativeAuthV2Callback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) = future.setException(exception)
+            }
+        )
+        val callbackResult = future.get(30, TimeUnit.SECONDS)
+
+        assertTrue(suspendResult is NativeAuthResultV2.PasswordRequired)
+        assertTrue(callbackResult is NativeAuthResultV2.PasswordRequired)
+        assertEquals(suspendResult.scenario, callbackResult.scenario)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Deferred password submission
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun submitPasswordWithWrongPasswordIsInvalidPasswordNotInvalidCredentials() = runTest {
+        val state = passwordRequiredState()
+        enqueueResult(
+            NativeAuthV2CommandResult.IncorrectPassword(
+                correlationId,
+                "invalid_grant",
+                "AADSTS50126: invalid username or password.",
+                "invalidUserNameOrPassword",
+                errorCodes
+            ),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+
+        val result = state.submitPassword("WrongPassword!".toCharArray())
+
+        assertTrue(result is SubmitPasswordErrorV2)
+        result as SubmitPasswordErrorV2
+        assertTrue(result.isInvalidPassword())
+        @Suppress("DEPRECATION")
+        assertFalse(
+            "A deferred password rejection must not be classified as invalid credentials",
+            result.isInvalidCredentials()
+        )
+        assertEquals(errorCodes, result.errorCodes)
+    }
+
+    @Test
+    fun submitPasswordRejectsAnEmptyPasswordWithoutIssuingACommand() = runTest {
+        val state = passwordRequiredState()
+
+        val result = state.submitPassword(CharArray(0)) as SubmitPasswordErrorV2
+
+        assertTrue(result.isInvalidPassword())
+    }
+
+    @Test
+    fun submitPasswordClearsItsOwnCopyAndLeavesTheCallersBufferIntact() = runTest {
+        val state = passwordRequiredState()
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+
+        val callerPassword = "Password123!".toCharArray()
+        state.submitPassword(callerPassword)
+
+        assertEquals("Password123!", String(callerPassword))
+    }
+
+    @Test
+    fun submitPasswordPropagatesCancellation() = runTest {
+        val state = passwordRequiredState()
+        enqueueCancellation(NativeAuthV2SubmitPasswordCommand::class)
+
+        try {
+            state.submitPassword("Password123!".toCharArray())
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun submitPasswordMapsApiErrorAndBrowserRequired() = runTest {
+        val state = passwordRequiredState()
+
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+        assertTrue((state.submitPassword("Password123!".toCharArray()) as SubmitPasswordErrorV2).isBrowserRequired())
+
+        enqueueResult(
+            INativeAuthCommandResult.APIError("api_error", "API failed", correlationId = correlationId, errorCodes = errorCodes),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+        val apiError = state.submitPassword("Password123!".toCharArray()) as SubmitPasswordErrorV2
+        assertEquals(errorCodes, apiError.errorCodes)
+        assertFalse(apiError.isInvalidPassword())
+    }
+
+    @Test
+    fun submitPasswordCallbackDeliversRecoverableErrorThroughOnResult() = runTest {
+        val state = passwordRequiredState()
+        enqueueResult(
+            NativeAuthV2CommandResult.IncorrectPassword(
+                correlationId,
+                "invalid_grant",
+                "invalid",
+                "invalidUserNameOrPassword"
+            ),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+
+        val future = ResultFuture<NativeAuthResultV2>()
+        state.submitPassword(
+            "WrongPassword!".toCharArray(),
+            object : PasswordRequiredStateV2.SubmitPasswordCallback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) =
+                    future.setException(IllegalStateException("Expected callback.onResult", exception))
+            }
+        )
+
+        val result = future.get(30, TimeUnit.SECONDS)
+        assertTrue((result as SubmitPasswordErrorV2).isInvalidPassword())
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Email OTP MFA
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun signInV2WithPasswordCanTransitionToMFARequiredWithServerMethods() = runTest {
+        enqueueResult(
+            NativeAuthV2CommandResult.MFARequired(
+                correlationId,
+                createContinuationState(),
+                listOf(NativeAuthV2AuthMethod("email-1", "email", "u***@contoso.com"))
+            ),
+            NativeAuthV2SignInStartCommand::class
+        )
+
+        val result = application.signInV2(signInParameters()) as NativeAuthResultV2.MFARequired
+
+        assertEquals(1, result.authMethods.size)
+        val method = result.authMethods.single()
+        assertEquals("email-1", method.id)
+        assertEquals("email", method.challengeChannel)
+        assertEquals("oob", method.challengeType)
+        assertEquals("u***@contoso.com", method.loginHint)
+        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, result.scenario)
+    }
+
+    @Test
+    fun selectAuthMethodTransitionsToMFAVerificationRequired() = runTest {
+        val state = mfaRequiredState()
+        enqueueResult(
+            NativeAuthV2CommandResult.MFAVerificationRequired(
+                correlationId,
+                createContinuationState(),
+                6,
+                "u***@contoso.com",
+                "email"
+            ),
+            NativeAuthV2SelectMFAMethodCommand::class
+        )
+
+        val result = state.selectAuthMethod(state.authMethods.single()) as NativeAuthResultV2.MFAVerificationRequired
+
+        assertEquals(6, result.codeLength)
+        assertTrue("Code length must be positive", result.codeLength > 0)
+        assertEquals("u***@contoso.com", result.sentTo)
+        assertEquals("email", result.channel)
+        assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, result.scenario)
+    }
+
+    @Test
+    fun selectAuthMethodRejectsAMethodTheServerDidNotOffer() = runTest {
+        val state = mfaRequiredState()
+
+        val result = state.selectAuthMethod(
+            com.microsoft.identity.nativeauth.AuthMethod("not-offered", "oob", null, "email")
+        )
+
+        assertTrue(result is MFARequestChallengeErrorV2)
+        assertEquals(ErrorTypes.INVALID_STATE, (result as MFARequestChallengeErrorV2).errorType)
+    }
+
+    @Test
+    fun selectAuthMethodRejectsAnUnsupportedChannelWithoutIssuingACommand() = runTest {
+        val state = mfaRequiredState(
+            methods = listOf(NativeAuthV2AuthMethod("sms-1", "sms", "+1***4567"))
+        )
+
+        val result = state.selectAuthMethod(state.authMethods.single())
+
+        assertTrue(result is MFARequestChallengeErrorV2)
+        assertFalse((result as MFARequestChallengeErrorV2).isAuthMethodBlocked())
+    }
+
+    @Test
+    fun selectAuthMethodMapsBlockedMethod() = runTest {
+        val state = mfaRequiredState()
+        enqueueResult(
+            NativeAuthV2CommandResult.AuthMethodBlocked(
+                correlationId,
+                "accessDenied",
+                "blocked",
+                "providerBlockedByRep",
+                errorCodes
+            ),
+            NativeAuthV2SelectMFAMethodCommand::class
+        )
+
+        val result = state.selectAuthMethod(state.authMethods.single()) as MFARequestChallengeErrorV2
+
+        assertTrue(result.isAuthMethodBlocked())
+        assertEquals(errorCodes, result.errorCodes)
+    }
+
+    @Test
+    fun submitChallengeWithWrongCodeIsRecoverableAndAllowsAFreshChallenge() = runTest {
+        val mfaState = mfaRequiredState()
+        val verificationState = mfaVerificationState(mfaState)
+
+        enqueueResult(
+            NativeAuthV2CommandResult.IncorrectCode(
+                correlationId,
+                "invalidGrant",
+                "AADSTS50184: invalid code.",
+                "invalidOneTimeCode",
+                errorCodes
+            ),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+        val wrongCode = verificationState.submitChallenge("000000") as MFASubmitChallengeErrorV2
+        assertTrue(wrongCode.isInvalidChallenge())
+        assertEquals("invalidOneTimeCode", wrongCode.subError)
+
+        // The app requests a fresh challenge from the retained MFARequiredStateV2, not from a
+        // state carried on the error.
+        enqueueResult(
+            NativeAuthV2CommandResult.MFAVerificationRequired(
+                correlationId,
+                createContinuationState(),
+                6,
+                "u***@contoso.com",
+                "email"
+            ),
+            NativeAuthV2SelectMFAMethodCommand::class
+        )
+        val fresh = mfaState.selectAuthMethod(mfaState.authMethods.single())
+        assertTrue(fresh is NativeAuthResultV2.MFAVerificationRequired)
+
+        // Retrying on the state instance the caller already holds also works.
+        enqueueResult(
+            NativeAuthV2CommandResult.IncorrectCode(
+                correlationId,
+                "invalidGrant",
+                "invalid",
+                "invalidOneTimeCode"
+            ),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+        assertTrue((verificationState.submitChallenge("111111") as MFASubmitChallengeErrorV2).isInvalidChallenge())
+    }
+
+    @Test
+    fun submitChallengeRejectsAnEmptyCodeWithoutIssuingACommand() = runTest {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+
+        val result = verificationState.submitChallenge("") as MFASubmitChallengeErrorV2
+
+        assertTrue(result.isInvalidChallenge())
+    }
+
+    @Test
+    fun submitChallengeMapsNotImplementedAndBrowserRequired() = runTest {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+        assertTrue((verificationState.submitChallenge("123456") as MFASubmitChallengeErrorV2).isBrowserRequired())
+
+        enqueueResult(
+            NativeAuthV2CommandResult.NotImplemented(correlationId, "not_implemented", "nope"),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+        assertTrue((verificationState.submitChallenge("123456") as NativeAuthErrorV2).isNotImplemented())
+    }
+
+    @Test
+    fun submitChallengePropagatesCancellation() = runTest {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+        enqueueCancellation(NativeAuthV2SubmitMFAChallengeCommand::class)
+
+        try {
+            verificationState.submitChallenge("123456")
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun mfaVerificationCallbackDeliversRecoverableErrorThroughOnResult() = runTest {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+        enqueueResult(
+            NativeAuthV2CommandResult.IncorrectCode(
+                correlationId,
+                "invalidGrant",
+                "invalid",
+                "invalidOneTimeCode"
+            ),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+
+        val future = ResultFuture<NativeAuthResultV2>()
+        verificationState.submitChallenge(
+            "000000",
+            object : MFAVerificationRequiredStateV2.SubmitChallengeCallback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) =
+                    future.setException(IllegalStateException("Expected callback.onResult", exception))
+            }
+        )
+
+        assertTrue((future.get(30, TimeUnit.SECONDS) as MFASubmitChallengeErrorV2).isInvalidChallenge())
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // State restoration
+    // -----------------------------------------------------------------------------------------
+
+    @Test
+    fun signInStatesSurviveParcelRestorationWithoutExposingSecrets() = runTest {
+        val passwordState = passwordRequiredState()
+        val mfaState = mfaRequiredState()
+        val verificationState = mfaVerificationState(mfaState)
+
+        val restoredPassword = parcelRoundTrip(passwordState, PasswordRequiredStateV2.CREATOR)
+        val restoredMfa = parcelRoundTrip(mfaState, MFARequiredStateV2.CREATOR)
+        val restoredVerification = parcelRoundTrip(verificationState, MFAVerificationRequiredStateV2.CREATOR)
+
+        listOf(restoredPassword, restoredMfa, restoredVerification).forEach { restored ->
+            assertNull(restored.continuationToken)
+            assertEquals(correlationId, restored.correlationId)
+            assertEquals(NativeAuthFlowScenarioV2.SIGN_IN, restored.scenario)
+            assertEquals(listOf("scope"), restored.continuationState?.scopesForTokenRequest())
+            // The opaque DTO must reveal nothing, even after restoration.
+            assertFalse(restored.continuationState.toString().contains("opaque-token"))
+        }
+
+        // The offered methods must survive restoration so selection can still be validated.
+        assertEquals(mfaState.authMethods, restoredMfa.authMethods)
+
+        // Validation against the restored method set still happens before any command is issued,
+        // so a stale selection fails deterministically on a restored state too.
+        val staleSelection = restoredMfa.selectAuthMethod(
+            com.microsoft.identity.nativeauth.AuthMethod("not-offered", "oob", null, "email")
+        )
+        assertTrue(staleSelection is MFARequestChallengeErrorV2)
+        assertEquals(ErrorTypes.INVALID_STATE, (staleSelection as MFARequestChallengeErrorV2).errorType)
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------------------------
+
+    private fun signInParameters(
+        password: CharArray? = "Password123!".toCharArray(),
+        scopes: List<String>? = null,
+        username: String = this.username
+    ): NativeAuthSignInParameters = NativeAuthSignInParameters(username).also {
+        it.password = password
+        it.scopes = scopes
+    }
+
+    private suspend fun passwordRequiredState(): PasswordRequiredStateV2 {
+        enqueueResult(
+            NativeAuthV2CommandResult.PasswordRequired(correlationId, createContinuationState()),
+            NativeAuthV2SignInStartCommand::class
+        )
+        return (application.signInV2(signInParameters(password = null)) as
+            NativeAuthResultV2.PasswordRequired).nextState
+    }
+
+    private suspend fun mfaRequiredState(
+        methods: List<NativeAuthV2AuthMethod> =
+            listOf(NativeAuthV2AuthMethod("email-1", "email", "u***@contoso.com"))
+    ): MFARequiredStateV2 {
+        enqueueResult(
+            NativeAuthV2CommandResult.MFARequired(correlationId, createContinuationState(), methods),
+            NativeAuthV2SignInStartCommand::class
+        )
+        return (application.signInV2(signInParameters()) as NativeAuthResultV2.MFARequired).nextState
+    }
+
+    private suspend fun mfaVerificationState(state: MFARequiredStateV2): MFAVerificationRequiredStateV2 {
+        enqueueResult(
+            NativeAuthV2CommandResult.MFAVerificationRequired(
+                correlationId,
+                createContinuationState(),
+                6,
+                "u***@contoso.com",
+                "email"
+            ),
+            NativeAuthV2SelectMFAMethodCommand::class
+        )
+        return (state.selectAuthMethod(state.authMethods.single()) as
+            NativeAuthResultV2.MFAVerificationRequired).nextState
+    }
+
+    private fun <T : com.microsoft.identity.nativeauth.statemachine.states.NativeAuthBaseStateV2> parcelRoundTrip(
+        state: T,
+        creator: android.os.Parcelable.Creator<T>
+    ): T {
+        val parcel = Parcel.obtain()
+        try {
+            state.writeToParcel(parcel, 0)
+            parcel.setDataPosition(0)
+            return creator.createFromParcel(parcel)
+        } finally {
+            parcel.recycle()
+        }
+    }
+
+    private fun enqueueResult(
+        result: INativeAuthCommandResult,
+        commandClass: KClass<out BaseCommand<*>>
+    ) {
+        val future = FinalizableResultFuture<CommandResult<Any>>()
+        future.setResult(
+            CommandResult(
+                ICommandResult.ResultStatus.COMPLETED,
+                result as Any,
+                result.correlationId
+            )
+        )
+        every {
+            CommandDispatcher.submitSilentReturningFuture(
+                match { commandClass.java.isInstance(it) }
+            )
+        } returns future
+    }
+
+    private fun enqueueCancellation(commandClass: KClass<out BaseCommand<*>>) {
+        every {
+            CommandDispatcher.submitSilentReturningFuture(
+                match { commandClass.java.isInstance(it) }
+            )
+        } throws CancellationException("cancelled")
+    }
+
+    private fun createContinuationState(): NativeAuthV2ContinuationState {
+        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
+            .single { it.parameterCount == 8 }
+        constructor.isAccessible = true
+        return constructor.newInstance(
+            "opaque-token",
+            emptyMap<String, String>(),
+            emptyMap<String, Map<String, String>>(),
+            listOf("scope"),
+            null,
+            correlationId,
+            NativeAuthV2LinkRelation.SIGN_IN.value,
+            NativeAuthV2FlowScenario.SIGN_IN
+        ) as NativeAuthV2ContinuationState
+    }
+
+    private companion object {
+        const val correlationId = "correlation-id"
+        val errorCodes = listOf(50126)
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -653,7 +653,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             NativeAuthV2SubmitMFAChallengeCommand::class
         )
         val wrongCode = verificationState.submitChallenge("000000") as MFASubmitChallengeErrorV2
-        assertTrue(wrongCode.isInvalidCode())
+        assertTrue(wrongCode.isInvalidChallenge())
         assertEquals("invalidOneTimeCode", wrongCode.subError)
 
         val refreshedContinuationState = createContinuationState(correlationId = "resend-correlation-id")
@@ -701,7 +701,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             ),
             NativeAuthV2SubmitMFAChallengeCommand::class
         )
-        assertTrue((verificationState.submitChallenge("111111") as MFASubmitChallengeErrorV2).isInvalidCode())
+        assertTrue((verificationState.submitChallenge("111111") as MFASubmitChallengeErrorV2).isInvalidChallenge())
     }
 
     @Test
@@ -710,7 +710,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
 
         val result = verificationState.submitChallenge("") as MFASubmitChallengeErrorV2
 
-        assertTrue(result.isInvalidCode())
+        assertTrue(result.isInvalidChallenge())
         assertEquals(ErrorTypes.INVALID_CODE, result.errorType)
     }
 
@@ -792,7 +792,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             }
         )
 
-        assertTrue((future.get(30, TimeUnit.SECONDS) as MFASubmitChallengeErrorV2).isInvalidCode())
+        assertTrue((future.get(30, TimeUnit.SECONDS) as MFASubmitChallengeErrorV2).isInvalidChallenge())
     }
 
     @Test

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -35,8 +35,10 @@ import com.microsoft.identity.common.java.controllers.CommandDispatcher
 import com.microsoft.identity.common.java.commands.BaseCommand
 import com.microsoft.identity.common.java.commands.ICommandResult
 import com.microsoft.identity.common.java.controllers.CommandResult
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId
 import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.logging.DiagnosticContext
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
@@ -44,6 +46,7 @@ import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.Nati
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
 import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResendCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignInStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitMFAChallengeCommand
@@ -542,23 +545,43 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             NativeAuthV2SubmitMFAChallengeCommand::class
         )
         val wrongCode = verificationState.submitChallenge("000000") as MFASubmitChallengeErrorV2
-        assertTrue(wrongCode.isInvalidChallenge())
+        assertTrue(wrongCode.isInvalidCode())
         assertEquals("invalidOneTimeCode", wrongCode.subError)
 
-        // The app requests a fresh challenge from the retained MFARequiredStateV2, not from a
-        // state carried on the error.
-        enqueueResult(
-            NativeAuthV2CommandResult.MFAVerificationRequired(
-                correlationId,
-                createContinuationState(),
-                6,
-                "u***@contoso.com",
-                "email"
-            ),
-            NativeAuthV2SelectMFAMethodCommand::class
+        val refreshedContinuationState = createContinuationState(correlationId = "resend-correlation-id")
+        val resendFuture = FinalizableResultFuture<CommandResult<Any>>()
+        resendFuture.setResult(
+            CommandResult(
+                ICommandResult.ResultStatus.COMPLETED,
+                NativeAuthV2CommandResult.CodeRequired(
+                    correlationId = "resend-correlation-id",
+                    continuationState = refreshedContinuationState,
+                    codeLength = 8,
+                    challengeTargetLabel = "n***@contoso.com",
+                    challengeChannel = "email"
+                ) as Any,
+                "resend-correlation-id"
+            )
         )
-        val fresh = mfaState.selectAuthMethod(mfaState.authMethods.single())
+        every {
+            CommandDispatcher.submitSilentReturningFuture(
+                match {
+                    it is NativeAuthV2ResendCodeCommand &&
+                        it.publicApiId == PublicApiId.NATIVE_AUTH_V2_SIGN_IN_RESEND_MFA_CHALLENGE &&
+                        (it.parameters as NativeAuthV2ResendCodeCommandParameters).continuationState === verificationState.continuationState
+                }
+            )
+        } returns resendFuture
+
+        val fresh = verificationState.resendChallenge()
         assertTrue(fresh is NativeAuthResultV2.MFAVerificationRequired)
+        fresh as NativeAuthResultV2.MFAVerificationRequired
+        assertEquals(8, fresh.codeLength)
+        assertEquals("n***@contoso.com", fresh.sentTo)
+        assertEquals("email", fresh.channel)
+        assertEquals("resend-correlation-id", fresh.nextState.correlationId)
+        assertTrue(fresh.nextState !== verificationState)
+        assertTrue(fresh.nextState.continuationState === refreshedContinuationState)
 
         // Retrying on the state instance the caller already holds also works.
         enqueueResult(
@@ -570,7 +593,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             ),
             NativeAuthV2SubmitMFAChallengeCommand::class
         )
-        assertTrue((verificationState.submitChallenge("111111") as MFASubmitChallengeErrorV2).isInvalidChallenge())
+        assertTrue((verificationState.submitChallenge("111111") as MFASubmitChallengeErrorV2).isInvalidCode())
     }
 
     @Test
@@ -579,7 +602,8 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
 
         val result = verificationState.submitChallenge("") as MFASubmitChallengeErrorV2
 
-        assertTrue(result.isInvalidChallenge())
+        assertTrue(result.isInvalidCode())
+        assertEquals(ErrorTypes.INVALID_CODE, result.errorType)
     }
 
     @Test
@@ -624,7 +648,6 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             ),
             NativeAuthV2SubmitMFAChallengeCommand::class
         )
-
         val future = ResultFuture<NativeAuthResultV2>()
         verificationState.submitChallenge(
             "000000",
@@ -635,7 +658,40 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             }
         )
 
-        assertTrue((future.get(30, TimeUnit.SECONDS) as MFASubmitChallengeErrorV2).isInvalidChallenge())
+        assertTrue((future.get(30, TimeUnit.SECONDS) as MFASubmitChallengeErrorV2).isInvalidCode())
+    }
+
+    @Test
+    fun resendChallengeCallbackDeliversARefreshedVerificationStateThroughOnResult() = runTest {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+        val refreshedContinuationState = createContinuationState(correlationId = "callback-resend-correlation-id")
+        enqueueResult(
+            NativeAuthV2CommandResult.CodeRequired(
+                correlationId = "callback-resend-correlation-id",
+                continuationState = refreshedContinuationState,
+                codeLength = 7,
+                challengeTargetLabel = "c***@contoso.com",
+                challengeChannel = "email"
+            ),
+            NativeAuthV2ResendCodeCommand::class
+        )
+
+        val future = ResultFuture<NativeAuthResultV2>()
+        verificationState.resendChallenge(
+            object : MFAVerificationRequiredStateV2.ResendChallengeCallback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) =
+                    future.setException(IllegalStateException("Expected callback.onResult", exception))
+            }
+        )
+
+        val result = future.get(30, TimeUnit.SECONDS)
+        assertTrue(result is NativeAuthResultV2.MFAVerificationRequired)
+        result as NativeAuthResultV2.MFAVerificationRequired
+        assertEquals(7, result.codeLength)
+        assertEquals("c***@contoso.com", result.sentTo)
+        assertEquals("email", result.channel)
+        assertTrue(result.nextState.continuationState === refreshedContinuationState)
     }
 
     // -----------------------------------------------------------------------------------------
@@ -762,7 +818,9 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
         } throws CancellationException("cancelled")
     }
 
-    private fun createContinuationState(): NativeAuthV2ContinuationState {
+    private fun createContinuationState(
+        correlationId: String = NativeAuthV2SignInTest.correlationId
+    ): NativeAuthV2ContinuationState {
         val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
             .single { it.parameterCount == 8 }
         constructor.isAccessible = true

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -618,22 +618,23 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
     }
 
     @Test
-    fun selectAuthMethodMapsBlockedMethod() = runTest {
+    fun selectAuthMethodMapsApiError() = runTest {
         val state = mfaRequiredState()
         enqueueResult(
-            NativeAuthV2CommandResult.AuthMethodBlocked(
-                correlationId,
-                "accessDenied",
-                "blocked",
-                "providerBlockedByRep",
-                errorCodes
+            INativeAuthCommandResult.APIError(
+                error = "accessDenied",
+                errorDescription = "blocked",
+                correlationId = correlationId,
+                errorCodes = errorCodes
             ),
             NativeAuthV2SelectMFAMethodCommand::class
         )
 
         val result = state.selectAuthMethod(state.authMethods.single()) as MFARequestChallengeErrorV2
 
-        assertTrue(result.isAuthMethodBlocked())
+        assertFalse(result.isAuthMethodBlocked())
+        assertEquals("accessDenied", result.error)
+        assertEquals("blocked", result.errorMessage)
         assertEquals(errorCodes, result.errorCodes)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -39,6 +39,8 @@ import com.microsoft.identity.common.java.eststelemetry.PublicApiId
 import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.logging.DiagnosticContext
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitPasswordCommandParameters
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.SignInV2StartCommandParameters
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
@@ -80,6 +82,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotSame
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -91,6 +94,7 @@ import org.robolectric.annotation.Config
 import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Parity coverage for Native Auth V2 sign-in: password first factor and password followed by email
@@ -228,7 +232,8 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
     }
 
     @Test
-    fun signInV2ClearsTheCallersPasswordCopyAndLeavesTheOriginalIntact() = runTest {
+    fun signInV2ClearsTheOwnedPasswordCopyOnCompletionAndCancellationWhileLeavingTheCallersBufferIntact() = runTest(timeout = 60.seconds) {
+        var capturedOnCompletion: CharArray? = null
         enqueueResult(
             NativeAuthV2CommandResult.InvalidCredentials(
                 correlationId,
@@ -237,14 +242,64 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
                 "invalidUserNameOrPassword"
             ),
             NativeAuthV2SignInStartCommand::class
-        )
+        ) { command ->
+            capturedOnCompletion = (command.parameters as SignInV2StartCommandParameters).password
+        }
 
         val callerPassword = "Password123!".toCharArray()
         application.signInV2(signInParameters(password = callerPassword))
 
-        // signInV2 copies the buffer, so the caller's own array is untouched while the copy handed
-        // to Common is cleared. A password is never stored in a state or continuation state.
+        // The command must have received a distinct, owned copy -- never the caller's own array.
+        assertNotSame(callerPassword, capturedOnCompletion)
         assertEquals("Password123!", String(callerPassword))
+        assertPasswordCleared(capturedOnCompletion!!)
+
+        var capturedOnCancellation: CharArray? = null
+        enqueueCancellation(NativeAuthV2SignInStartCommand::class) { command ->
+            capturedOnCancellation = (command.parameters as SignInV2StartCommandParameters).password
+        }
+        val secondCallerPassword = "Password123!".toCharArray()
+        try {
+            application.signInV2(signInParameters(password = secondCallerPassword))
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+
+        // The owned copy must be cleared even when the command is cancelled, while the caller's
+        // own buffer -- which it never handed over -- remains untouched.
+        assertEquals("Password123!", String(secondCallerPassword))
+        assertPasswordCleared(capturedOnCancellation!!)
+    }
+
+    @Test
+    fun signInV2CallbackSnapshotsThePasswordSynchronouslyBeforeLaunch() = runTest {
+        var capturedPassword: CharArray? = null
+        enqueueResult(
+            NativeAuthV2CommandResult.PasswordRequired(correlationId, createContinuationState()),
+            NativeAuthV2SignInStartCommand::class
+        ) { command ->
+            capturedPassword = (command.parameters as SignInV2StartCommandParameters).password?.copyOf()
+        }
+
+        val callerPassword = "Password123!".toCharArray()
+        val future = ResultFuture<NativeAuthResultV2>()
+        application.signInV2(
+            signInParameters(password = callerPassword),
+            object : NativeAuthPublicClientApplication.NativeAuthV2Callback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) = future.setException(exception)
+            }
+        )
+        // Mutate the caller's own buffer immediately after the call returns, before the launched
+        // coroutine has necessarily had a chance to run. If the snapshot were taken lazily (inside
+        // the coroutine body, as opposed to synchronously before launch), this mutation could race
+        // with -- and change -- what actually gets submitted to Common.
+        callerPassword.fill('X')
+
+        future.get(10, TimeUnit.SECONDS)
+
+        assertEquals("Password123!", String(capturedPassword!!))
     }
 
     @Test
@@ -360,17 +415,70 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
     }
 
     @Test
-    fun submitPasswordClearsItsOwnCopyAndLeavesTheCallersBufferIntact() = runTest {
+    fun submitPasswordClearsTheOwnedPasswordCopyOnCompletionAndCancellationWhileLeavingTheCallersBufferIntact() = runTest(timeout = 60.seconds) {
         val state = passwordRequiredState()
+        var capturedOnCompletion: CharArray? = null
         enqueueResult(
             INativeAuthCommandResult.Redirect(correlationId, "browser"),
             NativeAuthV2SubmitPasswordCommand::class
-        )
+        ) { command ->
+            capturedOnCompletion = (command.parameters as NativeAuthV2SubmitPasswordCommandParameters).password
+        }
 
         val callerPassword = "Password123!".toCharArray()
         state.submitPassword(callerPassword)
 
+        // The command must have received a distinct, owned copy -- never the caller's own array.
+        assertNotSame(callerPassword, capturedOnCompletion)
         assertEquals("Password123!", String(callerPassword))
+        assertPasswordCleared(capturedOnCompletion!!)
+
+        var capturedOnCancellation: CharArray? = null
+        enqueueCancellation(NativeAuthV2SubmitPasswordCommand::class) { command ->
+            capturedOnCancellation = (command.parameters as NativeAuthV2SubmitPasswordCommandParameters).password
+        }
+        val secondCallerPassword = "Password123!".toCharArray()
+        try {
+            state.submitPassword(secondCallerPassword)
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected.
+        }
+
+        // The owned copy must be cleared even when the command is cancelled, while the caller's
+        // own buffer -- which it never handed over -- remains untouched.
+        assertEquals("Password123!", String(secondCallerPassword))
+        assertPasswordCleared(capturedOnCancellation!!)
+    }
+
+    @Test
+    fun submitPasswordCallbackSnapshotsThePasswordSynchronouslyBeforeLaunch() = runTest {
+        val state = passwordRequiredState()
+        var capturedPassword: CharArray? = null
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2SubmitPasswordCommand::class
+        ) { command ->
+            capturedPassword = (command.parameters as NativeAuthV2SubmitPasswordCommandParameters).password.copyOf()
+        }
+
+        val callerPassword = "Password123!".toCharArray()
+        val future = ResultFuture<NativeAuthResultV2>()
+        state.submitPassword(
+            callerPassword,
+            object : PasswordRequiredStateV2.SubmitPasswordCallback {
+                override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                override fun onError(exception: BaseException) = future.setException(exception)
+            }
+        )
+        // Mutate the caller's own buffer immediately after the call returns, before the launched
+        // coroutine has necessarily had a chance to run, for the same reason as the signInV2
+        // callback variant above.
+        callerPassword.fill('X')
+
+        future.get(10, TimeUnit.SECONDS)
+
+        assertEquals("Password123!", String(capturedPassword!!))
     }
 
     @Test
@@ -624,6 +732,32 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
     }
 
     @Test
+    fun signInCompletionWithoutAuthenticationResultUsesScenarioNeutralDiagnostic() = runTest {
+        val expectedMessage =
+            "Native Auth V2 flow completed but no authentication result was returned."
+
+        val passwordState = passwordRequiredState()
+        enqueueResult(
+            NativeAuthV2CommandResult.Complete(correlationId, null, null, null),
+            NativeAuthV2SubmitPasswordCommand::class
+        )
+        assertEquals(
+            expectedMessage,
+            (passwordState.submitPassword("Password123!".toCharArray()) as NativeAuthErrorV2).errorMessage
+        )
+
+        val verificationState = mfaVerificationState(mfaRequiredState())
+        enqueueResult(
+            NativeAuthV2CommandResult.Complete(correlationId, null, null, null),
+            NativeAuthV2SubmitMFAChallengeCommand::class
+        )
+        assertEquals(
+            expectedMessage,
+            (verificationState.submitChallenge("123456") as NativeAuthErrorV2).errorMessage
+        )
+    }
+
+    @Test
     fun submitChallengePropagatesCancellation() = runTest {
         val verificationState = mfaVerificationState(mfaRequiredState())
         enqueueCancellation(NativeAuthV2SubmitMFAChallengeCommand::class)
@@ -692,6 +826,38 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
         assertEquals("c***@contoso.com", result.sentTo)
         assertEquals("email", result.channel)
         assertTrue(result.nextState.continuationState === refreshedContinuationState)
+    }
+
+    @Test
+    fun resendChallengeMapsNotImplementedRedirectAndApiErrorThenPropagatesCancellation() = runTest(timeout = 60.seconds) {
+        val verificationState = mfaVerificationState(mfaRequiredState())
+
+        enqueueResult(
+            INativeAuthCommandResult.Redirect(correlationId, "browser"),
+            NativeAuthV2ResendCodeCommand::class
+        )
+        assertTrue((verificationState.resendChallenge() as NativeAuthErrorV2).isBrowserRequired())
+
+        enqueueResult(
+            NativeAuthV2CommandResult.NotImplemented(correlationId, "not_implemented", "nope"),
+            NativeAuthV2ResendCodeCommand::class
+        )
+        assertTrue((verificationState.resendChallenge() as NativeAuthErrorV2).isNotImplemented())
+
+        enqueueResult(
+            INativeAuthCommandResult.APIError("api_error", "API failed", correlationId = correlationId, errorCodes = errorCodes),
+            NativeAuthV2ResendCodeCommand::class
+        )
+        val apiError = verificationState.resendChallenge() as NativeAuthErrorV2
+        assertEquals(errorCodes, apiError.errorCodes)
+
+        enqueueCancellation(NativeAuthV2ResendCodeCommand::class)
+        try {
+            verificationState.resendChallenge()
+            fail("Expected CancellationException")
+        } catch (_: CancellationException) {
+            // Expected: cancellation is not an authentication failure.
+        }
     }
 
     // -----------------------------------------------------------------------------------------
@@ -791,9 +957,14 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
         }
     }
 
+    private fun assertPasswordCleared(password: CharArray) {
+        password.forEach { assertEquals('\u0000', it) }
+    }
+
     private fun enqueueResult(
         result: INativeAuthCommandResult,
-        commandClass: KClass<out BaseCommand<*>>
+        commandClass: KClass<out BaseCommand<*>>,
+        onCommand: (BaseCommand<*>) -> Unit = {}
     ) {
         val future = FinalizableResultFuture<CommandResult<Any>>()
         future.setResult(
@@ -807,15 +978,24 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
             CommandDispatcher.submitSilentReturningFuture(
                 match { commandClass.java.isInstance(it) }
             )
-        } returns future
+        } answers {
+            onCommand(firstArg())
+            future
+        }
     }
 
-    private fun enqueueCancellation(commandClass: KClass<out BaseCommand<*>>) {
+    private fun enqueueCancellation(
+        commandClass: KClass<out BaseCommand<*>>,
+        onCommand: (BaseCommand<*>) -> Unit = {}
+    ) {
         every {
             CommandDispatcher.submitSilentReturningFuture(
                 match { commandClass.java.isInstance(it) }
             )
-        } throws CancellationException("cancelled")
+        } answers {
+            onCommand(firstArg())
+            throw CancellationException("cancelled")
+        }
     }
 
     private fun createContinuationState(

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -45,8 +45,6 @@ import com.microsoft.identity.common.java.nativeauth.controllers.results.INative
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
-import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
-import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResendCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand
@@ -996,21 +994,7 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
 
     private fun createContinuationState(
         correlationId: String = NativeAuthV2SignInTest.correlationId
-    ): NativeAuthV2ContinuationState {
-        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 8 }
-        constructor.isAccessible = true
-        return constructor.newInstance(
-            "opaque-token",
-            emptyMap<String, String>(),
-            emptyMap<String, Map<String, String>>(),
-            listOf("scope"),
-            null,
-            correlationId,
-            NativeAuthV2LinkRelation.SIGN_IN.value,
-            NativeAuthV2FlowScenario.SIGN_IN
-        ) as NativeAuthV2ContinuationState
-    }
+    ): NativeAuthV2ContinuationState = newContinuationState(correlationId)
 
     private companion object {
         const val correlationId = "correlation-id"

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -397,11 +397,6 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
         assertTrue(result is SubmitPasswordErrorV2)
         result as SubmitPasswordErrorV2
         assertTrue(result.isInvalidPassword())
-        @Suppress("DEPRECATION")
-        assertFalse(
-            "A deferred password rejection must not be classified as invalid credentials",
-            result.isInvalidCredentials()
-        )
         assertEquals(errorCodes, result.errorCodes)
     }
 

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -158,11 +158,12 @@ class NativeAuthV2StatesTest {
 
     private fun createContinuationState(): NativeAuthV2ContinuationState {
         val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 7 }
+            .single { it.parameterCount == 8 }
         constructor.isAccessible = true
         return constructor.newInstance(
             "opaque-token",
             emptyMap<String, String>(),
+            emptyMap<String, Map<String, String>>(),
             listOf("scope"),
             null,
             correlationId,
@@ -230,8 +231,8 @@ class NativeAuthV2StatesTest {
     }
 
     @Test
-    fun testPasswordRequiredStateCallbackReturnsNotImplemented() {
-        assertCallbackNotImplemented { future ->
+    fun testPasswordRequiredStateCallbackReturnsInvalidState() {
+        assertCallbackInvalidState { future ->
             PasswordRequiredStateV2(continuationToken, correlationId, scenario, config).submitPassword(
                 "password".toCharArray(),
                 object : PasswordRequiredStateV2.SubmitPasswordCallback {
@@ -284,9 +285,9 @@ class NativeAuthV2StatesTest {
     }
 
     @Test
-    fun testMFARequiredStateCallbackReturnsNotImplemented() {
+    fun testMFARequiredStateCallbackReturnsInvalidState() {
         val authMethod = AuthMethod("id", "oob", null, "email")
-        assertCallbackNotImplemented { future ->
+        assertCallbackInvalidState { future ->
             MFARequiredStateV2(continuationToken, correlationId, scenario, config).selectAuthMethod(
                 authMethod,
                 callback = object : MFARequiredStateV2.SelectAuthMethodCallback {
@@ -298,8 +299,8 @@ class NativeAuthV2StatesTest {
     }
 
     @Test
-    fun testMFAVerificationRequiredStateCallbackReturnsNotImplemented() {
-        assertCallbackNotImplemented { future ->
+    fun testMFAVerificationRequiredStateCallbackReturnsInvalidState() {
+        assertCallbackInvalidState { future ->
             MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config).submitChallenge(
                 "challenge",
                 object : MFAVerificationRequiredStateV2.SubmitChallengeCallback {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -309,6 +309,14 @@ class NativeAuthV2StatesTest {
                 }
             )
         }
+        assertCallbackInvalidState { future ->
+            MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config).resendChallenge(
+                object : MFAVerificationRequiredStateV2.ResendChallengeCallback {
+                    override fun onResult(result: NativeAuthResultV2) = future.setResult(result)
+                    override fun onError(exception: BaseException) = future.setException(exception)
+                }
+            )
+        }
     }
 
     @Test
@@ -409,6 +417,14 @@ class NativeAuthV2StatesTest {
             MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config).submitChallenge(
                 "challenge",
                 object : MFAVerificationRequiredStateV2.SubmitChallengeCallback {
+                    override fun onResult(result: NativeAuthResultV2): Unit = throw thrown
+                    override fun onError(exception: BaseException) = future.setException(exception)
+                }
+            )
+        }
+        assertCallbackRoutesToOnError { future, thrown ->
+            MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config).resendChallenge(
+                object : MFAVerificationRequiredStateV2.ResendChallengeCallback {
                     override fun onResult(result: NativeAuthResultV2): Unit = throw thrown
                     override fun onError(exception: BaseException) = future.setException(exception)
                 }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import java.lang.reflect.Constructor
 
 /**
  * Unit tests for the Native Auth V2 states, covering Parcelable serialization and the
@@ -156,21 +157,8 @@ class NativeAuthV2StatesTest {
         }
     }
 
-    private fun createContinuationState(): NativeAuthV2ContinuationState {
-        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 8 }
-        constructor.isAccessible = true
-        return constructor.newInstance(
-            "opaque-token",
-            emptyMap<String, String>(),
-            emptyMap<String, Map<String, String>>(),
-            listOf("scope"),
-            null,
-            correlationId,
-            NativeAuthV2LinkRelation.RESET_PASSWORD.value,
-            NativeAuthV2FlowScenario.RESET_PASSWORD
-        ) as NativeAuthV2ContinuationState
-    }
+    private fun createContinuationState(): NativeAuthV2ContinuationState =
+        newContinuationState(correlationId)
 
     private fun assertCallbackNotImplemented(action: (ResultFuture<NativeAuthResultV2>) -> Unit) {
         val future = ResultFuture<NativeAuthResultV2>()
@@ -471,4 +459,63 @@ class NativeAuthV2StatesTest {
             )
         }
     }
+}
+
+/**
+ * The synthetic marker Kotlin appends to the extra constructor it generates for a class that takes
+ * a value class parameter.
+ */
+private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConstructorMarker"
+
+/**
+ * Builds a real [NativeAuthV2ContinuationState] for the tests in this package.
+ *
+ * common4j keeps the constructor private and its factories internal, so the state has to be built
+ * reflectively, and a mock will not do because callers parcel it and assert on the restored values.
+ *
+ * The lookup binds to the widest real constructor and derives the argument list from its shape
+ * rather than pinning a single arity. common4j keeps adding fields to this state as Native Auth V2
+ * grows, and a hard-coded arity turns each of those additions into a mass failure here even though
+ * no MSAL production code constructs the type. Constructors taking a `DefaultConstructorMarker` are
+ * skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to the
+ * real constructor.
+ */
+internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
+    val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors
+        .filterNot { candidate ->
+            candidate.parameterTypes.any { it.name == DEFAULT_CONSTRUCTOR_MARKER }
+        }
+        .maxByOrNull { it.parameterCount }
+        ?: error("NativeAuthV2ContinuationState declares no usable constructor")
+    constructor.isAccessible = true
+
+    val continuationToken = "opaque-token"
+    val links = emptyMap<String, String>()
+    val methodLinks = emptyMap<String, Map<String, String>>()
+    val scopes = listOf("scope")
+    val claimsRequestJson: String? = null
+    // Value classes are erased to their underlying type, so reflection needs the raw String here.
+    val entryRelation = NativeAuthV2LinkRelation.RESET_PASSWORD.value
+    val scenario = NativeAuthV2FlowScenario.RESET_PASSWORD
+    val authenticationFactor: String? = null
+
+    val arguments: Array<Any?> = when (constructor.parameterCount) {
+        7 -> arrayOf(
+            continuationToken, links, scopes, claimsRequestJson, correlationId, entryRelation,
+            scenario
+        )
+        8 -> arrayOf(
+            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
+            entryRelation, scenario
+        )
+        9 -> arrayOf(
+            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
+            entryRelation, scenario, authenticationFactor
+        )
+        else -> error(
+            "Unrecognised NativeAuthV2ContinuationState constructor, update this helper: $constructor"
+        )
+    }
+
+    return constructor.newInstance(*arguments) as NativeAuthV2ContinuationState
 }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -299,6 +299,27 @@ class NativeAuthV2StatesTest {
     }
 
     @Test
+    fun testMFARequiredStateDefensivelyCopiesAuthMethods() {
+        val source = mutableListOf(AuthMethod("id", "oob", null, "email"))
+        val state = MFARequiredStateV2(
+            continuationToken,
+            correlationId,
+            scenario,
+            config,
+            authMethods = source
+        )
+
+        source.clear()
+        assertEquals(1, state.authMethods.size)
+        try {
+            (state.authMethods as MutableList<AuthMethod>).clear()
+            fail("Expected authMethods to be unmodifiable")
+        } catch (_: UnsupportedOperationException) {
+            // Expected.
+        }
+    }
+
+    @Test
     fun testMFAVerificationRequiredStateCallbackReturnsInvalidState() {
         assertCallbackInvalidState { future ->
             MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config).submitChallenge(

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -468,17 +468,9 @@ class NativeAuthV2StatesTest {
 private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConstructorMarker"
 
 /**
- * Builds a real [NativeAuthV2ContinuationState] for the tests in this package.
+ * Builds a real [NativeAuthV2ContinuationState] for parcel tests using its private constructor.
  *
- * common4j keeps the constructor private and its factories internal, so the state has to be built
- * reflectively, and a mock will not do because callers parcel it and assert on the restored values.
- *
- * The lookup binds to the widest real constructor and derives the argument list from its shape
- * rather than pinning a single arity. common4j keeps adding fields to this state as Native Auth V2
- * grows, and a hard-coded arity turns each of those additions into a mass failure here even though
- * no MSAL production code constructs the type. Constructors taking a `DefaultConstructorMarker` are
- * skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to the
- * real constructor.
+ * Supports the transitional 7/9-parameter shapes and skips Kotlin's synthetic value-class overload.
  */
 internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
     val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors
@@ -503,10 +495,6 @@ internal fun newContinuationState(correlationId: String): NativeAuthV2Continuati
         7 -> arrayOf(
             continuationToken, links, scopes, claimsRequestJson, correlationId, entryRelation,
             scenario
-        )
-        8 -> arrayOf(
-            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
-            entryRelation, scenario
         )
         9 -> arrayOf(
             continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,


### PR DESCRIPTION
## Summary

Implements Native Auth V2 sign-in in MSAL for password first-factor flows and password followed by email OTP MFA, aligned with the current iOS V2 service contract.

## Supported flows

- Username with password supplied at `signInV2` entry
- Username followed by deferred password submission through `PasswordRequiredStateV2`
- Password followed by explicit email OTP MFA method selection and OTP verification
- Invalid MFA code recovery by requesting a fresh challenge
- Authorization-code exchange, token caching, requested scopes/claims, correlation IDs, browser-required results, Kotlin suspend APIs, and Java callbacks

## Behavior and error handling

- Entry-supplied wrong password maps to `SignInErrorV2.isInvalidCredentials()`.
- Deferred wrong password maps to `SubmitPasswordErrorV2.isInvalidPassword()`.
- Recoverable failures return result values without embedding a next state; callers retry using the retained state.
- Missing or invalid continuation state maps to `INVALID_STATE`.
- Unsupported MFA channels map to `NOT_IMPLEMENTED`.
- Preserves Android V1 account-cache behavior by rejecting `signInV2` while an account is already signed in.
- Password buffers are copied and cleared in `finally`; passwords are not retained in Parcelable or continuation state.

## Scope exclusions

- Email OTP as the first factor
- SMS OTP, passkeys, sign-up, JIT/strong-auth registration, and silent-refresh changes
- MFA returned only from the final token exchange
- Repeated same-account or switch-account sign-in

## Validation

- MSAL V2 unit suites: **85 tests passed, 0 failures**, including 26 new sign-in scenarios.
- Full MSAL unit-suite comparison against `dev`: **no new failures**. Remaining failures in both runs are confined to existing network tests that require the CI mock-API endpoint.
- Common V2 suites: **245 tests passed, 0 failures**.
- Common full `:common4j:test`: **1,757 tests passed, 0 failures**.
- `:common4j:spotbugsMain`: **0 violations**.

## E2E coverage

Adds eight public-API E2E scenarios in `SignInV2EmailPasswordTest`. They compile but remain `@Ignore`-gated because the V2 authorize-challenge sign-in endpoints are not available on the current test slice and the secure lab configuration is only available in CI. The tests can be enabled unchanged when a V2-capable slice is available.

Fixes [AB#3729067](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3729067)