### PR TITLE
Fixes AB#3757342 Release integration/8.5.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -2,6 +2,10 @@ MSAL Wiki : https://github.com/AzureAD/microsoft-authentication-library-for-andr
 
 vNext
 ----------
+
+Version 8.5.0-RC1
+----------
+- [PATCH] Update common @24.7.0-RC1
 - [PATCH] Upgrade Apache HttpCore to 5.4.3 to address CVE-2026-54399 (AB#3746140) (#2566)
 - [MINOR] Bump Kotlin to 2.0.21 with languageVersion/apiVersion pinned to 1.9 (#2561)
 - [MINOR] Added v2 private preview interfaces

--- a/msal/build.gradle
+++ b/msal/build.gradle
@@ -272,12 +272,12 @@ task sourcesJar(type: Jar) {
 
 // In dev, we want to keep the dependencies (common4j, common) to 1.0.+ to be able to be consumed by daily dev pipeline.
 // In release/*, we change these to specific versions being consumed.
-def commonVersion = "1.0.+"
+def commonVersion = "24.7.0-RC1"
 if (project.hasProperty("distCommonVersion")) {
     commonVersion = project.distCommonVersion
 }
 // Used for testfixtures
-def common4jVersion = "1.0.+"
+def common4jVersion = "24.7.0-RC1"
 if (project.hasProperty("distCommon4jVersion")) {
     distCommon4jVersion = project.distCommon4jVersion
 }

--- a/msal/versioning/version.properties
+++ b/msal/versioning/version.properties
@@ -1,3 +1,3 @@
 #Wed Aug 01 15:24:11 PDT 2018
-versionName=8.4.2
+versionName=8.5.0-RC1
 versionCode=0


### PR DESCRIPTION
## msal — Integration

[AB#3757342](https://identitydivision.visualstudio.com/Engineering/_workitems/edit/3757342)

### What this PR does
Merge `release-integration/8.5.0` into `dev` to bring this release's version + changelog back. build.gradle changes are reverted so `dev` stays dynamic.

### Scout automation (release-agent · integ_prs)
- [x] RI brought up to date with target
- [x] build.gradle reverted (dynamic preserved)
- [ ] <add details>

<!-- Scout-generated. Edit freely. -->
