### PR TITLE
Fixes AB#3746140 Inline HttpCore dependency version

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -30,7 +30,6 @@ ext {
     dexmakerMockitoVersion = "2.19.0"
     espressoCoreVersion = "3.1.0"
     gsonVersion = "2.8.9"
-    httpCore5Version = "5.4.3"
     junitVersion = "4.13.2"
     legacySupportV4Version = "1.0.0"
     localBroadcastManagerVersion = "1.0.0"

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -292,7 +292,7 @@ dependencies {
     implementation ("com.nimbusds:nimbus-jose-jwt:$rootProject.ext.nimbusVersion") {
         exclude module: 'asm'
     }
-    implementation "org.apache.httpcomponents.core5:httpcore5:$rootProject.ext.httpCore5Version"
+    implementation 'org.apache.httpcomponents.core5:httpcore5:5.4.3'
     implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayoutVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$rootProject.ext.kotlinXCoroutinesVersion"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$rootProject.ext.kotlinXCoroutinesVersion"


### PR DESCRIPTION
Fixes [AB#3746140](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3746140) Inline HttpCore dependency version

Moving the dependency update to be inline to avoid build issues.