### PR TITLE
Temporarily support current and incoming common4j continuation-state constructors in MSAL tests, Fixes AB#3749428

### DIFF
--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -41,8 +41,6 @@ import com.microsoft.identity.common.java.logging.DiagnosticContext
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
-import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
-import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult
 import com.microsoft.identity.common.java.util.ResultFuture
@@ -837,20 +835,8 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         } returns future
     }
 
-    private fun createContinuationState(): NativeAuthV2ContinuationState {
-        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 7 }
-        constructor.isAccessible = true
-        return constructor.newInstance(
-            "opaque-token",
-            emptyMap<String, String>(),
-            listOf("scope"),
-            null,
-            correlationId,
-            NativeAuthV2LinkRelation.RESET_PASSWORD.value,
-            NativeAuthV2FlowScenario.RESET_PASSWORD
-        ) as NativeAuthV2ContinuationState
-    }
+    private fun createContinuationState(): NativeAuthV2ContinuationState =
+        newContinuationState(correlationId)
 
     @Suppress("unused")
     private fun exhaustiveWhen(result: NativeAuthResultV2): String = when (result) {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -59,6 +59,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
+import java.lang.reflect.Constructor
 
 /**
  * Unit tests for the Native Auth V2 states, covering Parcelable serialization and the
@@ -156,20 +157,8 @@ class NativeAuthV2StatesTest {
         }
     }
 
-    private fun createContinuationState(): NativeAuthV2ContinuationState {
-        val constructor = NativeAuthV2ContinuationState::class.java.declaredConstructors
-            .single { it.parameterCount == 7 }
-        constructor.isAccessible = true
-        return constructor.newInstance(
-            "opaque-token",
-            emptyMap<String, String>(),
-            listOf("scope"),
-            null,
-            correlationId,
-            NativeAuthV2LinkRelation.RESET_PASSWORD.value,
-            NativeAuthV2FlowScenario.RESET_PASSWORD
-        ) as NativeAuthV2ContinuationState
-    }
+    private fun createContinuationState(): NativeAuthV2ContinuationState =
+        newContinuationState(correlationId)
 
     private fun assertCallbackNotImplemented(action: (ResultFuture<NativeAuthResultV2>) -> Unit) {
         val future = ResultFuture<NativeAuthResultV2>()
@@ -433,4 +422,63 @@ class NativeAuthV2StatesTest {
             )
         }
     }
+}
+
+/**
+ * The synthetic marker Kotlin appends to the extra constructor it generates for a class that takes
+ * a value class parameter.
+ */
+private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConstructorMarker"
+
+/**
+ * Builds a real [NativeAuthV2ContinuationState] for the tests in this package.
+ *
+ * common4j keeps the constructor private and its factories internal, so the state has to be built
+ * reflectively, and a mock will not do because callers parcel it and assert on the restored values.
+ *
+ * The lookup binds to the widest real constructor and derives the argument list from its shape
+ * rather than pinning a single arity. common4j keeps adding fields to this state as Native Auth V2
+ * grows, and a hard-coded arity turns each of those additions into a mass failure here even though
+ * no MSAL production code constructs the type. Constructors taking a `DefaultConstructorMarker` are
+ * skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to the
+ * real constructor.
+ */
+internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
+    val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors
+        .filterNot { candidate ->
+            candidate.parameterTypes.any { it.name == DEFAULT_CONSTRUCTOR_MARKER }
+        }
+        .maxByOrNull { it.parameterCount }
+        ?: error("NativeAuthV2ContinuationState declares no usable constructor")
+    constructor.isAccessible = true
+
+    val continuationToken = "opaque-token"
+    val links = emptyMap<String, String>()
+    val methodLinks = emptyMap<String, Map<String, String>>()
+    val scopes = listOf("scope")
+    val claimsRequestJson: String? = null
+    // Value classes are erased to their underlying type, so reflection needs the raw String here.
+    val entryRelation = NativeAuthV2LinkRelation.RESET_PASSWORD.value
+    val scenario = NativeAuthV2FlowScenario.RESET_PASSWORD
+    val authenticationFactor: String? = null
+
+    val arguments: Array<Any?> = when (constructor.parameterCount) {
+        7 -> arrayOf(
+            continuationToken, links, scopes, claimsRequestJson, correlationId, entryRelation,
+            scenario
+        )
+        8 -> arrayOf(
+            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
+            entryRelation, scenario
+        )
+        9 -> arrayOf(
+            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
+            entryRelation, scenario, authenticationFactor
+        )
+        else -> error(
+            "Unrecognised NativeAuthV2ContinuationState constructor, update this helper: $constructor"
+        )
+    }
+
+    return constructor.newInstance(*arguments) as NativeAuthV2ContinuationState
 }

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -436,12 +436,10 @@ private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConst
  * common4j keeps the constructor private and its factories internal, so the state has to be built
  * reflectively, and a mock will not do because callers parcel it and assert on the restored values.
  *
- * The lookup binds to the widest real constructor and derives the argument list from its shape
- * rather than pinning a single arity. common4j keeps adding fields to this state as Native Auth V2
- * grows, and a hard-coded arity turns each of those additions into a mass failure here even though
- * no MSAL production code constructs the type. Constructors taking a `DefaultConstructorMarker` are
- * skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to the
- * real constructor.
+ * The lookup binds to the widest real constructor and supports the current common4j shape plus the
+ * incoming shape needed by consumer validation. Constructors taking a `DefaultConstructorMarker`
+ * are skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to
+ * the real constructor.
  */
 internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
     val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors
@@ -466,10 +464,6 @@ internal fun newContinuationState(correlationId: String): NativeAuthV2Continuati
         7 -> arrayOf(
             continuationToken, links, scopes, claimsRequestJson, correlationId, entryRelation,
             scenario
-        )
-        8 -> arrayOf(
-            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
-            entryRelation, scenario
         )
         9 -> arrayOf(
             continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -431,15 +431,9 @@ class NativeAuthV2StatesTest {
 private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConstructorMarker"
 
 /**
- * Builds a real [NativeAuthV2ContinuationState] for the tests in this package.
+ * Builds a real [NativeAuthV2ContinuationState] for parcel tests using its private constructor.
  *
- * common4j keeps the constructor private and its factories internal, so the state has to be built
- * reflectively, and a mock will not do because callers parcel it and assert on the restored values.
- *
- * The lookup binds to the widest real constructor and supports the current common4j shape plus the
- * incoming shape needed by consumer validation. Constructors taking a `DefaultConstructorMarker`
- * are skipped: `entryRelation` is a value class, so the compiler emits a synthetic overload next to
- * the real constructor.
+ * Supports the transitional 7/9-parameter shapes and skips Kotlin's synthetic value-class overload.
  */
 internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
     val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors


### PR DESCRIPTION
### Summary

MSAL Native Auth V2 tests construct `NativeAuthV2ContinuationState` reflectively because common4j keeps its constructor private. The tests selected a constructor with exactly seven parameters, so common4j PR 3239— which expands it to nine parameters—causes 27 unrelated MSAL test failures in the **Assemble consumers (Validate MSAL)** stage.

This change replaces the duplicated reflection code with one shared test helper that:

- skips Kotlin's synthetic `DefaultConstructorMarker` constructor;
- supports only the current 7-parameter shape and the incoming 9-parameter shape required by common4j consumer validation;
- fails once with a clear error for an unknown future shape instead of producing widespread `NoSuchElementException` failures.

The helper remains test-only. MSAL still treats the continuation state as an opaque common4j-owned object and only verifies that it survives Parcelable transport with its public correlation ID and scopes intact.

### Verification

`msal:testLocalDebugUnitTest` for both affected classes: **32 passed, 0 failed** against:

- currently pinned common4j (`a809870a3`);
- common4j PR 3239 (`e5fd150e0`).

This unblocks common4j 3239 without adding a compatibility constructor to production code. Future constructor shapes still require an explicit helper update, by design, to avoid silently supplying unsafe defaults.


### TODO

Replace this temporary 7/9-parameter compatibility helper with a stable common4j test-fixture factory, then remove constructor reflection from MSAL. Tracked by [AB#3749428](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3749428).


