### PR TITLE
Add Native Auth V2 SMS password reset support, Fixes AB#3754595

### DIFF
--- a/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
+++ b/msal/src/main/java/com/microsoft/identity/client/internal/CommandParametersAdapter.java
@@ -67,6 +67,7 @@ import com.microsoft.identity.common.java.nativeauth.commands.parameters.MFAChal
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.MFASubmitChallengeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2ResendCodeCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectMFAMethodCommandParameters;
+import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SelectResetPasswordMethodCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterResetPasswordCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SignInAfterSignUpCommandParameters;
 import com.microsoft.identity.common.java.nativeauth.commands.parameters.NativeAuthV2SubmitAttributesCommandParameters;
@@ -1663,6 +1664,52 @@ public class CommandParametersAdapter {
                         .build();
 
         return commandParameters;
+    }
+
+    /**
+     * Creates command parameters for selecting a V2 reset-password first-factor method.
+     *
+     * @param configuration PCA configuration
+     * @param tokenCache token cache for storing results
+     * @param methodId server-issued ID of the authentication method the app selected
+     * @param continuationState opaque continuation state from the reset-password start response
+     * @return Command parameter object
+     */
+    public static NativeAuthV2SelectResetPasswordMethodCommandParameters createNativeAuthV2SelectResetPasswordMethodCommandParameters(
+            @NonNull final NativeAuthPublicClientApplicationConfiguration configuration,
+            @NonNull final OAuth2TokenCache tokenCache,
+            @NonNull final String methodId,
+            @NonNull final NativeAuthV2ContinuationState continuationState) throws ClientException {
+
+        final NativeAuthCIAMAuthority authority = ((NativeAuthCIAMAuthority) configuration.getDefaultAuthority());
+        final AbstractAuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.createScheme(
+                AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()),
+                null
+        );
+
+        return NativeAuthV2SelectResetPasswordMethodCommandParameters.builder()
+                .platformComponents(AndroidPlatformComponentsFactory.createFromContext(configuration.getAppContext()))
+                .applicationName(configuration.getAppContext().getPackageName())
+                .applicationVersion(getPackageVersion(configuration.getAppContext()))
+                .clientId(configuration.getClientId())
+                .isSharedDevice(configuration.getIsSharedDevice())
+                .redirectUri(configuration.getRedirectUri())
+                .oAuth2TokenCache(tokenCache)
+                .requiredBrokerProtocolVersion(configuration.getRequiredBrokerProtocolVersion())
+                .sdkType(SdkType.MSAL)
+                .sdkVersion(PublicClientApplication.getSdkVersion())
+                .powerOptCheckEnabled(configuration.isPowerOptCheckForEnabled())
+                .authority(authority)
+                .authenticationScheme(authenticationScheme)
+                .challengeType(configuration.getChallengeTypes())
+                .requestInterceptor(configuration.getRequestInterceptor())
+                .capabilities(configuration.getCapabilities())
+                .methodId(methodId)
+                .continuationState(continuationState)
+                .scopes(continuationState.scopesForTokenRequest())
+                .claimsRequestJson(continuationState.claimsRequestJsonForTokenRequest())
+                .correlationId(continuationState.getCorrelationId())
+                .build();
     }
 
     /**

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/NativeAuthPublicClientApplication.kt
@@ -96,6 +96,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.AwaitingMFAState
 import com.microsoft.identity.nativeauth.statemachine.states.Callback
 import com.microsoft.identity.nativeauth.statemachine.states.RegisterStrongAuthState
 import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordCodeRequiredState
+import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordMethodRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.SignInCodeRequiredState
 import com.microsoft.identity.nativeauth.statemachine.states.SignInContinuationState
 import com.microsoft.identity.nativeauth.statemachine.states.SignInPasswordRequiredState
@@ -1042,6 +1043,16 @@ class NativeAuthPublicClientApplication(
                             codeLength = result.codeLength,
                             sentTo = result.challengeTargetLabel,
                             channel = result.challengeChannel
+                        )
+                    }
+                    is NativeAuthV2CommandResult.ResetPasswordMethodRequired -> {
+                        NativeAuthResultV2.ResetPasswordMethodRequired(
+                            nextState = ResetPasswordMethodRequiredStateV2(
+                                continuationState = result.continuationState,
+                                authMethods = result.authMethods.toListOfV2AuthMethods(),
+                                config = nativeAuthConfig
+                            ),
+                            scenario = NativeAuthFlowScenarioV2.RESET_PASSWORD
                         )
                     }
                     is NativeAuthV2CommandResult.Complete -> {

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/ResetPasswordErrorsV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/errors/ResetPasswordErrorsV2.kt
@@ -27,8 +27,8 @@ import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
 
 /**
  * Reset password error for the Native Auth V2 surface. Use the utility methods of this class to
- * identify and handle the error. This error is produced by
- * [com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication.resetPasswordV2].
+ * identify and handle the error. This error is produced while starting password reset or selecting
+ * a reset-password verification method.
  *
  * @param errorType the error type value of the error that occurred.
  * @param error the error returned by the authentication server.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/results/NativeAuthResultV2.kt
@@ -36,6 +36,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.NewPasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordMethodRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterSignUpStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
@@ -79,6 +80,23 @@ interface NativeAuthResultV2 : Result {
         val sentTo: String,
         val channel: String
     ) : Result.SuccessResult(nextState = nextState), NativeAuthResultV2
+
+    /**
+     * ResetPasswordMethodRequired Result, which indicates that password reset can continue with
+     * more than one verification method and the user must select one before a code is sent.
+     *
+     * @param nextState the current state with follow-on methods.
+     */
+    class ResetPasswordMethodRequired(
+        override val nextState: ResetPasswordMethodRequiredStateV2,
+        override val scenario: NativeAuthFlowScenarioV2
+    ) : Result.SuccessResult(nextState = nextState), NativeAuthResultV2 {
+        /**
+         * The reset-password verification methods available to the user.
+         */
+        val authMethods: List<AuthMethod>
+            get() = nextState.authMethods
+    }
 
     /**
      * PasswordRequired Result, which indicates a password is required from the user to continue.

--- a/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordMethodRequiredStateV2.kt
+++ b/msal/src/main/java/com/microsoft/identity/nativeauth/statemachine/states/ResetPasswordMethodRequiredStateV2.kt
@@ -1,0 +1,236 @@
+//  Copyright (c) Microsoft Corporation.
+//  All rights reserved.
+//
+//  This code is licensed under the MIT License.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files(the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions :
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+package com.microsoft.identity.nativeauth.statemachine.states
+
+import android.os.Parcel
+import android.os.Parcelable
+import com.microsoft.identity.client.exception.MsalException
+import com.microsoft.identity.client.internal.CommandParametersAdapter
+import com.microsoft.identity.common.java.controllers.CommandDispatcher
+import com.microsoft.identity.common.java.eststelemetry.PublicApiId
+import com.microsoft.identity.common.java.logging.LogSession
+import com.microsoft.identity.common.java.logging.Logger
+import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2SelectResetPasswordMethodCommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.NativeAuthConstants
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
+import com.microsoft.identity.common.java.nativeauth.util.checkAndWrapCommandResultType
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectResetPasswordMethodCommand
+import com.microsoft.identity.common.nativeauth.internal.controllers.v2.NativeAuthV2FlowController
+import com.microsoft.identity.nativeauth.AuthMethod
+import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
+import com.microsoft.identity.nativeauth.statemachine.NativeAuthFlowScenarioV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ErrorTypes
+import com.microsoft.identity.nativeauth.statemachine.errors.NativeAuthErrorV2
+import com.microsoft.identity.nativeauth.statemachine.errors.ResetPasswordErrorV2
+import com.microsoft.identity.nativeauth.statemachine.results.NativeAuthResultV2
+import com.microsoft.identity.nativeauth.utils.getCancellable
+import com.microsoft.identity.nativeauth.utils.serializable
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Collections
+
+/**
+ * State that requires the user to select an email or SMS verification method for password reset.
+ *
+ * No challenge is sent until the app explicitly selects one of [authMethods].
+ */
+class ResetPasswordMethodRequiredStateV2 internal constructor(
+    continuationToken: String?,
+    correlationId: String,
+    scenario: NativeAuthFlowScenarioV2,
+    config: NativeAuthPublicClientApplicationConfiguration,
+    continuationState: NativeAuthV2ContinuationState? = null,
+    authMethods: List<AuthMethod> = emptyList()
+) : NativeAuthBaseStateV2(continuationToken, correlationId, scenario, config, continuationState) {
+    private val TAG: String = ResetPasswordMethodRequiredStateV2::class.java.simpleName
+    val authMethods: List<AuthMethod> = Collections.unmodifiableList(ArrayList(authMethods))
+
+    internal constructor(
+        continuationState: NativeAuthV2ContinuationState,
+        authMethods: List<AuthMethod>,
+        config: NativeAuthPublicClientApplicationConfiguration
+    ) : this(
+        continuationToken = null,
+        correlationId = continuationState.correlationId,
+        scenario = NativeAuthFlowScenarioV2.RESET_PASSWORD,
+        config = config,
+        continuationState = continuationState,
+        authMethods = authMethods
+    )
+
+    private constructor(parcel: Parcel) : this(
+        continuationToken = parcel.readString(),
+        correlationId = parcel.readString() ?: "UNSET",
+        scenario = NativeAuthFlowScenarioV2.valueOf(
+            parcel.readString() ?: NativeAuthFlowScenarioV2.UNKNOWN.name
+        ),
+        config = parcel.serializable<NativeAuthPublicClientApplicationConfiguration>()
+            as NativeAuthPublicClientApplicationConfiguration,
+        continuationState = parcel.serializable<NativeAuthV2ContinuationState>(),
+        authMethods = parcel.createTypedArrayList(AuthMethod.CREATOR) ?: emptyList()
+    )
+
+    override fun writeToParcel(parcel: Parcel, flags: Int) {
+        super.writeToParcel(parcel, flags)
+        parcel.writeTypedList(authMethods)
+    }
+
+    interface SelectAuthMethodCallback : Callback<NativeAuthResultV2>
+
+    /**
+     * Sends a verification code using the selected method; callback variant.
+     */
+    fun selectAuthMethod(method: AuthMethod, callback: SelectAuthMethodCallback) {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.selectAuthMethod(method: AuthMethod, callback: SelectAuthMethodCallback)"
+        )
+        NativeAuthPublicClientApplication.pcaScope.launch {
+            try {
+                callback.onResult(selectAuthMethod(method))
+            } catch (e: MsalException) {
+                Logger.error(TAG, "Exception thrown in selectAuthMethod", e)
+                callback.onError(e)
+            }
+        }
+    }
+
+    /**
+     * Sends a verification code using the selected method; Kotlin coroutines variant.
+     */
+    suspend fun selectAuthMethod(method: AuthMethod): NativeAuthResultV2 {
+        LogSession.logMethodCall(
+            tag = TAG,
+            correlationId = correlationId,
+            methodName = "${TAG}.selectAuthMethod(method: AuthMethod)"
+        )
+        val state = continuationState ?: return invalidState()
+        val offeredMethod = authMethods.firstOrNull { it.id == method.id }
+            ?: return ResetPasswordErrorV2(
+                errorType = ErrorTypes.INVALID_STATE,
+                errorMessage = "The selected authentication method is not one of the methods the server offered.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+
+        if (!offeredMethod.challengeChannel.equals(
+                NativeAuthConstants.ChallengeChannel.EMAIL,
+                ignoreCase = true
+            ) &&
+            !offeredMethod.challengeChannel.equals(
+                NativeAuthConstants.ChallengeChannel.SMS,
+                ignoreCase = true
+            )
+        ) {
+            return NativeAuthErrorV2(
+                errorType = ErrorTypes.NOT_IMPLEMENTED,
+                errorMessage = "Only email and SMS authentication methods are supported for password reset.",
+                correlationId = correlationId,
+                scenario = scenario
+            )
+        }
+
+        return withContext(Dispatchers.IO) {
+            try {
+                val parameters =
+                    CommandParametersAdapter.createNativeAuthV2SelectResetPasswordMethodCommandParameters(
+                        config,
+                        config.oAuth2TokenCache,
+                        offeredMethod.id,
+                        state
+                    )
+                val command = NativeAuthV2SelectResetPasswordMethodCommand(
+                    parameters,
+                    NativeAuthV2FlowController(),
+                    PublicApiId.NATIVE_AUTH_V2_RESET_PASSWORD_SELECT_METHOD
+                )
+                ensureActive()
+                val rawCommandResult =
+                    CommandDispatcher.submitSilentReturningFuture(command).getCancellable()
+                ensureActive()
+                when (val result =
+                    rawCommandResult.checkAndWrapCommandResultType<NativeAuthV2SelectResetPasswordMethodCommandResult>()) {
+                    is NativeAuthV2CommandResult.CodeRequired -> NativeAuthResultV2.CodeRequired(
+                        nextState = CodeRequiredStateV2(
+                            continuationState = result.continuationState,
+                            scenario = scenario,
+                            config = config
+                        ),
+                        scenario = scenario,
+                        codeLength = result.codeLength,
+                        sentTo = result.challengeTargetLabel,
+                        channel = result.challengeChannel
+                    )
+                    is NativeAuthV2CommandResult.NotImplemented -> NativeAuthErrorV2(
+                        errorType = ErrorTypes.NOT_IMPLEMENTED,
+                        error = result.error,
+                        errorMessage = result.errorDescription,
+                        correlationId = result.correlationId,
+                        scenario = scenario
+                    )
+                    is INativeAuthCommandResult.Redirect -> ResetPasswordErrorV2(
+                        errorType = ErrorTypes.BROWSER_REQUIRED,
+                        error = result.error,
+                        errorMessage = result.errorDescription,
+                        correlationId = result.correlationId,
+                        scenario = scenario
+                    )
+                    is INativeAuthCommandResult.APIError -> ResetPasswordErrorV2(
+                        error = result.error,
+                        errorMessage = result.errorDescription,
+                        correlationId = result.correlationId,
+                        scenario = scenario,
+                        errorCodes = result.errorCodes,
+                        exception = result.exception
+                    )
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Logger.error(TAG, correlationId, "Exception thrown in selectAuthMethod", e)
+                ResetPasswordErrorV2(
+                    errorType = ErrorTypes.CLIENT_EXCEPTION,
+                    errorMessage = "MSAL client exception occurred in selectAuthMethod.",
+                    correlationId = correlationId,
+                    scenario = scenario,
+                    exception = e
+                )
+            }
+        }
+    }
+
+    companion object CREATOR : Parcelable.Creator<ResetPasswordMethodRequiredStateV2> {
+        override fun createFromParcel(parcel: Parcel): ResetPasswordMethodRequiredStateV2 =
+            ResetPasswordMethodRequiredStateV2(parcel)
+
+        override fun newArray(size: Int): Array<ResetPasswordMethodRequiredStateV2?> =
+            arrayOfNulls(size)
+    }
+}

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2InterfaceKotlinTest.kt
@@ -40,6 +40,7 @@ import com.microsoft.identity.common.java.exception.BaseException
 import com.microsoft.identity.common.java.logging.DiagnosticContext
 import com.microsoft.identity.common.java.nativeauth.controllers.results.INativeAuthCommandResult
 import com.microsoft.identity.common.java.nativeauth.controllers.results.NativeAuthV2CommandResult
+import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2AuthMethod
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationState
 import com.microsoft.identity.common.java.nativeauth.providers.responses.v2.NativeAuthV2ContinuationStateTestFactory
 import com.microsoft.identity.common.java.result.FinalizableResultFuture
@@ -48,10 +49,12 @@ import com.microsoft.identity.common.java.util.ResultFuture
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResendCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResetPasswordSubmitCodeCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2ResetPasswordStartCommand
+import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SelectResetPasswordMethodCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignInAfterResetPasswordCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SignUpStartCommand
 import com.microsoft.identity.common.nativeauth.internal.commands.NativeAuthV2SubmitNewPasswordCommand
 import com.microsoft.identity.nativeauth.INativeAuthPublicClientApplication
+import com.microsoft.identity.nativeauth.AuthMethod
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplication
 import com.microsoft.identity.nativeauth.NativeAuthPublicClientApplicationConfiguration
 import com.microsoft.identity.nativeauth.parameters.NativeAuthResetPasswordParameters
@@ -71,6 +74,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.NewPasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordMethodRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthVerificationRequiredStateV2
@@ -184,6 +188,65 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         assertEquals("email", result.channel)
         assertNull(result.nextState.continuationToken)
         assertEquals(correlationId, result.nextState.correlationId)
+    }
+
+    @Test
+    fun resetPasswordV2MapsMethodSelectionAndSmsChallengeWithoutNetwork() = runTest {
+        val selectionState = createContinuationState()
+        enqueueResult(
+            NativeAuthV2CommandResult.ResetPasswordMethodRequired(
+                correlationId = correlationId,
+                continuationState = selectionState,
+                authMethods = listOf(
+                    NativeAuthV2AuthMethod("email-1", "email", "a***@example.com"),
+                    NativeAuthV2AuthMethod("sms-1", "sms", "+X XXX XXX 34")
+                )
+            ),
+            NativeAuthV2ResetPasswordStartCommand::class
+        )
+
+        val required = application.resetPasswordV2(
+            NativeAuthResetPasswordParameters(username = username)
+        ) as NativeAuthResultV2.ResetPasswordMethodRequired
+
+        assertEquals(listOf("email", "sms"), required.authMethods.map { it.challengeChannel })
+        val smsMethod = required.authMethods.single { it.challengeChannel == "sms" }
+
+        enqueueResult(
+            NativeAuthV2CommandResult.CodeRequired(
+                correlationId = correlationId,
+                continuationState = createContinuationState(),
+                codeLength = 6,
+                challengeTargetLabel = "+X XXX XXX 34",
+                challengeChannel = "sms"
+            ),
+            NativeAuthV2SelectResetPasswordMethodCommand::class
+        )
+
+        val codeRequired = required.nextState.selectAuthMethod(smsMethod)
+
+        assertTrue(codeRequired is NativeAuthResultV2.CodeRequired)
+        codeRequired as NativeAuthResultV2.CodeRequired
+        assertEquals(NativeAuthFlowScenarioV2.RESET_PASSWORD, codeRequired.scenario)
+        assertEquals(6, codeRequired.codeLength)
+        assertEquals("+X XXX XXX 34", codeRequired.sentTo)
+        assertEquals("sms", codeRequired.channel)
+    }
+
+    @Test
+    fun resetPasswordMethodSelectionRejectsMethodNotOfferedByServer() = runTest {
+        val state = ResetPasswordMethodRequiredStateV2(
+            continuationState = createContinuationState(),
+            authMethods = listOf(AuthMethod("email-1", "oob", "a***@example.com", "email")),
+            config = NativeAuthPublicClientApplicationConfiguration()
+        )
+
+        val result = state.selectAuthMethod(
+            AuthMethod("sms-1", "sms", "+X XXX XXX 34", "sms")
+        )
+
+        assertTrue(result is ResetPasswordErrorV2)
+        assertEquals(ErrorTypes.INVALID_STATE, (result as ResetPasswordErrorV2).errorType)
     }
 
     @Test
@@ -603,9 +666,17 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
             NativeAuthFlowScenarioV2.RESET_PASSWORD,
             codeState.config
         )
+        val methodState = ResetPasswordMethodRequiredStateV2(
+            createContinuationState(),
+            listOf(AuthMethod("sms-1", "sms", "+X XXX XXX 34", "sms")),
+            codeState.config
+        )
 
         assertCommandWaitCancellation(NativeAuthV2ResetPasswordStartCommand::class) {
             application.resetPasswordV2(NativeAuthResetPasswordParameters(username))
+        }
+        assertCommandWaitCancellation(NativeAuthV2SelectResetPasswordMethodCommand::class) {
+            methodState.selectAuthMethod(methodState.authMethods.single())
         }
         assertCommandWaitCancellation(NativeAuthV2ResetPasswordSubmitCodeCommand::class) {
             codeState.submitCode("123456")
@@ -682,6 +753,14 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
         assertInvalidState(AttributesRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitAttributes(attributes))
         assertInvalidState(AttributesInvalidStateV2("continuation-token", "correlation-id", scenario, config).submitAttributes(attributes))
         assertInvalidState(MFARequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
+        assertInvalidState(
+            ResetPasswordMethodRequiredStateV2(
+                "continuation-token",
+                "correlation-id",
+                NativeAuthFlowScenarioV2.RESET_PASSWORD,
+                config
+            ).selectAuthMethod(authMethod)
+        )
         assertInvalidState(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).submitChallenge("challenge"))
         assertInvalidState(MFAVerificationRequiredStateV2("continuation-token", "correlation-id", scenario, config).resendChallenge())
         assertNotImplemented(StrongAuthRegistrationRequiredStateV2("continuation-token", "correlation-id", scenario, config).selectAuthMethod(authMethod))
@@ -873,6 +952,7 @@ class NativeAuthV2InterfaceKotlinTest : PublicClientApplicationAbstractTest() {
     private fun exhaustiveWhen(result: NativeAuthResultV2): String = when (result) {
         is NativeAuthResultV2.Complete -> "complete"
         is NativeAuthResultV2.CodeRequired -> "code"
+        is NativeAuthResultV2.ResetPasswordMethodRequired -> "resetPasswordMethod"
         is NativeAuthResultV2.PasswordRequired -> "password"
         is NativeAuthResultV2.NewPasswordRequired -> "newPassword"
         is NativeAuthResultV2.SignInAfterResetPasswordRequired -> "signInAfterResetPassword"

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2ResultsTest.kt
@@ -36,6 +36,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.MFARequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.NewPasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordMethodRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthVerificationRequiredStateV2
 import io.mockk.mockk
@@ -170,6 +171,34 @@ class NativeAuthV2ResultsTest {
         assertSame(nextState.authMethods, result.authMethods)
         assertEquals(scenario, result.scenario)
 
+        authMethods.clear()
+        assertEquals(1, result.authMethods.size)
+        try {
+            (result.authMethods as MutableList<AuthMethod>).clear()
+            org.junit.Assert.fail("Expected authMethods to be unmodifiable")
+        } catch (_: UnsupportedOperationException) {
+            // Expected.
+        }
+    }
+
+    @Test
+    fun testResetPasswordMethodRequiredExposesImmutableMethods() {
+        val authMethods =
+            mutableListOf(AuthMethod("sms-1", "sms", "+X XXX XXX 34", "sms"))
+        val nextState = ResetPasswordMethodRequiredStateV2(
+            continuationToken,
+            correlationId,
+            NativeAuthFlowScenarioV2.RESET_PASSWORD,
+            config,
+            authMethods = authMethods
+        )
+        val result = NativeAuthResultV2.ResetPasswordMethodRequired(
+            nextState = nextState,
+            scenario = NativeAuthFlowScenarioV2.RESET_PASSWORD
+        )
+
+        assertSame(nextState.authMethods, result.authMethods)
+        assertEquals("sms-1", result.authMethods.single().id)
         authMethods.clear()
         assertEquals(1, result.authMethods.size)
         try {

--- a/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
+++ b/msal/src/test/java/com/microsoft/identity/nativeauth/v2/NativeAuthV2StatesTest.kt
@@ -45,6 +45,7 @@ import com.microsoft.identity.nativeauth.statemachine.states.MFAVerificationRequ
 import com.microsoft.identity.nativeauth.statemachine.states.NativeAuthBaseStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.NewPasswordRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.PasswordRequiredStateV2
+import com.microsoft.identity.nativeauth.statemachine.states.ResetPasswordMethodRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.SignInAfterResetPasswordStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthRegistrationRequiredStateV2
 import com.microsoft.identity.nativeauth.statemachine.states.StrongAuthVerificationRequiredStateV2
@@ -117,6 +118,17 @@ class NativeAuthV2StatesTest {
             MFARequiredStateV2(continuationToken, correlationId, scenario, config),
             MFARequiredStateV2.CREATOR
         )
+        val restoredResetPasswordMethodState = assertParcelRoundTrip(
+            ResetPasswordMethodRequiredStateV2(
+                continuationToken,
+                correlationId,
+                NativeAuthFlowScenarioV2.RESET_PASSWORD,
+                config,
+                authMethods = listOf(AuthMethod("sms-1", "sms", "+X XXX XXX 34", "sms"))
+            ),
+            ResetPasswordMethodRequiredStateV2.CREATOR
+        )
+        assertEquals("sms-1", restoredResetPasswordMethodState.authMethods.single().id)
         assertParcelRoundTrip(
             MFAVerificationRequiredStateV2(continuationToken, correlationId, scenario, config),
             MFAVerificationRequiredStateV2.CREATOR
@@ -415,6 +427,20 @@ class NativeAuthV2StatesTest {
                 authMethod,
                 null,
                 object : MFARequiredStateV2.SelectAuthMethodCallback {
+                    override fun onResult(result: NativeAuthResultV2): Unit = throw thrown
+                    override fun onError(exception: BaseException) = future.setException(exception)
+                }
+            )
+        }
+        assertCallbackRoutesToOnError { future, thrown ->
+            ResetPasswordMethodRequiredStateV2(
+                continuationToken,
+                correlationId,
+                NativeAuthFlowScenarioV2.RESET_PASSWORD,
+                config
+            ).selectAuthMethod(
+                authMethod,
+                object : ResetPasswordMethodRequiredStateV2.SelectAuthMethodCallback {
                     override fun onResult(result: NativeAuthResultV2): Unit = throw thrown
                     override fun onError(exception: BaseException) = future.setException(exception)
                 }


### PR DESCRIPTION
## Summary
- expose reset-password method selection when the service offers both email and SMS
- add a parcelable state with callback and coroutine APIs for selecting an offered method
- map the selected SMS challenge into the existing reset-password code-required flow
- preserve method validation, cancellation, errors, code length, channel, and masked destination
- update the Common submodule to `631fa691d`

## Testing
- Native Auth V2 interface, result, and state unit tests

Depends on #2578 and AzureAD/microsoft-authentication-library-common-for-android#3254.

Fixes [AB#3754595](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3754595)