### PR TITLE
Harden pull-request AB ID extraction, Fixes AB#3751539

### DIFF
--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -39,8 +39,8 @@ jobs:
           # Sanitize PR body by removing backticks before parsing (aligns behavior with the Common repository workflow)
           clean=$(printf "%s" "$PR_BODY" | tr -d '`')
 
-          # Extract AB ID (AB#1234567) - takes first match if multiple exist
-          result=$(printf "%s" "$clean" | grep -oP -m 1 '(?<=AB#)\d+')
+          # Extract AB ID (AB#1234567) - take the first match if multiple exist
+          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+' | head -n 1)
 
           echo "id=$result" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -20,15 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'skip AB ID validation')"
     steps:
-      - name: Validate AB ID
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          clean=$(printf "%s" "$PR_BODY" | tr -d '`')
-          if ! printf "%s" "$clean" | grep -qP 'AB#\d+'; then
-            echo "::error::Pull request description must contain a valid ADO work item ID in the format AB#1234567."
-            exit 1
-          fi
+      - uses: danhellem/github-actions-pr-is-linked-to-work-item@main
         
   # Get AB#ID
   get_ab_id:

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -36,7 +36,7 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          # Sanitize PR body by removing backticks to prevent command substitution
+          # Sanitize PR body by removing backticks before parsing (aligns behavior with the Common repository workflow)
           clean=$(printf "%s" "$PR_BODY" | tr -d '`')
 
           # Extract AB ID (AB#1234567) - takes first match if multiple exist

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -20,7 +20,15 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.pull_request.labels.*.name, 'skip AB ID validation')"
     steps:
-      - uses: danhellem/github-actions-pr-is-linked-to-work-item@main
+      - name: Validate AB ID
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          clean=$(printf "%s" "$PR_BODY" | tr -d '`')
+          if ! printf "%s" "$clean" | grep -qP 'AB#\d+'; then
+            echo "::error::Pull request description must contain a valid ADO work item ID in the format AB#1234567."
+            exit 1
+          fi
         
   # Get AB#ID
   get_ab_id:

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -36,8 +36,13 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          result=$(echo "$PR_BODY" | grep -oP '(?<=#)\d+')
-          echo "id=${result}" >> "$GITHUB_OUTPUT"
+          # Sanitize PR body by removing backticks to prevent command substitution
+          clean=$(printf "%s" "$PR_BODY" | tr -d '`')
+
+          # Extract AB ID (AB#1234567) - takes first match if multiple exist
+          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+' | head -n 1)
+
+          echo "id=$result" >> "$GITHUB_OUTPUT"
 
   # Get Pull request ID
   get_pr_id:

--- a/.github/workflows/validate-pr-ab-id.yml
+++ b/.github/workflows/validate-pr-ab-id.yml
@@ -40,7 +40,7 @@ jobs:
           clean=$(printf "%s" "$PR_BODY" | tr -d '`')
 
           # Extract AB ID (AB#1234567) - takes first match if multiple exist
-          result=$(printf "%s" "$clean" | grep -oP '(?<=AB#)\d+' | head -n 1)
+          result=$(printf "%s" "$clean" | grep -oP -m 1 '(?<=AB#)\d+')
 
           echo "id=$result" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary
- match only explicit references in the pull-request body
- ignore GitHub issue and pull-request references
- use only the first Azure Boards ID when multiple references exist
- strip backticks before parsing and align behavior with the Common repository workflow

## Validation
- verified a single Azure Boards reference is extracted
- verified a GitHub PR reference followed by an Azure Boards reference returns only the Azure Boards ID
- verified multiple Azure Boards references return the first ID
- verified backtick content is not executed

No other workflow behavior is changed.

[AB#3751539](https://identitydivision.visualstudio.com/fac9d424-53d2-45c0-91b5-ef6ba7a6bf26/_workitems/edit/3751539)

Ref: Common repo