### PR TITLE
Use common4j continuation-state test fixture, Fixes AB#3749428

### DIFF
--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          result=$(printf '%s\n' "$PR_BODY" | grep -oP '(?<=AB#)\d+' | head -n 1)
+          result=$(echo "$PR_BODY" | grep -oP '(?<=#)\d+')
           echo "id=${result}" >> "$GITHUB_OUTPUT"
 
   # Get Pull request ID

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          result=$(echo "$PR_BODY" | grep -oP '(?<=#)\d+')
+          result=$(printf '%s\n' "$PR_BODY" | grep -oP '(?<=AB#)\d+' | head -n 1)
           echo "id=${result}" >> "$GITHUB_OUTPUT"
 
   # Get Pull request ID

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -41,6 +41,7 @@ import com.microsoft.identity.common.java.logging.DiagnosticContext
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationStateTestFactory
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
 import com.microsoft.identity.common.java.result.ILocalAuthenticationResult
 import com.microsoft.identity.common.java.util.ResultFuture
@@ -830,7 +831,7 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
     }
 
     private fun createContinuationState(): NativeAuthV2ContinuationState =
-        newContinuationState(correlationId)
+        NativeAuthV2ContinuationStateTestFactory.create(correlationId)
 
     @Suppress("unused")
     private fun exhaustiveWhen(result: NativeAuthResultV2): String = when (result) {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2SignInTest.kt
@@ -45,6 +45,7 @@ import com.microsoft.identity.common.java.nativeauth.controllers.results.INative
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationStateTestFactory
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResendCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectMFAMethodCommand
@@ -994,7 +995,8 @@ class NativeAuthV2SignInTest : PublicClientApplicationAbstractTest() {
 
     private fun createContinuationState(
         correlationId: String = NativeAuthV2SignInTest.correlationId
-    ): NativeAuthV2ContinuationState = newContinuationState(correlationId)
+    ): NativeAuthV2ContinuationState =
+        NativeAuthV2ContinuationStateTestFactory.create(correlationId)
 
     private companion object {
         const val correlationId = "correlation-id"

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -28,8 +28,7 @@ import com.microsoft.identity.client.exception.MsalClientException
 import com.microsoft.identity.client.exception.MsalException
 import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
-import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2LinkRelation
-import com.microsoft.identity.common.java.nativeauth.providers.v2.NativeAuthV2FlowScenario
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationStateTestFactory
 import com.microsoft.identity.common.java.util.ResultFuture
 import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
@@ -59,7 +58,6 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
-import java.lang.reflect.Constructor
 
 /**
  * Unit tests for the Native Auth V2 states, covering Parcelable serialization and the
@@ -158,7 +156,7 @@ class NativeAuthV2StatesTest {
     }
 
     private fun createContinuationState(): NativeAuthV2ContinuationState =
-        newContinuationState(correlationId)
+        NativeAuthV2ContinuationStateTestFactory.create(correlationId)
 
     private fun assertCallbackNotImplemented(action: (ResultFuture<NativeAuthResultV2>) -> Unit) {
         val future = ResultFuture<NativeAuthResultV2>()
@@ -459,51 +457,4 @@ class NativeAuthV2StatesTest {
             )
         }
     }
-}
-
-/**
- * The synthetic marker Kotlin appends to the extra constructor it generates for a class that takes
- * a value class parameter.
- */
-private const val DEFAULT_CONSTRUCTOR_MARKER = "kotlin.jvm.internal.DefaultConstructorMarker"
-
-/**
- * Builds a real [NativeAuthV2ContinuationState] for parcel tests using its private constructor.
- *
- * Supports the transitional 7/9-parameter shapes and skips Kotlin's synthetic value-class overload.
- */
-internal fun newContinuationState(correlationId: String): NativeAuthV2ContinuationState {
-    val constructor: Constructor<*> = NativeAuthV2ContinuationState::class.java.declaredConstructors
-        .filterNot { candidate ->
-            candidate.parameterTypes.any { it.name == DEFAULT_CONSTRUCTOR_MARKER }
-        }
-        .maxByOrNull { it.parameterCount }
-        ?: error("NativeAuthV2ContinuationState declares no usable constructor")
-    constructor.isAccessible = true
-
-    val continuationToken = "opaque-token"
-    val links = emptyMap<String, String>()
-    val methodLinks = emptyMap<String, Map<String, String>>()
-    val scopes = listOf("scope")
-    val claimsRequestJson: String? = null
-    // Value classes are erased to their underlying type, so reflection needs the raw String here.
-    val entryRelation = NativeAuthV2LinkRelation.RESET_PASSWORD.value
-    val scenario = NativeAuthV2FlowScenario.RESET_PASSWORD
-    val authenticationFactor: String? = null
-
-    val arguments: Array<Any?> = when (constructor.parameterCount) {
-        7 -> arrayOf(
-            continuationToken, links, scopes, claimsRequestJson, correlationId, entryRelation,
-            scenario
-        )
-        9 -> arrayOf(
-            continuationToken, links, methodLinks, scopes, claimsRequestJson, correlationId,
-            entryRelation, scenario, authenticationFactor
-        )
-        else -> error(
-            "Unrecognised NativeAuthV2ContinuationState constructor, update this helper: $constructor"
-        )
-    }
-
-    return constructor.newInstance(*arguments) as NativeAuthV2ContinuationState
 }


### PR DESCRIPTION
## Summary
- replace MSAL's reflective `NativeAuthV2ContinuationState` construction with the common4j test fixture
- remove private-constructor enumeration, synthetic-marker filtering, and constructor-arity handling
- update the Common gitlink 

## Why
MSAL tests should not encode common4j's private constructor shape. Keeping construction in the Common-owned fixture allows the opaque continuation state to evolve without requiring matching MSAL test changes.

## Tracking
[AB#3749428](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3749428)

## Validation
Local execution was attempted, but dependency resolution was blocked by Azure Artifacts `401 Unauthorized`. Draft CI is the current distributed validation source.