### PR TITLE
Fixes AB#3746140 Upgrade Apache HttpCore to 5.4.3 for CVE-2026-54399

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,7 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
-- [PATCH] Consume Apache HttpCore 5.4.3 from Common to address CVE-2026-54399 (AB#3746140)
+- [PATCH] Upgrade Apache HttpCore to 5.4.3 to address CVE-2026-54399 (AB#3746140) (#2566)
 - [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9 (#2561)
 - [MINOR] Added v2 private preview interfaces
 

--- a/changelog
+++ b/changelog
@@ -2,6 +2,7 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+- [PATCH] Consume Apache HttpCore 5.4.3 from Common to address CVE-2026-54399 (AB#3746140)
 - [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9 (#2561)
 - [MINOR] Added v2 private preview interfaces
 

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,6 +30,7 @@ ext {
     dexmakerMockitoVersion = "2.19.0"
     espressoCoreVersion = "3.1.0"
     gsonVersion = "2.8.9"
+    httpCore5Version = "5.4.3"
     junitVersion = "4.13.2"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -292,6 +292,7 @@ dependencies {
     implementation ("com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion") {
         exclude module: 'asm'
     }
+    implementation "org.apache.httpcomponents.core5:httpcore5:$rootProject.ext.httpCore5Version"
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.ext.kotlinXCoroutinesVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.ext.kotlinXCoroutinesVersion"

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -292,7 +292,6 @@ dependencies {
     implementation ("com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion") {
         exclude module: 'asm'
     }
-    implementation 'org.apache.httpcomponents.core5:httpcore5:5.3'
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.ext.kotlinXCoroutinesVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.ext.kotlinXCoroutinesVersion"


### PR DESCRIPTION
Fixes [AB#3746140](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3746140)

## Summary

- upgrade MSAL's direct Apache HttpCore dependency from 5.3 to 5.4.3
- centralize the version in `gradle/versions.gradle`
- update the changelog

## Security

Addresses CVE-2026-54399, an uncontrolled resource consumption vulnerability in the HTTP/1.1 message parser.

## Validation

- confirmed `:msal:localDebugRuntimeClasspath` resolves `httpcore5:5.4.3`
- confirmed Common's transitive 5.3 request is upgraded to MSAL's direct 5.4.3 version
- full Android build is blocked locally by HTTP 401 responses from the NewAndroid package feed

Fixes [AB#3746140](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3746140)
